### PR TITLE
Add rough draft BSD BPF sniffer API

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,6 +23,7 @@ Loic Prylli <loicp@google.com>
 Alexandre Fiori <fiorix@gmail.com>
 Adrian Tam <adrian.c.m.tam@gmail.com>
 Satoshi Matsumoto <kaorimatz@gmail.com>
+David Stainton <dstainton415@gmail.com>
 
 -----------------------------------------------
 FORKED FROM github.com/akrennmair/gopcap

--- a/bsdbpf/bsd_bpf_sniffer.go
+++ b/bsdbpf/bsd_bpf_sniffer.go
@@ -1,21 +1,10 @@
 // +build darwin dragonfly freebsd netbsd openbsd
 
-/*
- * This rough sketch of a golang API for a Berkeley packet filter sniffer for BSD variants.
- * It provides only the capability to sniff ethernet frames... but could easily be extended for
- * sending frames as well.
- *
- * This file was inspired by BSD licensed code from https://github.com/songgao/ether
- *
- * ( http://opensource.org/licenses/BSD-3-Clause )
- *
- * The bpf_wordalign function was borrowed... and readFrames was very much inspired by
- * design I saw in songgao's ether git repository; the rest of the code I wrote myself ;-)
- *
- * Author: David Anthony Stainton
- * License: BSD
- *
- */
+// Copyright 2012 Google, Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file in the root of the source
+// tree.
 
 package bpf_sniffer
 

--- a/bsdbpf/bsd_bpf_sniffer.go
+++ b/bsdbpf/bsd_bpf_sniffer.go
@@ -37,9 +37,10 @@ type BPFSniffer struct {
 	readChan chan TimedFrame
 }
 
-func NewBPFSniffer(name string) *BPFSniffer {
+func NewBPFSniffer(sniffDeviceName, bpfDeviceName string) *BPFSniffer {
 	return &BPFSniffer{
-		sniffDeviceName: name,
+		sniffDeviceName: sniffDeviceName,
+		bpfDeviceName: bpfDeviceName,
 		stopChan: make(chan bool, 0),
 		readChan: make(chan TimedFrame, 0),
 	}
@@ -61,7 +62,9 @@ func (b *BPFSniffer) Init() error {
 	var err error
 	enable := 1
 
-	b.pickBpfDevice()
+	if b.bpfDeviceName == "" {
+		b.pickBpfDevice()
+	}
 
 	err = syscall.SetBpfInterface(b.fd, b.sniffDeviceName)
 	if err != nil {

--- a/bsdbpf/bsd_bpf_sniffer.go
+++ b/bsdbpf/bsd_bpf_sniffer.go
@@ -24,22 +24,44 @@ func bpfWordAlign(x int) int {
 	return (((x) + (wordSize - 1)) &^ (wordSize - 1))
 }
 
+// Options is used to configure various properties of the BPF sniffer.
+// Default values are used when a nil Options pointer is passed to NewBPFSniffer.
 type Options struct {
-	bpfDeviceName    string
-	readBufLen       int
-	timeout          *syscall.Timeval
-	promisc          bool
-	immediate        bool
-	preserveLinkAddr bool
+	// BPFDeviceName is name of the bpf device to use for sniffing
+	// the network device. The default value of BPFDeviceName is empty string
+	// which causes the first available BPF device file /dev/bpfX to be used.
+	BPFDeviceName string
+	// ReadBufLen specifies the size of the buffer used to read packets
+	// off the wire such that multiple packets are buffered with each read syscall.
+	// The packet will be clipped if it's size exceeds the buffer size.
+	// A larger buffer should increase performance because fewer read syscalls would be made.
+	// If zero is used the system's default buffer length will be used.
+	// ReadBufLen defaults to 32767.
+	ReadBufLen int
+	// Timeout is the length of time to wait before timing out on a read request.
+	// Timeout defaults to nil which means no timeout is used.
+	Timeout *syscall.Timeval
+	// Promisc is set to true for promiscuous mode ethernet sniffing.
+	// Promisc defaults to true.
+	Promisc bool
+	// Immediate is set to true to make our read requests return as soon as a packet becomes available.
+	// Otherwise, a read will block until either the kernel buffer becomes full or a timeout occurs.
+	// The default is false.
+	Immediate bool
+	// PreserveLinkAddr is set to false if the link level source address should be filled in automatically
+	// by the interface output routine. Set to true if the link level source address will be written,
+	// as provided, to the wire.
+	// The default is true.
+	PreserveLinkAddr bool
 }
 
 var defaultOptions = Options{
-	bpfDeviceName:    "",
-	readBufLen:       0,
-	timeout:          nil,
-	promisc:          true,
-	immediate:        false,
-	preserveLinkAddr: true,
+	BpfDeviceName:    "",
+	ReadBufLen:       32767,
+	Timeout:          nil,
+	Promisc:          true,
+	Immediate:        false,
+	PreserveLinkAddr: true,
 }
 
 type BPFSniffer struct {

--- a/bsdbpf/bsd_bpf_sniffer.go
+++ b/bsdbpf/bsd_bpf_sniffer.go
@@ -9,9 +9,10 @@
 package bpf_sniffer
 
 import (
-	"fmt"
 	"github.com/google/gopacket"
 	"golang.org/x/sys/unix"
+
+	"fmt"
 	"syscall"
 	"time"
 	"unsafe"

--- a/bsdbpf/bsd_bpf_sniffer.go
+++ b/bsdbpf/bsd_bpf_sniffer.go
@@ -49,6 +49,10 @@ func NewBPFSniffer(sniffDeviceName, bpfDeviceName string, readBufLen int) *BPFSn
 	}
 }
 
+func (b *BPFSniffer) Close() error {
+	return syscall.Close(b.fd)
+}
+
 func (b *BPFSniffer) pickBpfDevice() {
 	for i := 0; i < 99; i++ {
 		b.bpfDeviceName = fmt.Sprintf("/dev/bpf%d", i)

--- a/bsdbpf/bsd_bpf_sniffer.go
+++ b/bsdbpf/bsd_bpf_sniffer.go
@@ -72,6 +72,10 @@ func (b *BPFSniffer) Init() error {
 	var err error
 	enable := 1
 
+	if b.bpfDeviceName == "" {
+		b.pickBpfDevice()
+	}
+
 	// setup our read buffer
 	if b.readBufLen == 0 {
 		b.readBufLen, err = syscall.BpfBuflen(b.fd)
@@ -83,12 +87,15 @@ func (b *BPFSniffer) Init() error {
 		if err != nil {
 			panic(err)
 		}
+		var actualBufLen int
+		actualBufLen, err = syscall.BpfBuflen(b.fd)
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("actual buf len %d\n", actualBufLen)
 	}
 	b.readBuffer = make([]byte, b.readBufLen)
 
-	if b.bpfDeviceName == "" {
-		b.pickBpfDevice()
-	}
 
 	err = syscall.SetBpfInterface(b.fd, b.sniffDeviceName)
 	if err != nil {

--- a/bsdbpf/bsd_bpf_sniffer.go
+++ b/bsdbpf/bsd_bpf_sniffer.go
@@ -1,0 +1,153 @@
+// +build darwin dragonfly freebsd netbsd openbsd
+
+/*
+ * This rough sketch of a golang API for a Berkeley packet filter sniffer for BSD variants.
+ * It provides only the capability to sniff ethernet frames... but could easily be extended for
+ * sending frames as well.
+ *
+ * This file was inspired by BSD licensed code from https://github.com/songgao/ether
+ *
+ * ( http://opensource.org/licenses/BSD-3-Clause )
+ *
+ * The bpf_wordalign function was borrowed... and readFrames was very much inspired by
+ * design I saw in songgao's ether git repository; the rest of the code I wrote myself ;-)
+ *
+ * Author: David Anthony Stainton
+ * License: BSD
+ *
+ */
+
+package bpf_sniffer
+
+import (
+	"fmt"
+	"github.com/google/gopacket"
+	"golang.org/x/sys/unix"
+	"syscall"
+	"time"
+	"unsafe"
+)
+
+const wordSize = int(unsafe.Sizeof(uintptr(0)))
+
+func bpf_wordalign(x int) int {
+	return (((x) + (wordSize - 1)) &^ (wordSize - 1))
+}
+
+type TimedFrame struct {
+	RawFrame  []byte
+	Timestamp time.Time
+}
+
+type BpfSniffer struct {
+	sniffDeveiceName string
+	bpfDeviceName string
+	fd       int
+	stopChan chan bool
+	readChan chan TimedFrame
+}
+
+func NewBpfSniffer(name string) *BpfSniffer {
+	return &BpfSniffer{
+		sniffDeviceName: name,
+		stopChan: make(chan bool, 0),
+		readChan: make(chan TimedFrame, 0),
+	}
+}
+
+func (b *BpfSniffer) pickBpfDevice() {
+	for i := 0; i < 99; i++ {
+		b.bpfDeviceName = fmt.Sprintf("/dev/bpf%d", i)
+		b.fd, err = syscall.Open(b.bpfDeviceName, syscall.O_RDWR, 0)
+		if err == nil {
+			break
+		}
+	}
+}
+
+// Init is used to initialize a BPF device for promiscuous sniffing.
+// It also starts a goroutine to continuously read frames.
+func (b *BpfSniffer) Init() error {
+	var err error
+	enable := 1
+
+	b.pickBpfDevice()
+
+	err = syscall.SetBpfInterface(b.fd, b.sniffDeviceName)
+	if err != nil {
+		return err
+	}
+
+	// turning Immediate mode off should make the snffer
+	// block when no packets are available.
+	err = syscall.SetBpfImmediate(b.fd, enable)
+	if err != nil {
+		return err
+	}
+
+	// preserves the link level source address...
+	// higher level protocol analyzers will not need this
+	err = syscall.SetBpfHeadercmpl(b.fd, enable)
+	if err != nil {
+		return err
+	}
+
+	// forces the interface into promiscuous mode
+	err = syscall.SetBpfPromisc(b.fd, enable)
+	if err != nil {
+		return err
+	}
+
+	go b.readFrames()
+	return nil
+}
+
+func (b *BpfSniffer) Stop() {
+	b.stopChan <- true
+}
+
+func (b *BpfSniffer) readFrames() {
+	bufLen, err := syscall.BpfBuflen(b.fd)
+	if err != nil {
+		panic(err)
+	}
+	buf := make([]byte, bufLen)
+	var n int
+	for {
+		select {
+		case <-b.stopChan:
+			return
+		default:
+			n, err = syscall.Read(b.fd, buf)
+			if err != nil {
+				continue
+			} else {
+				p := int(0)
+				for p < n {
+					hdr := (*unix.BpfHdr)(unsafe.Pointer(&buf[p]))
+					frameStart := p + int(hdr.Hdrlen)
+					b.readChan <- TimedFrame{
+						RawFrame:  buf[frameStart : frameStart+int(hdr.Caplen)],
+						Timestamp: time.Unix(int64(hdr.Tstamp.Sec), int64(hdr.Tstamp.Usec)*1000),
+					}
+					p += bpf_wordalign(int(hdr.Hdrlen) + int(hdr.Caplen))
+				}
+			}
+		}
+	}
+}
+
+func (b *BpfSniffer) ReadTimedFrame() TimedFrame {
+	timedFrame := <-b.readChan
+	return timedFrame
+}
+
+func (b *BpfSniffer) ReadPacketData() (data []byte, ci gopacket.CaptureInfo, err error) {
+	timedFrame := b.ReadTimedFrame()
+	captureInfo := gopacket.CaptureInfo{
+		Timestamp:     timedFrame.Timestamp,
+		CaptureLength: len(timedFrame.RawFrame),
+		Length:        len(timedFrame.RawFrame),
+	}
+	return timedFrame.RawFrame, captureInfo, nil
+}

--- a/bsdbpf/bsd_bpf_sniffer.go
+++ b/bsdbpf/bsd_bpf_sniffer.go
@@ -202,6 +202,7 @@ func (b *BPFSniffer) ReadPacketData() ([]byte, gopacket.CaptureInfo, error) {
 	return rawFrame, captureInfo, nil
 }
 
+// GetReadBufLen returns the BPF read buffer length
 func (b *BPFSniffer) GetReadBufLen() int {
 	return b.options.ReadBufLen
 }

--- a/bsdbpf/bsd_bpf_sniffer.go
+++ b/bsdbpf/bsd_bpf_sniffer.go
@@ -148,11 +148,13 @@ func (b *BPFSniffer) Init() error {
 func (b *BPFSniffer) ReadPacketData() ([]byte, gopacket.CaptureInfo, error) {
 	var err error
 	if b.readBytesConsumed >= b.lastReadLen {
+		b.readBytesConsumed = 0
+		b.readBuffer = make([]byte, b.options.readBufLen)
 		b.lastReadLen, err = syscall.Read(b.fd, b.readBuffer)
 		if err != nil {
+			b.lastReadLen = 0
 			return nil, gopacket.CaptureInfo{}, err
 		}
-		b.readBytesConsumed = 0
 	}
 	hdr := (*unix.BpfHdr)(unsafe.Pointer(&b.readBuffer[b.readBytesConsumed]))
 	frameStart := b.readBytesConsumed + int(hdr.Hdrlen)

--- a/bsdbpf/bsd_bpf_sniffer.go
+++ b/bsdbpf/bsd_bpf_sniffer.go
@@ -30,26 +30,24 @@ type TimedFrame struct {
 }
 
 type BPFSniffer struct {
-	sniffDeviceName string
-	bpfDeviceName string
-	fd       int
-	stopChan chan bool
-	readChan chan TimedFrame
-	readBuffer []byte
-	readBufLen int
-	lastReadLen int
+	sniffDeviceName   string
+	bpfDeviceName     string
+	fd                int
+	readBuffer        []byte
+	readBufLen        int
+	lastReadLen       int
 	readBytesConsumed int
-	timeout int
+	timeout           int
 }
 
 func NewBPFSniffer(sniffDeviceName, bpfDeviceName string, readBufLen, timeout int) *BPFSniffer {
 	return &BPFSniffer{
 		sniffDeviceName: sniffDeviceName,
-		bpfDeviceName: bpfDeviceName,
-		stopChan: make(chan bool, 0),
-		readChan: make(chan TimedFrame, 0),
-		readBufLen: readBufLen,
-		timeout: timeout,
+		bpfDeviceName:   bpfDeviceName,
+		stopChan:        make(chan bool, 0),
+		readChan:        make(chan TimedFrame, 0),
+		readBufLen:      readBufLen,
+		timeout:         timeout,
 	}
 }
 
@@ -91,7 +89,6 @@ func (b *BPFSniffer) Init() error {
 		}
 	}
 	b.readBuffer = make([]byte, b.readBufLen)
-
 
 	err = syscall.SetBpfInterface(b.fd, b.sniffDeviceName)
 	if err != nil {

--- a/bsdbpf/bsd_bpf_sniffer.go
+++ b/bsdbpf/bsd_bpf_sniffer.go
@@ -64,6 +64,8 @@ var defaultOptions = Options{
 	PreserveLinkAddr: true,
 }
 
+// BPFSniffer is a struct used to track state of a BSD BPF ethernet sniffer
+// such that gopacket's PacketDataSource interface is implemented.
 type BPFSniffer struct {
 	options           *Options
 	sniffDeviceName   string
@@ -73,6 +75,11 @@ type BPFSniffer struct {
 	readBytesConsumed int
 }
 
+// NewBPFSniffer is used to create BSD-only BPF ethernet sniffer
+// iface is the network interface device name that you wish to sniff
+// options can set to nil in order to utilize default values for everything.
+// Each field of Options also have a default setting if left unspecified by
+// the user's custome Options struct.
 func NewBPFSniffer(iface string, options *Options) *BPFSniffer {
 	sniffer := BPFSniffer{
 		sniffDeviceName: iface,
@@ -85,6 +92,7 @@ func NewBPFSniffer(iface string, options *Options) *BPFSniffer {
 	return &sniffer
 }
 
+// Close is used to close the file-descriptor of the BPF device file.
 func (b *BPFSniffer) Close() error {
 	return syscall.Close(b.fd)
 }

--- a/bsdbpf/bsd_bpf_sniffer.go
+++ b/bsdbpf/bsd_bpf_sniffer.go
@@ -87,12 +87,6 @@ func (b *BPFSniffer) Init() error {
 		if err != nil {
 			panic(err)
 		}
-		var actualBufLen int
-		actualBufLen, err = syscall.BpfBuflen(b.fd)
-		if err != nil {
-			panic(err)
-		}
-		fmt.Printf("actual buf len %d\n", actualBufLen)
 	}
 	b.readBuffer = make([]byte, b.readBufLen)
 

--- a/bsdbpf/bsd_bpf_sniffer.go
+++ b/bsdbpf/bsd_bpf_sniffer.go
@@ -72,6 +72,20 @@ func (b *BPFSniffer) Init() error {
 	var err error
 	enable := 1
 
+	// setup our read buffer
+	if b.readBufLen == 0 {
+		b.readBufLen, err = syscall.BpfBuflen(b.fd)
+		if err != nil {
+			panic(err)
+		}
+	} else {
+		b.readBufLen, err = syscall.SetBpfBuflen(b.fd, b.readBufLen)
+		if err != nil {
+			panic(err)
+		}
+	}
+	b.readBuffer = make([]byte, b.readBufLen)
+
 	if b.bpfDeviceName == "" {
 		b.pickBpfDevice()
 	}
@@ -100,20 +114,6 @@ func (b *BPFSniffer) Init() error {
 	if err != nil {
 		return err
 	}
-
-	// setup our read buffer
-	if b.readBufLen == 0 {
-		b.readBufLen, err = syscall.BpfBuflen(b.fd)
-		if err != nil {
-			panic(err)
-		}
-	} else {
-		b.readBufLen, err = syscall.SetBpfBuflen(b.fd, b.readBufLen)
-		if err != nil {
-			panic(err)
-		}
-	}
-	b.readBuffer = make([]byte, b.readBufLen)
 
 	return nil
 }

--- a/bsdbpf/bsd_bpf_sniffer.go
+++ b/bsdbpf/bsd_bpf_sniffer.go
@@ -117,9 +117,12 @@ func (b *BPFSniffer) Init() error {
 
 func (b *BPFSniffer) ReadPacketData() (data []byte, ci gopacket.CaptureInfo, err error) {
 	var err error
-	b.lastReadLen, err = syscall.Read(b.fd, b.readBuffer)
-	if err != nil {
-		return nil, gopacket.CaptureInfo{}, err
+	if b.readBytesConsumed == b.lastReadLen {
+		b.lastReadLen, err = syscall.Read(b.fd, b.readBuffer)
+		if err != nil {
+			return nil, gopacket.CaptureInfo{}, err
+		}
+		b.readBytesConsumed = 0
 	}
 	hdr := (*unix.BpfHdr)(unsafe.Pointer(&buf[b.readBytesConsumed]))
 	frameStart := b.readBytesConsumed + int(hdr.Hdrlen)

--- a/bsdbpf/bsd_bpf_sniffer.go
+++ b/bsdbpf/bsd_bpf_sniffer.go
@@ -33,10 +33,14 @@ type Options struct {
 	BPFDeviceName string
 	// ReadBufLen specifies the size of the buffer used to read packets
 	// off the wire such that multiple packets are buffered with each read syscall.
-	// The packet will be clipped if it's size exceeds the buffer size.
+	// Note that an individual packet larger than the buffer size is necessarily truncated.
 	// A larger buffer should increase performance because fewer read syscalls would be made.
-	// If zero is used the system's default buffer length will be used.
-	// ReadBufLen defaults to 32767.
+	// If zero is used, the system's default buffer length will be used which depending on the
+	// system may default to 4096 bytes which is not big enough to accomodate some link layers
+	// such as WLAN (802.11).
+	// ReadBufLen defaults to 32767... however typical BSD manual pages for BPF indicate that
+	// if the requested buffer size cannot be accommodated, the closest allowable size will be
+	// set and returned... hence our GetReadBufLen method.
 	ReadBufLen int
 	// Timeout is the length of time to wait before timing out on a read request.
 	// Timeout defaults to nil which means no timeout is used.
@@ -196,4 +200,8 @@ func (b *BPFSniffer) ReadPacketData() ([]byte, gopacket.CaptureInfo, error) {
 		Length:        len(rawFrame),
 	}
 	return rawFrame, captureInfo, nil
+}
+
+func (b *BPFSniffer) GetReadBufLen() int {
+	return b.options.ReadBufLen
 }

--- a/bsdbpf/bsd_bpf_sniffer.go
+++ b/bsdbpf/bsd_bpf_sniffer.go
@@ -1,10 +1,10 @@
-// +build darwin dragonfly freebsd netbsd openbsd
-
 // Copyright 2012 Google, Inc. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file in the root of the source
 // tree.
+
+// +build darwin dragonfly freebsd netbsd openbsd
 
 package bsdbpf
 


### PR DESCRIPTION
OK... here's the code. I haven't done a smoke test lately but last time I tested it worked on OpenBSD, FreeBSD and NetBSD.

Maybe we should be calling SetBpfBuflen instead of using the default. OpenBSD and NetBSD both default to a BPF bufLen of 32767 but FreeBSD uses 4096... obviously having a larger bufLen should improve performance.

