### PR TITLE
Add serialization of IPv6 Hop-by-hop extension header

### DIFF
--- a/layers/enums.go
+++ b/layers/enums.go
@@ -457,7 +457,7 @@ func init() {
 	IPProtocolMetadata[IPProtocolESP] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeIPSecESP), Name: "IPSecESP", LayerType: LayerTypeIPSecESP}
 	IPProtocolMetadata[IPProtocolUDPLite] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeUDPLite), Name: "UDPLite", LayerType: LayerTypeUDPLite}
 	IPProtocolMetadata[IPProtocolMPLSInIP] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeMPLS), Name: "MPLS", LayerType: LayerTypeMPLS}
-	IPProtocolMetadata[IPProtocolNoNextHeader] = EnumMetadata{DecodeWith: errorFunc("NoNextHeader with non-zero byte payload"), Name: "NoNextHeader"}
+	IPProtocolMetadata[IPProtocolNoNextHeader] = EnumMetadata{DecodeWith: gopacket.DecodePayload, Name: "NoNextHeader", LayerType: gopacket.LayerTypePayload}
 	IPProtocolMetadata[IPProtocolIGMP] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeIGMP), Name: "IGMP", LayerType: LayerTypeIGMP}
 
 	SCTPChunkTypeMetadata[SCTPChunkTypeData] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeSCTPData), Name: "Data"}

--- a/layers/ip6.go
+++ b/layers/ip6.go
@@ -269,9 +269,6 @@ func decodeIPv6(data []byte, p gopacket.PacketBuilder) error {
 	p.AddLayer(ip6)
 	p.SetNetworkLayer(ip6)
 	if ip6.HopByHop != nil {
-		// TODO(gconnell):  Since HopByHop is now an integral part of the IPv6
-		// layer, should it actually be added as its own layer?  I'm leaning towards
-		// no.
 		p.AddLayer(ip6.HopByHop)
 	}
 	if err != nil {

--- a/layers/ip6.go
+++ b/layers/ip6.go
@@ -41,13 +41,140 @@ const (
 	IPv6HopByHopOptionJumbogram = 0xC2 // RFC 2675
 )
 
+const (
+	ipv6MaxPayloadLength = 65535
+)
+
+// Search for Jumbo Payload TLV in IPv6HopByHop and return (length, true) if found
+func getIPv6HopByHopJumboLength(hopopts *IPv6HopByHop) (uint32, bool, error) {
+	var tlv *IPv6HopByHopOption
+
+	for _, t := range hopopts.Options {
+		if t.OptionType == IPv6HopByHopOptionJumbogram {
+			tlv = t
+			break
+		}
+	}
+	if tlv == nil {
+		// Not found
+		return 0, false, nil
+	}
+	if len(tlv.OptionData) != 4 {
+		return 0, false, fmt.Errorf("Jumbo length TLV data must have length 4")
+	}
+	l := binary.BigEndian.Uint32(tlv.OptionData)
+	if l <= ipv6MaxPayloadLength {
+		return 0, false, fmt.Errorf("Jumbo length cannot be less than %d", ipv6MaxPayloadLength + 1)
+	}
+	// Found
+	return l, true, nil
+}
+
+// Adds zero-valued Jumbo TLV to IPv6 header if it does not exist
+// (if necessary add hop-by-hop header)
+func addIPv6JumboOption(ip6 *IPv6) {
+	var tlv *IPv6HopByHopOption
+
+	if ip6.HopByHop == nil {
+		// Add IPv6 HopByHop
+		ip6.HopByHop = &IPv6HopByHop{}
+		ip6.HopByHop.NextHeader = ip6.NextHeader
+		ip6.HopByHop.HeaderLength = 0
+		ip6.NextHeader = IPProtocolIPv6HopByHop
+	}
+	for _, t := range ip6.HopByHop.Options {
+		if t.OptionType == IPv6HopByHopOptionJumbogram {
+			tlv = t
+			break
+		}
+	}
+	if tlv == nil {
+		// Add Jumbo TLV
+		tlv = &IPv6HopByHopOption{}
+		ip6.HopByHop.Options = append(ip6.HopByHop.Options, tlv)
+	}
+	tlv.SetJumboLength(0)
+}
+
+// Set jumbo length in serialized IPv6 payload (starting with HopByHop header)
+func setIPv6PayloadJumboLength(hbh []byte) error {
+	pLen := len(hbh)
+	if pLen < 8 {
+		//HopByHop is minimum 8 bytes
+		return fmt.Errorf("Invalid IPv6 payload (length %d)", pLen)
+	}
+	hbhLen := int((hbh[1] + 1) * 8)
+	if hbhLen > pLen {
+		return fmt.Errorf("Invalid hop-by-hop length (length: %d, payload: %d", hbhLen, pLen)
+	}
+	offset := 2 //start with options
+	for offset < hbhLen {
+		opt := hbh[offset]
+		if opt == 0 {
+			//Pad1
+			offset += 1
+			continue
+		}
+		optLen := int(hbh[offset+1])
+		if opt == IPv6HopByHopOptionJumbogram {
+			if optLen == 4 {
+				binary.BigEndian.PutUint32(hbh[offset+2:], uint32(pLen))
+				return nil
+			}
+			return fmt.Errorf("Jumbo TLV too short (%d bytes)", optLen)
+		}
+		offset += 2 + optLen
+	}
+	return fmt.Errorf("Jumbo TLV not found")
+}
+
 // SerializeTo writes the serialized form of this layer into the
 // SerializationBuffer, implementing gopacket.SerializableLayer.
 // See the docs for gopacket.SerializableLayer for more info.
 func (ip6 *IPv6) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeOptions) error {
+	var jumbo bool
+	var err error
+
 	payload := b.Bytes()
+	pLen := len(payload)
+	if pLen > ipv6MaxPayloadLength {
+		jumbo = true
+		if opts.FixLengths {
+			// We need to set the length later because the hop-by-hop header may
+			// not exist or else need padding, so pLen may yet change
+			addIPv6JumboOption(ip6)
+		} else if ip6.HopByHop == nil {
+			return fmt.Errorf("Cannot fit payload length of %d into IPv6 packet", pLen)
+		} else {
+			_, ok, err := getIPv6HopByHopJumboLength(ip6.HopByHop)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return fmt.Errorf("Missing jumbo length hop-by-hop option")
+			}
+		}
+	}
 	if ip6.HopByHop != nil {
-		return fmt.Errorf("unable to serialize hopbyhop for now")
+		if ip6.NextHeader != IPProtocolIPv6HopByHop {
+			// Just fix it instead of throwing an error
+			ip6.NextHeader = IPProtocolIPv6HopByHop
+		}
+		err = ip6.HopByHop.SerializeTo(b, opts)
+		if err != nil {
+			return err
+		}
+		payload = b.Bytes()
+		pLen = len(payload)
+		if opts.FixLengths && jumbo {
+			err := setIPv6PayloadJumboLength(payload)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	if !jumbo && pLen > ipv6MaxPayloadLength {
+		return fmt.Errorf("Cannot fit payload into IPv6 header")
 	}
 	bytes, err := b.PrependBytes(40)
 	if err != nil {
@@ -57,7 +184,11 @@ func (ip6 *IPv6) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.Serialize
 	bytes[1] = (ip6.TrafficClass << 4) | uint8(ip6.FlowLabel>>16)
 	binary.BigEndian.PutUint16(bytes[2:], uint16(ip6.FlowLabel))
 	if opts.FixLengths {
-		ip6.Length = uint16(len(payload))
+		if jumbo {
+			ip6.Length = 0
+		} else {
+			ip6.Length = uint16(pLen)
+		}
 	}
 	binary.BigEndian.PutUint16(bytes[4:], ip6.Length)
 	bytes[6] = byte(ip6.NextHeader)
@@ -80,38 +211,35 @@ func (ip6 *IPv6) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error 
 	ip6.SrcIP = data[8:24]
 	ip6.DstIP = data[24:40]
 	ip6.HopByHop = nil
-	// We initially set the payload to all bytes after 40.  ip6.Length or the
-	// HopByHop jumbogram option can both change this eventually, though.
 	ip6.BaseLayer = BaseLayer{data[:40], data[40:]}
 
 	// We treat a HopByHop IPv6 option as part of the IPv6 packet, since its
 	// options are crucial for understanding what's actually happening per packet.
 	if ip6.NextHeader == IPProtocolIPv6HopByHop {
-		ip6.hbh.DecodeFromBytes(ip6.Payload, df)
-		hbhLen := len(ip6.hbh.Contents)
-		// Reset IPv6 contents to include the HopByHop header.
-		ip6.BaseLayer = BaseLayer{data[:40+hbhLen], data[40+hbhLen:]}
+		err := ip6.hbh.DecodeFromBytes(ip6.Payload, df)
+		if err != nil {
+			return err
+		}
 		ip6.HopByHop = &ip6.hbh
-		if ip6.Length == 0 {
-			for _, o := range ip6.hbh.Options {
-				if o.OptionType == IPv6HopByHopOptionJumbogram {
-					if len(o.OptionData) != 4 {
-						return fmt.Errorf("Invalid jumbo packet option length")
-					}
-					payloadLength := binary.BigEndian.Uint32(o.OptionData)
-					pEnd := int(payloadLength)
-					if pEnd > len(ip6.Payload) {
-						df.SetTruncated()
-					} else {
-						ip6.Payload = ip6.Payload[:pEnd]
-						ip6.hbh.Payload = ip6.Payload
-					}
-					return nil
-				}
+		pEnd, jumbo, err := getIPv6HopByHopJumboLength(ip6.HopByHop)
+		if err != nil {
+			return err
+		}
+		if jumbo && ip6.Length == 0 {
+			pEnd := int(pEnd)
+			if pEnd > len(ip6.Payload) {
+				df.SetTruncated()
+				pEnd = len(ip6.Payload)
 			}
+			ip6.Payload = ip6.Payload[:pEnd]
+			return nil
+		} else if jumbo && ip6.Length != 0 {
+			return fmt.Errorf("IPv6 has jumbo length and IPv6 length is not 0")
+		} else if !jumbo && ip6.Length == 0 {
 			return fmt.Errorf("IPv6 length 0, but HopByHop header does not have jumbogram option")
 		}
 	}
+
 	if ip6.Length == 0 {
 		return fmt.Errorf("IPv6 length 0, but next header is %v, not HopByHop", ip6.NextHeader)
 	} else {
@@ -155,13 +283,45 @@ func decodeIPv6(data []byte, p gopacket.PacketBuilder) error {
 	return p.NextDecoder(ip6.NextHeader)
 }
 
+func (i *IPv6HopByHop) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeOptions) error {
+	var bytes []byte
+	var err error
+
+	o := make([]ipv6HeaderTLVOption, 0, len(i.Options))
+	for _, v := range i.Options {
+		o = append(o, ipv6HeaderTLVOption(*v))
+	}
+
+	l := serializeIPv6HeaderTLVOptions(nil, o, opts.FixLengths, true)
+	bytes, err = b.PrependBytes(l)
+	if err != nil {
+		return err
+	}
+	serializeIPv6HeaderTLVOptions(bytes, o, opts.FixLengths, false)
+
+	length := len(bytes) + 2
+	if length%8 != 0 {
+		return fmt.Errorf("IPv6HopByHop actual length must be multiple of 8")
+	}
+	bytes, err = b.PrependBytes(2)
+	if err != nil {
+		return err
+	}
+	bytes[0] = uint8(i.NextHeader)
+	if opts.FixLengths {
+		i.HeaderLength = uint8((length / 8) - 1)
+	}
+	bytes[1] = uint8(i.HeaderLength)
+	return nil
+}
+
 func (i *IPv6HopByHop) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 	i.ipv6ExtensionBase = decodeIPv6ExtensionBase(data)
-	i.Options = i.opts[:0]
-	var opt *IPv6HopByHopOption
-	for d := i.Contents[2:]; len(d) > 0; d = d[opt.ActualLength:] {
-		i.Options = append(i.Options, IPv6HopByHopOption(decodeIPv6HeaderTLVOption(d)))
-		opt = &i.Options[len(i.Options)-1]
+	offset := 2
+	for offset < i.ActualLength {
+		opt := decodeIPv6HeaderTLVOption(data[offset:])
+		i.Options = append(i.Options, (*IPv6HopByHopOption)(opt))
+		offset += opt.ActualLength
 	}
 	return nil
 }
@@ -180,9 +340,11 @@ type ipv6HeaderTLVOption struct {
 	OptionType, OptionLength uint8
 	ActualLength             int
 	OptionData               []byte
+	OptionAlignment          [2]uint8 // Xn+Y = [2]uint8{X, Y}
 }
 
-func decodeIPv6HeaderTLVOption(data []byte) (h ipv6HeaderTLVOption) {
+func decodeIPv6HeaderTLVOption(data []byte) (h *ipv6HeaderTLVOption) {
+	h = &ipv6HeaderTLVOption{}
 	if data[0] == 0 {
 		h.ActualLength = 1
 		return
@@ -194,23 +356,93 @@ func decodeIPv6HeaderTLVOption(data []byte) (h ipv6HeaderTLVOption) {
 	return
 }
 
-func (h *ipv6HeaderTLVOption) serializeTo(b gopacket.SerializeBuffer, fixLengths bool) (int, error) {
+func (h *ipv6HeaderTLVOption) serializeTo(data []byte, fixLengths bool, dryrun bool) int {
 	if fixLengths {
 		h.OptionLength = uint8(len(h.OptionData))
 	}
 	length := int(h.OptionLength) + 2
-	data, err := b.PrependBytes(length)
-	if err != nil {
-		return 0, err
+	if !dryrun {
+		data[0] = h.OptionType
+		data[1] = h.OptionLength
+		copy(data[2:], h.OptionData)
 	}
-	data[0] = h.OptionType
-	data[1] = h.OptionLength
-	copy(data[2:], h.OptionData)
-	return length, nil
+	return length
 }
 
 // IPv6HopByHopOption is a TLV option present in an IPv6 hop-by-hop extension.
 type IPv6HopByHopOption ipv6HeaderTLVOption
+
+func (o *IPv6HopByHopOption) SetJumboLength(len uint32) {
+	o.OptionType = IPv6HopByHopOptionJumbogram
+	o.OptionLength = 4
+	o.ActualLength = 6
+	if o.OptionData == nil {
+		o.OptionData = make([]byte, 4)
+	}
+	binary.BigEndian.PutUint32(o.OptionData, len)
+	o.OptionAlignment = [2]uint8{4, 2}
+}
+
+func serializeTLVOptionPadding(data []byte, padLength int) {
+	if padLength <= 0 {
+		return
+	}
+	if padLength == 1 {
+		data[0] = 0x0
+		return
+	}
+	tlvLength := uint8(padLength) - 2
+	data[0] = 0x1
+	data[1] = tlvLength
+	if tlvLength != 0 {
+		for k := range data[2:] {
+			data[k+2] = 0x0
+		}
+	}
+	return
+}
+
+func serializeIPv6HeaderTLVOptions(buf []byte, options []ipv6HeaderTLVOption, fixLengths bool, dryrun bool) int {
+	var l int
+
+	length := 2
+	for _, opt := range options {
+		if fixLengths {
+			x := int(opt.OptionAlignment[0])
+			y := int(opt.OptionAlignment[1])
+			if x != 0 {
+				n := length / x
+				offset := x*n + y
+				if offset < length {
+					offset += x
+				}
+				if length != offset {
+					pad := offset - length
+					if !dryrun {
+						serializeTLVOptionPadding(buf[length-2:], pad)
+					}
+					length += pad
+				}
+			}
+		}
+		if dryrun {
+			l = opt.serializeTo(nil, fixLengths, true)
+		} else {
+			l = opt.serializeTo(buf[length-2:], fixLengths, false)
+		}
+		length += l
+	}
+	if fixLengths {
+		pad := length % 8
+		if pad != 0 {
+			if !dryrun {
+				serializeTLVOptionPadding(buf[length-2:], pad)
+			}
+			length += pad
+		}
+	}
+	return length - 2
+}
 
 type ipv6ExtensionBase struct {
 	BaseLayer
@@ -252,8 +484,7 @@ func (i *IPv6ExtensionSkipper) NextLayerType() gopacket.LayerType {
 // IPv6HopByHop is the IPv6 hop-by-hop extension.
 type IPv6HopByHop struct {
 	ipv6ExtensionBase
-	Options []IPv6HopByHopOption
-	opts    [2]IPv6HopByHopOption
+	Options []*IPv6HopByHopOption
 }
 
 // LayerType returns LayerTypeIPv6HopByHop.
@@ -331,32 +562,33 @@ func decodeIPv6Fragment(data []byte, p gopacket.PacketBuilder) error {
 // IPv6DestinationOption is a TLV option present in an IPv6 destination options extension.
 type IPv6DestinationOption ipv6HeaderTLVOption
 
-func (o *IPv6DestinationOption) serializeTo(b gopacket.SerializeBuffer, fixLengths bool) (int, error) {
-	return (*ipv6HeaderTLVOption)(o).serializeTo(b, fixLengths)
-}
-
 // IPv6Destination is the IPv6 destination options header.
 type IPv6Destination struct {
 	ipv6ExtensionBase
-	Options []IPv6DestinationOption
+	Options []*IPv6DestinationOption
 }
 
 // LayerType returns LayerTypeIPv6Destination.
 func (i *IPv6Destination) LayerType() gopacket.LayerType { return LayerTypeIPv6Destination }
 
+func (i *IPv6Destination) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
+	i.ipv6ExtensionBase = decodeIPv6ExtensionBase(data)
+	offset := 2
+	for offset < i.ActualLength {
+		opt := decodeIPv6HeaderTLVOption(data[offset:])
+		i.Options = append(i.Options, (*IPv6DestinationOption)(opt))
+		offset += opt.ActualLength
+	}
+	return nil
+}
+
 func decodeIPv6Destination(data []byte, p gopacket.PacketBuilder) error {
-	i := &IPv6Destination{
-		ipv6ExtensionBase: decodeIPv6ExtensionBase(data),
-		// We guess we'll 1-2 options, one regular option at least, then maybe one
-		// padding option.
-		Options: make([]IPv6DestinationOption, 0, 2),
-	}
-	var opt *IPv6DestinationOption
-	for d := i.Contents[2:]; len(d) > 0; d = d[opt.ActualLength:] {
-		i.Options = append(i.Options, IPv6DestinationOption(decodeIPv6HeaderTLVOption(d)))
-		opt = &i.Options[len(i.Options)-1]
-	}
+	i := &IPv6Destination{}
+	err := i.DecodeFromBytes(data, p)
 	p.AddLayer(i)
+	if err != nil {
+		return err
+	}
 	return p.NextDecoder(i.NextHeader)
 }
 
@@ -364,30 +596,34 @@ func decodeIPv6Destination(data []byte, p gopacket.PacketBuilder) error {
 // SerializationBuffer, implementing gopacket.SerializableLayer.
 // See the docs for gopacket.SerializableLayer for more info.
 func (i *IPv6Destination) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeOptions) error {
-	optionLength := 0
-	for _, opt := range i.Options {
-		l, err := opt.serializeTo(b, opts.FixLengths)
-		if err != nil {
-			return err
-		}
-		optionLength += l
+	var bytes []byte
+	var err error
+
+	o := make([]ipv6HeaderTLVOption, 0, len(i.Options))
+	for _, v := range i.Options {
+		o = append(o, ipv6HeaderTLVOption(*v))
 	}
-	bytes, err := b.PrependBytes(2)
+
+	l := serializeIPv6HeaderTLVOptions(nil, o, opts.FixLengths, true)
+	bytes, err = b.PrependBytes(l)
+	if err != nil {
+		return err
+	}
+	serializeIPv6HeaderTLVOptions(bytes, o, opts.FixLengths, false)
+
+	length := len(bytes) + 2
+	if length%8 != 0 {
+		return fmt.Errorf("IPv6Destination actual length must be multiple of 8")
+	}
+	bytes, err = b.PrependBytes(2)
 	if err != nil {
 		return err
 	}
 	bytes[0] = uint8(i.NextHeader)
 	if opts.FixLengths {
-		if optionLength <= 0 {
-			return fmt.Errorf("cannot serialize empty IPv6Destination")
-		}
-		length := optionLength + 2
-		if length % 8 != 0 {
-			return fmt.Errorf("IPv6Destination actual length must be multiple of 8 (check TLV alignment)")
-		}
 		i.HeaderLength = uint8((length / 8) - 1)
 	}
-	bytes[1] = i.HeaderLength
+	bytes[1] = uint8(i.HeaderLength)
 	return nil
 }
 

--- a/layers/ip6_test.go
+++ b/layers/ip6_test.go
@@ -7,11 +7,197 @@
 package layers
 
 import (
+	"bytes"
 	"github.com/google/gopacket"
+	"github.com/google/gopacket/bytediff"
 	"net"
 	"reflect"
 	"testing"
 )
+
+func TestSerializeIPv6HeaderTLVOptions(t *testing.T) {
+	//RFC 2460 Appendix B
+	/*
+	   Example 3
+
+	   A Hop-by-Hop or Destination Options header containing both options X
+	   and Y from Examples 1 and 2 would have one of the two following
+	   formats, depending on which option appeared first:
+
+	   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	   |  Next Header  | Hdr Ext Len=3 | Option Type=X |Opt Data Len=12|
+	   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	   |                         4-octet field                         |
+	   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	   |                                                               |
+	   +                         8-octet field                         +
+	   |                                                               |
+	   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	   | PadN Option=1 |Opt Data Len=1 |       0       | Option Type=Y |
+	   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	   |Opt Data Len=7 | 1-octet field |         2-octet field         |
+	   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	   |                         4-octet field                         |
+	   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	   | PadN Option=1 |Opt Data Len=2 |       0       |       0       |
+	   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	*/
+	opt1 := &ipv6HeaderTLVOption{}
+	opt1.OptionType = 0x1E
+	opt1.OptionData = []byte{0xaa, 0xaa, 0xaa, 0xaa, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb}
+	opt1.OptionAlignment = [2]uint8{8, 2}
+
+	opt2 := &ipv6HeaderTLVOption{}
+	opt2.OptionType = 0x3E
+	opt2.OptionData = []byte{0x11, 0x22, 0x22, 0x44, 0x44, 0x44, 0x44}
+	opt2.OptionAlignment = [2]uint8{4, 3}
+
+	l := serializeIPv6HeaderTLVOptions(nil, []ipv6HeaderTLVOption{*opt1, *opt2}, true, true)
+	b := make([]byte, l)
+	serializeIPv6HeaderTLVOptions(b, []ipv6HeaderTLVOption{*opt1, *opt2}, true, false)
+	got := b
+	want := []byte{0x1E, 0x0C, 0xaa, 0xaa, 0xaa, 0xaa, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0x01, 0x01, 0x00, 0x3E, 0x07, 0x11, 0x22, 0x22, 0x44, 0x44, 0x44, 0x44, 0x01, 0x02, 0x00, 0x00}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("IPv6HeaderTLVOption serialize (X,Y) failed:\ngot:\n%#v\n\nwant:\n%#v\n\n", got, want)
+	}
+
+	/*
+	   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	   |  Next Header  | Hdr Ext Len=3 | Pad1 Option=0 | Option Type=Y |
+	   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	   |Opt Data Len=7 | 1-octet field |         2-octet field         |
+	   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	   |                         4-octet field                         |
+	   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	   | PadN Option=1 |Opt Data Len=4 |       0       |       0       |
+	   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	   |       0       |       0       | Option Type=X |Opt Data Len=12|
+	   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	   |                         4-octet field                         |
+	   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	   |                                                               |
+	   +                         8-octet field                         +
+	   |                                                               |
+	   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	*/
+
+	l = serializeIPv6HeaderTLVOptions(nil, []ipv6HeaderTLVOption{*opt2, *opt1}, true, true)
+	b = make([]byte, l)
+	serializeIPv6HeaderTLVOptions(b, []ipv6HeaderTLVOption{*opt2, *opt1}, true, false)
+	got = b
+	want = []byte{0x00, 0x3E, 0x07, 0x11, 0x22, 0x22, 0x44, 0x44, 0x44, 0x44, 0x01, 0x04, 0x00, 0x00, 0x00, 0x00, 0x1E, 0x0C, 0xaa, 0xaa, 0xaa, 0xaa, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb, 0xbb}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("IPv6HeaderTLVOption serialize (Y, X) failed:\ngot:\n%#v\n\nwant:\n%#v\n\n", got, want)
+	}
+}
+
+var testPacketIPv6HopByHop0 = []byte{
+	0x60, 0x00, 0x00, 0x00, 0x00, 0x08, 0x00, 0x40, 0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x3b, 0x00, 0x01, 0x04, 0x00, 0x00, 0x00, 0x00,
+}
+
+func TestPacketIPv6HopByHop0Serialize(t *testing.T) {
+	var serialize []gopacket.SerializableLayer = make([]gopacket.SerializableLayer, 0, 2)
+	var err error
+
+	ip6 := &IPv6{}
+	ip6.Version = 6
+	ip6.NextHeader = IPProtocolIPv6HopByHop
+	ip6.HopLimit = 64
+	ip6.SrcIP = net.ParseIP("2001:db8::1")
+	ip6.DstIP = net.ParseIP("2001:db8::2")
+	serialize = append(serialize, ip6)
+
+	tlv := &IPv6HopByHopOption{}
+	tlv.OptionType = 0x01 //PadN
+	tlv.OptionData = []byte{0x00, 0x00, 0x00, 0x00}
+	hop := &IPv6HopByHop{}
+	hop.Options = append(hop.Options, tlv)
+	hop.NextHeader = IPProtocolNoNextHeader
+	ip6.HopByHop = hop
+
+	buf := gopacket.NewSerializeBuffer()
+	opts := gopacket.SerializeOptions{FixLengths: true}
+	err = gopacket.SerializeLayers(buf, opts, serialize...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := buf.Bytes()
+	want := testPacketIPv6HopByHop0
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("IPv6HopByHop serialize failed:\ngot:\n%#v\n\nwant:\n%#v\n\n", got, want)
+	}
+}
+
+func TestPacketIPv6HopByHop0Decode(t *testing.T) {
+	var ip6 *IPv6
+	var hop *IPv6HopByHop
+
+	ip6 = &IPv6{
+		BaseLayer: BaseLayer{
+			Contents: []byte{
+				0x60, 0x00, 0x00, 0x00, 0x00, 0x08, 0x00, 0x40, 0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
+			},
+			Payload: []byte{0x3b, 0x00, 0x01, 0x04, 0x00, 0x00, 0x00, 0x00},
+		},
+		Version:      6,
+		TrafficClass: 0,
+		FlowLabel:    0,
+		Length:       8,
+		NextHeader:   IPProtocolIPv6HopByHop,
+		HopLimit:     64,
+		SrcIP:        net.IP{0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01},
+		DstIP: net.IP{0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02},
+	}
+	hop = &ip6.hbh
+	hop.ipv6ExtensionBase = ipv6ExtensionBase{
+		BaseLayer: BaseLayer{
+			Contents: []byte{0x3b, 0x00, 0x01, 0x04, 0x00, 0x00, 0x00, 0x00},
+			Payload:  []byte{},
+		},
+		NextHeader:   IPProtocolNoNextHeader,
+		HeaderLength: uint8(0),
+		ActualLength: 8,
+	}
+	opt := &IPv6HopByHopOption{
+		OptionType:   uint8(0x01),
+		OptionLength: uint8(0x04),
+		ActualLength: 6,
+		OptionData:   []byte{0x00, 0x00, 0x00, 0x00},
+	}
+	hop.Options = append(hop.Options, opt)
+	ip6.HopByHop = hop
+
+	p := gopacket.NewPacket(testPacketIPv6HopByHop0, LinkTypeRaw, gopacket.DecodeOptions{SkipDecodeRecovery: true})
+	if p.ErrorLayer() != nil {
+		t.Error("Failed to decode packet:", p.ErrorLayer().Error())
+	}
+	checkLayers(p, []gopacket.LayerType{LayerTypeIPv6, LayerTypeIPv6HopByHop}, t)
+	if got, ok := p.Layer(LayerTypeIPv6).(*IPv6); ok {
+		want := ip6
+		want.HopByHop = got.HopByHop // avoid comparing pointers
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("IPv6 packet processing failed:\ngot  :\n%#v\n\nwant :\n%#v\n\n", got, want)
+		}
+	} else {
+		t.Error("No IPv6 layer type found in packet")
+	}
+	if got, ok := p.Layer(LayerTypeIPv6HopByHop).(*IPv6HopByHop); ok {
+		want := hop
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("IPv6HopByHop packet processing failed:\ngot  :\n%#v\n\nwant :\n%#v\n\n", got, want)
+		}
+	} else {
+		t.Error("No IPv6HopByHop layer type found in packet")
+	}
+}
 
 // testPacketIPv6Destination0 is the packet:
 //   12:40:14.429409595 IP6 2001:db8::1 > 2001:db8::2: DSTOPT no next header
@@ -40,7 +226,7 @@ func TestPacketIPv6Destination0Serialize(t *testing.T) {
 	tlv.OptionType = 0x01 //PadN
 	tlv.OptionData = []byte{0x00, 0x00, 0x00, 0x00}
 	dst := &IPv6Destination{}
-	dst.Options = append(dst.Options, *tlv)
+	dst.Options = append(dst.Options, tlv)
 	dst.NextHeader = IPProtocolNoNextHeader
 	serialize = append(serialize, dst)
 
@@ -99,7 +285,7 @@ func TestPacketIPv6Destination0Decode(t *testing.T) {
 		want.NextHeader = IPProtocolNoNextHeader
 		want.HeaderLength = uint8(0)
 		want.ActualLength = 8
-		opt := IPv6DestinationOption{
+		opt := &IPv6DestinationOption{
 			OptionType:   uint8(0x01),
 			OptionLength: uint8(0x04),
 			ActualLength: 6,
@@ -111,5 +297,141 @@ func TestPacketIPv6Destination0Decode(t *testing.T) {
 		}
 	} else {
 		t.Error("No IPv6Destination layer type found in packet")
+	}
+}
+
+var testPacketIPv6JumbogramHeader = []byte{
+	0x60, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x3b, 0x00, 0xC2, 0x04, 0x00, 0x01, 0x00, 0x08,
+}
+
+func TestIPv6JumbogramSerialize(t *testing.T) {
+	var serialize []gopacket.SerializableLayer = make([]gopacket.SerializableLayer, 0, 2)
+	var err error
+
+	ip6 := &IPv6{}
+	ip6.Version = 6
+	ip6.NextHeader = IPProtocolNoNextHeader
+	ip6.HopLimit = 64
+	ip6.SrcIP = net.ParseIP("2001:db8::1")
+	ip6.DstIP = net.ParseIP("2001:db8::2")
+	serialize = append(serialize, ip6)
+
+	payload := make([]byte, ipv6MaxPayloadLength+1)
+	for i := range payload {
+		payload[i] = 0xfe
+	}
+	serialize = append(serialize, gopacket.Payload(payload))
+
+	buf := gopacket.NewSerializeBuffer()
+	opts := gopacket.SerializeOptions{FixLengths: true}
+	err = gopacket.SerializeLayers(buf, opts, serialize...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := buf.Bytes()
+	w := new(bytes.Buffer)
+	w.Write(testPacketIPv6JumbogramHeader)
+	w.Write(payload)
+	want := w.Bytes()
+
+	if !bytes.Equal(got, want) {
+		t.Errorf("IPv6 Jumbogram serialize failed::\nwant: %d bytes\n\ngot: %d bytes\n\nBASH-colorized diff, want->got:\n%v\n\n", len(want), len(got), bytediff.BashOutput.String(bytediff.Diff(want, got)))
+	}
+
+}
+
+func TestIPv6JumbogramDecode(t *testing.T) {
+	var ip6 *IPv6
+	var hop *IPv6HopByHop
+
+	payload := make([]byte, ipv6MaxPayloadLength+1)
+	for i := range payload {
+		payload[i] = 0xfe
+	}
+
+	ip6 = &IPv6{
+		BaseLayer: BaseLayer{
+			Contents: []byte{
+				0x60, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
+			},
+		},
+		Version:      6,
+		TrafficClass: 0,
+		FlowLabel:    0,
+		Length:       0,
+		NextHeader:   IPProtocolIPv6HopByHop,
+		HopLimit:     64,
+		SrcIP:        net.IP{0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01},
+		DstIP: net.IP{0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02},
+	}
+	buf := new(bytes.Buffer)
+	buf.Write([]byte{0x3b, 0x00, 0xC2, 0x04, 0x00, 0x01, 0x00, 0x08})
+	buf.Write(payload)
+	ip6.Payload = buf.Bytes()
+
+	hop = &ip6.hbh
+	hop.ipv6ExtensionBase = ipv6ExtensionBase{
+		BaseLayer: BaseLayer{
+			Contents: []byte{0x3b, 0x00, 0x01, 0x04, 0x00, 0x00, 0x00, 0x00},
+			Payload:  []byte{},
+		},
+		NextHeader:   IPProtocolNoNextHeader,
+		HeaderLength: uint8(0),
+		ActualLength: 8,
+	}
+	hop.Contents = []byte{0x3b, 0x00, 0xC2, 0x04, 0x00, 0x01, 0x00, 0x08}
+	hop.Payload = payload
+	opt := &IPv6HopByHopOption{}
+	opt.OptionType = uint8(0xC2)
+	opt.OptionLength = uint8(0x04)
+	opt.ActualLength = 6
+	opt.OptionData = []byte{0x00, 0x01, 0x00, 0x08}
+	hop.Options = append(hop.Options, opt)
+	ip6.HopByHop = hop
+
+	pkt := new(bytes.Buffer)
+	pkt.Write(testPacketIPv6JumbogramHeader)
+	pkt.Write(payload)
+
+	p := gopacket.NewPacket(pkt.Bytes(), LinkTypeRaw, gopacket.Default)
+	if p.ErrorLayer() != nil {
+		t.Error("Failed to decode packet:", p.ErrorLayer().Error())
+	}
+
+	checkLayers(p, []gopacket.LayerType{LayerTypeIPv6, LayerTypeIPv6HopByHop, gopacket.LayerTypePayload}, t)
+
+	if got, ok := p.Layer(gopacket.LayerTypePayload).(*gopacket.Payload); ok {
+		want := payload
+		got := got.LayerContents()
+		if !bytes.Equal(got, want) {
+			t.Errorf("Jumbo payload mismatch:\nwant: %d bytes\n\ngot: %d bytes\n\nBASH-colorized diff, want->got:\n%v\n\n", len(want), len(got), bytediff.BashOutput.String(bytediff.Diff(want, got)))
+		}
+	} else {
+		t.Error("No Payload layer type found in packet")
+	}
+
+	if got, ok := p.Layer(LayerTypeIPv6HopByHop).(*IPv6HopByHop); ok {
+		want := hop
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("IPv6HopByHop packet processing failed:\ngot  :\n%v\n\nwant :\n%v\n\n", got, want)
+		}
+	} else {
+		t.Error("No IPv6HopByHop layer type found in packet")
+	}
+
+	if got, ok := p.Layer(LayerTypeIPv6).(*IPv6); ok {
+		want := ip6
+		want.HopByHop = got.HopByHop // Hack, avoid comparing pointers
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("IPv6 packet processing failed:\ngot  :\n%v\n\nwant :\n%v\n\n", got, want)
+		}
+	} else {
+		t.Error("No IPv6 layer type found in packet")
 	}
 }

--- a/layers/ip6_test.go
+++ b/layers/ip6_test.go
@@ -107,7 +107,7 @@ func TestPacketIPv6Destination0Decode(t *testing.T) {
 		}
 		want.Options = append(want.Options, opt)
 		if !reflect.DeepEqual(got, want) {
-			t.Errorf("IPV6Destination packet processing failed:\ngot  :\n%#v\n\nwant :\n%#v\n\n", got, want)
+			t.Errorf("IPv6Destination packet processing failed:\ngot  :\n%#v\n\nwant :\n%#v\n\n", got, want)
 		}
 	} else {
 		t.Error("No IPv6Destination layer type found in packet")

--- a/layers/tcpip_test.go
+++ b/layers/tcpip_test.go
@@ -8,13 +8,14 @@ package layers
 
 import (
 	"github.com/google/gopacket"
-	"testing"
 	"net"
+	"testing"
 )
 
 const (
-	ipv4UDPChecksum = uint16(0xbc5f) // Wireshark
+	ipv4UDPChecksum                = uint16(0xbc5f) // Wireshark
 	ipv6UDPChecksumWithIPv6DstOpts = uint16(0x4d21) // Wireshark
+	ipv6UDPChecksumJumbogram       = uint16(0xcda8)
 )
 
 func createIPv4ChecksumTestLayer() (ip4 *IPv4) {
@@ -128,6 +129,56 @@ func TestIPv6UDPChecksumWithIPv6DstOpts(t *testing.T) {
 	}
 	got := u.Checksum
 	want := ipv6UDPChecksumWithIPv6DstOpts
+	if got != want {
+		t.Errorf("Bad checksum:\ngot:\n%#v\n\nwant:\n%#v\n\n", got, want)
+	}
+}
+
+func TestIPv6JumbogramUDPChecksum(t *testing.T) {
+	var serialize []gopacket.SerializableLayer = make([]gopacket.SerializableLayer, 0, 4)
+	var u *UDP
+	var err error
+
+	ip6 := &IPv6{}
+	ip6.Version = 6
+	ip6.NextHeader = IPProtocolUDP
+	ip6.HopLimit = 64
+	ip6.SrcIP = net.ParseIP("2001:db8::1")
+	ip6.DstIP = net.ParseIP("2001:db8::2")
+	serialize = append(serialize, ip6)
+
+	udp := &UDP{}
+	udp.SrcPort = UDPPort(12345)
+	udp.DstPort = UDPPort(9999)
+	udp.SetNetworkLayerForChecksum(ip6)
+	serialize = append(serialize, udp)
+
+	payload := make([]byte, ipv6MaxPayloadLength+1)
+	for i := range payload {
+		payload[i] = 0xfe
+	}
+	serialize = append(serialize, gopacket.Payload(payload))
+
+	buf := gopacket.NewSerializeBuffer()
+	opts := gopacket.SerializeOptions{FixLengths: true, ComputeChecksums: true}
+	err = gopacket.SerializeLayers(buf, opts, serialize...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := gopacket.NewPacket(buf.Bytes(), LinkTypeRaw, gopacket.Default)
+	if p.ErrorLayer() != nil {
+		t.Fatal("Failed to decode packet:", p.ErrorLayer().Error())
+	}
+	checkLayers(p, []gopacket.LayerType{LayerTypeIPv6, LayerTypeIPv6HopByHop, LayerTypeUDP, gopacket.LayerTypePayload}, t)
+
+	if l, ok := p.Layer(LayerTypeUDP).(*UDP); !ok {
+		t.Fatal("No UDP layer type found in packet")
+	} else {
+		u = l
+	}
+	got := u.Checksum
+	want := ipv6UDPChecksumJumbogram
 	if got != want {
 		t.Errorf("Bad checksum:\ngot:\n%#v\n\nwant:\n%#v\n\n", got, want)
 	}

--- a/layers/tcpip_test.go
+++ b/layers/tcpip_test.go
@@ -77,12 +77,13 @@ func TestIPv4UDPChecksum(t *testing.T) {
 	if p.ErrorLayer() != nil {
 		t.Fatal("Failed to decode packet:", p.ErrorLayer().Error())
 	}
+	checkLayers(p, []gopacket.LayerType{LayerTypeIPv4, LayerTypeUDP}, t)
+
 	if l, ok := p.Layer(LayerTypeUDP).(*UDP); !ok {
 		t.Fatal("No UDP layer type found in packet")
 	} else {
 		u = l
 	}
-
 	got := u.Checksum
 	want := ipv4UDPChecksum
 	if got != want {
@@ -118,12 +119,13 @@ func TestIPv6UDPChecksumWithIPv6DstOpts(t *testing.T) {
 	if p.ErrorLayer() != nil {
 		t.Fatal("Failed to decode packet:", p.ErrorLayer().Error())
 	}
+	checkLayers(p, []gopacket.LayerType{LayerTypeIPv6, LayerTypeIPv6Destination, LayerTypeUDP}, t)
+
 	if l, ok := p.Layer(LayerTypeUDP).(*UDP); !ok {
 		t.Fatal("No UDP layer type found in packet")
 	} else {
 		u = l
 	}
-
 	got := u.Checksum
 	want := ipv6UDPChecksumWithIPv6DstOpts
 	if got != want {

--- a/layers/tcpip_test.go
+++ b/layers/tcpip_test.go
@@ -41,7 +41,7 @@ func createIPv6DestinationChecksumTestLayer() (dst *IPv6Destination) {
 	tlv.OptionType = 0x01 //PadN
 	tlv.OptionData = []byte{0x00, 0x00, 0x00, 0x00}
 	dst = &IPv6Destination{}
-	dst.Options = append(dst.Options, *tlv)
+	dst.Options = append(dst.Options, tlv)
 	dst.NextHeader = IPProtocolNoNextHeader
 	return
 }


### PR DESCRIPTION
This patch is a feature improvement for IPv6 adding IPv6 hop-by-hop header serialization with TLV padding, extensive jumbogram support and some other minor improvements/fixes.

Please review.