### PR TITLE
Set dot11 payload for InformationElement

### DIFF
--- a/layers/dot11.go
+++ b/layers/dot11.go
@@ -926,6 +926,7 @@ func (m *Dot11MgmtAssociationReq) NextLayerType() gopacket.LayerType {
 func (m *Dot11MgmtAssociationReq) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 	m.CapabilityInfo = binary.LittleEndian.Uint16(data[0:2])
 	m.ListenInterval = binary.LittleEndian.Uint16(data[2:4])
+	m.Payload = data[4:]
 	return m.Dot11Mgmt.DecodeFromBytes(data, df)
 }
 
@@ -954,6 +955,7 @@ func (m *Dot11MgmtAssociationResp) DecodeFromBytes(data []byte, df gopacket.Deco
 	m.CapabilityInfo = binary.LittleEndian.Uint16(data[0:2])
 	m.Status = Dot11Status(binary.LittleEndian.Uint16(data[2:4]))
 	m.AID = binary.LittleEndian.Uint16(data[4:6])
+	m.Payload = data[6:]
 	return m.Dot11Mgmt.DecodeFromBytes(data, df)
 }
 
@@ -982,6 +984,7 @@ func (m *Dot11MgmtReassociationReq) DecodeFromBytes(data []byte, df gopacket.Dec
 	m.CapabilityInfo = binary.LittleEndian.Uint16(data[0:2])
 	m.ListenInterval = binary.LittleEndian.Uint16(data[2:4])
 	m.CurrentApAddress = net.HardwareAddr(data[4:10])
+	m.Payload = data[10:]
 	return m.Dot11Mgmt.DecodeFromBytes(data, df)
 }
 
@@ -1068,6 +1071,7 @@ func (m *Dot11MgmtBeacon) DecodeFromBytes(data []byte, df gopacket.DecodeFeedbac
 	m.Timestamp = binary.LittleEndian.Uint64(data[0:8])
 	m.Interval = binary.LittleEndian.Uint16(data[8:10])
 	m.Flags = binary.LittleEndian.Uint16(data[10:12])
+	m.Payload = data[12:]
 	return m.Dot11Mgmt.DecodeFromBytes(data, df)
 }
 
@@ -1131,6 +1135,7 @@ func (m *Dot11MgmtAuthentication) DecodeFromBytes(data []byte, df gopacket.Decod
 	m.Algorithm = Dot11Algorithm(binary.LittleEndian.Uint16(data[0:2]))
 	m.Sequence = binary.LittleEndian.Uint16(data[2:4])
 	m.Status = Dot11Status(binary.LittleEndian.Uint16(data[4:6]))
+	m.Payload = data[6:]
 	return m.Dot11Mgmt.DecodeFromBytes(data, df)
 }
 


### PR DESCRIPTION
Fixes #54 mgmt class packets returns LayerTypeDot11InformationElement in NextLayerType() set BaseLayer.Payload, which will be used in the next layer decoding phase.
