### PR TITLE
[dot11] fix sequence number

### DIFF
--- a/layers/dot11.go
+++ b/layers/dot11.go
@@ -370,8 +370,8 @@ func (m *Dot11) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 		m.Address3 = net.HardwareAddr(data[offset : offset+6])
 		offset += 6
 
-		m.SequenceNumber = (binary.LittleEndian.Uint16(data[offset:offset+2]) & 0xFFC0) >> 6
-		m.FragmentNumber = (binary.LittleEndian.Uint16(data[offset:offset+2]) & 0x003F)
+		m.SequenceNumber = (binary.LittleEndian.Uint16(data[offset:offset+2]) & 0xFFF0) >> 4
+		m.FragmentNumber = (binary.LittleEndian.Uint16(data[offset:offset+2]) & 0x000F)
 		offset += 2
 	}
 

--- a/layers/dot11_test.go
+++ b/layers/dot11_test.go
@@ -147,6 +147,12 @@ func TestPacketDot11MgmtBeacon(t *testing.T) {
 	}
 	checkLayers(p, expectedLayers, t)
 
+	if p.Layer(LayerTypeDot11).(*Dot11).SequenceNumber != 2431 {
+		t.Error("dot11 invalid sequence number")
+	}
+	if p.Layer(LayerTypeDot11).(*Dot11).FragmentNumber != 0 {
+		t.Error("dot11 invalid fragment number")
+	}
 	if _, ok := p.Layer(LayerTypeDot11MgmtBeacon).(*Dot11MgmtBeacon); !ok {
 		t.Errorf("dot11 management beacon frame was expected")
 	}

--- a/layers/prism_test.go
+++ b/layers/prism_test.go
@@ -102,8 +102,8 @@ func TestPacketPrism(t *testing.T) {
 			Address2:       net.HardwareAddr{0xcc, 0xfa, 0x0, 0xad, 0x79, 0xe8},
 			Address3:       net.HardwareAddr{0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
 			Address4:       net.HardwareAddr(nil),
-			SequenceNumber: 0x106,
-			FragmentNumber: 0x20,
+			SequenceNumber: 0x041a,
+			FragmentNumber: 0x0,
 			Checksum:       0x0,
 		}
 


### PR DESCRIPTION
Sequence control field (16bits) has:
 Fragment number(b0-b3)
 Sequence number (b4-b15)

Signed-off-by: Hiroaki KAWAI <hiroaki.kawai@gmail.com>