### PR TITLE
Skip read() with EOF, and add BPF read filter methods

### DIFF
--- a/bsdbpf/bsd_bpf_sniffer.go
+++ b/bsdbpf/bsd_bpf_sniffer.go
@@ -200,3 +200,10 @@ func (b *BPFSniffer) ReadPacketData() ([]byte, gopacket.CaptureInfo, error) {
 func (b *BPFSniffer) GetReadBufLen() int {
 	return b.options.ReadBufLen
 }
+
+// Fd returns the BPF file descriptor, as required by SetBPF() to set filter program, etc.
+// from golang/go/src/syscall/bpf_bsd.go )
+func (b *BPFSniffer) Fd() int {
+        return b.fd
+}
+


### PR DESCRIPTION
How to proceed with the new functions at the bottom of the pull request, e.g. append them here, or try to get them pulled into src/syscall/bpf_bsd.go (where they probably belong)?
