### PR TITLE
refactoring - use ICMPv6 type constants

### DIFF
--- a/layers/icmp6.go
+++ b/layers/icmp6.go
@@ -37,7 +37,7 @@ type icmpv6TypeCodeInfoStruct struct {
 
 var (
 	icmpv6TypeCodeInfo = map[uint8]icmpv6TypeCodeInfoStruct{
-		1: icmpv6TypeCodeInfoStruct{
+		ICMPv6TypeDestinationUnreachable: icmpv6TypeCodeInfoStruct{
 			"DestinationUnreachable", &map[uint8]string{
 				0: "NoRouteToDst",
 				1: "AdminProhibited",
@@ -48,41 +48,41 @@ var (
 				6: "RejectRouteToDst",
 			},
 		},
-		2: icmpv6TypeCodeInfoStruct{
+		ICMPv6TypePacketTooBig: icmpv6TypeCodeInfoStruct{
 			"PacketTooBig", nil,
 		},
-		3: icmpv6TypeCodeInfoStruct{
+		ICMPv6TypeTimeExceeded: icmpv6TypeCodeInfoStruct{
 			"TimeExceeded", &map[uint8]string{
 				0: "HopLimitExceeded",
 				1: "FragmentReassemblyTimeExceeded",
 			},
 		},
-		4: icmpv6TypeCodeInfoStruct{
+		ICMPv6TypeParameterProblem: icmpv6TypeCodeInfoStruct{
 			"ParameterProblem", &map[uint8]string{
 				0: "ErroneousHeaderField",
 				1: "UnrecognizedNextHeader",
 				2: "UnrecognizedNextHeader",
 			},
 		},
-		128: icmpv6TypeCodeInfoStruct{
+		ICMPv6TypeEchoRequest: icmpv6TypeCodeInfoStruct{
 			"EchoRequest", nil,
 		},
-		129: icmpv6TypeCodeInfoStruct{
+		ICMPv6TypeEchoReply: icmpv6TypeCodeInfoStruct{
 			"EchoReply", nil,
 		},
-		133: icmpv6TypeCodeInfoStruct{
+		ICMPv6TypeRouterSolicitation: icmpv6TypeCodeInfoStruct{
 			"RouterSolicitation", nil,
 		},
-		134: icmpv6TypeCodeInfoStruct{
+		ICMPv6TypeRouterAdvertisement: icmpv6TypeCodeInfoStruct{
 			"RouterAdvertisement", nil,
 		},
-		135: icmpv6TypeCodeInfoStruct{
+		ICMPv6TypeNeighborSolicitation: icmpv6TypeCodeInfoStruct{
 			"NeighborSolicitation", nil,
 		},
-		136: icmpv6TypeCodeInfoStruct{
+		ICMPv6TypeNeighborAdvertisement: icmpv6TypeCodeInfoStruct{
 			"NeighborAdvertisement", nil,
 		},
-		137: icmpv6TypeCodeInfoStruct{
+		ICMPv6TypeRedirect: icmpv6TypeCodeInfoStruct{
 			"Redirect", nil,
 		},
 	}

--- a/layers/icmp6.go
+++ b/layers/icmp6.go
@@ -30,6 +30,26 @@ const (
 	ICMPv6TypeRedirect              = 137
 )
 
+const (
+	// DestinationUnreachable
+	ICMPv6CodeNoRouteToDst           = 0
+	ICMPv6CodeAdminProhibited        = 1
+	ICMPv6CodeBeyondScopeOfSrc       = 2
+	ICMPv6CodeAddressUnreachable     = 3
+	ICMPv6CodePortUnreachable        = 4
+	ICMPv6CodeSrcAddressFailedPolicy = 5
+	ICMPv6CodeRejectRouteToDst       = 6
+
+	// TimeExceeded
+	ICMPv6CodeHopLimitExceeded               = 0
+	ICMPv6CodeFragmentReassemblyTimeExceeded = 1
+
+	// ParameterProblem
+	ICMPv6CodeErroneousHeaderField   = 0
+	ICMPv6CodeUnrecognizedNextHeader = 1
+	ICMPv6CodeUnrecognizedIPv6Option = 2
+)
+
 type icmpv6TypeCodeInfoStruct struct {
 	typeStr string
 	codeStr *map[uint8]string
@@ -39,13 +59,13 @@ var (
 	icmpv6TypeCodeInfo = map[uint8]icmpv6TypeCodeInfoStruct{
 		ICMPv6TypeDestinationUnreachable: icmpv6TypeCodeInfoStruct{
 			"DestinationUnreachable", &map[uint8]string{
-				0: "NoRouteToDst",
-				1: "AdminProhibited",
-				2: "BeyondScopeOfSrc",
-				3: "AddressUnreachable",
-				4: "PortUnreachable",
-				5: "SrcAddressFailedPolicy",
-				6: "RejectRouteToDst",
+				ICMPv6CodeNoRouteToDst:           "NoRouteToDst",
+				ICMPv6CodeAdminProhibited:        "AdminProhibited",
+				ICMPv6CodeBeyondScopeOfSrc:       "BeyondScopeOfSrc",
+				ICMPv6CodeAddressUnreachable:     "AddressUnreachable",
+				ICMPv6CodePortUnreachable:        "PortUnreachable",
+				ICMPv6CodeSrcAddressFailedPolicy: "SrcAddressFailedPolicy",
+				ICMPv6CodeRejectRouteToDst:       "RejectRouteToDst",
 			},
 		},
 		ICMPv6TypePacketTooBig: icmpv6TypeCodeInfoStruct{
@@ -53,15 +73,15 @@ var (
 		},
 		ICMPv6TypeTimeExceeded: icmpv6TypeCodeInfoStruct{
 			"TimeExceeded", &map[uint8]string{
-				0: "HopLimitExceeded",
-				1: "FragmentReassemblyTimeExceeded",
+				ICMPv6CodeHopLimitExceeded:               "HopLimitExceeded",
+				ICMPv6CodeFragmentReassemblyTimeExceeded: "FragmentReassemblyTimeExceeded",
 			},
 		},
 		ICMPv6TypeParameterProblem: icmpv6TypeCodeInfoStruct{
 			"ParameterProblem", &map[uint8]string{
-				0: "ErroneousHeaderField",
-				1: "UnrecognizedNextHeader",
-				2: "UnrecognizedIPv6Option",
+				ICMPv6CodeErroneousHeaderField:   "ErroneousHeaderField",
+				ICMPv6CodeUnrecognizedNextHeader: "UnrecognizedNextHeader",
+				ICMPv6CodeUnrecognizedIPv6Option: "UnrecognizedIPv6Option",
 			},
 		},
 		ICMPv6TypeEchoRequest: icmpv6TypeCodeInfoStruct{

--- a/layers/icmp6.go
+++ b/layers/icmp6.go
@@ -61,7 +61,7 @@ var (
 			"ParameterProblem", &map[uint8]string{
 				0: "ErroneousHeaderField",
 				1: "UnrecognizedNextHeader",
-				2: "UnrecognizedNextHeader",
+				2: "UnrecognizedIPv6Option",
 			},
 		},
 		ICMPv6TypeEchoRequest: icmpv6TypeCodeInfoStruct{


### PR DESCRIPTION
This reduces duplicate code by using the constants defined for ICMPv6 types & codes.