### PR TITLE
Fix 802.11 management probe request/response

### DIFF
--- a/layers/dot11.go
+++ b/layers/dot11.go
@@ -1070,6 +1070,10 @@ func (m *Dot11MgmtProbeReq) CanDecode() gopacket.LayerClass { return LayerTypeDo
 func (m *Dot11MgmtProbeReq) NextLayerType() gopacket.LayerType {
 	return LayerTypeDot11InformationElement
 }
+func (m *Dot11MgmtProbeReq) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
+	m.Payload = data
+	return nil
+}
 
 type Dot11MgmtProbeResp struct {
 	Dot11Mgmt
@@ -1084,6 +1088,10 @@ func (m *Dot11MgmtProbeResp) LayerType() gopacket.LayerType  { return LayerTypeD
 func (m *Dot11MgmtProbeResp) CanDecode() gopacket.LayerClass { return LayerTypeDot11MgmtProbeResp }
 func (m *Dot11MgmtProbeResp) NextLayerType() gopacket.LayerType {
 	return LayerTypeDot11InformationElement
+}
+func (m *Dot11MgmtProbeResp) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
+	m.Payload = data
+	return nil
 }
 
 type Dot11MgmtMeasurementPilot struct {

--- a/layers/dot11.go
+++ b/layers/dot11.go
@@ -13,9 +13,10 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"github.com/google/gopacket"
 	"hash/crc32"
 	"net"
+
+	"github.com/google/gopacket"
 )
 
 // Dot11Flags contains the set of 8 flags in the IEEE 802.11 frame control
@@ -796,6 +797,41 @@ func decodeDot11InformationElement(data []byte, p gopacket.PacketBuilder) error 
 	return decodingLayerDecoder(d, data, p)
 }
 
+type Dot11FixedElement struct {
+	BaseLayer
+	Timestamp      uint64
+	BeaconInterval uint16
+	Capabilities   uint16
+}
+
+func (m *Dot11FixedElement) LayerType() gopacket.LayerType {
+	return LayerTypeDot11InformationElement
+}
+func (m *Dot11FixedElement) CanDecode() gopacket.LayerClass {
+	return LayerTypeDot11InformationElement
+}
+
+func (m *Dot11FixedElement) NextLayerType() gopacket.LayerType {
+	return LayerTypeDot11InformationElement
+}
+
+func (m *Dot11FixedElement) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
+	const length = 12
+	if len(data) < length {
+		return fmt.Errorf("Dot11FixedElement length %v too short, %v required", len(data), length)
+	}
+	m.Timestamp = binary.LittleEndian.Uint64(data[0:8])
+	m.BeaconInterval = binary.LittleEndian.Uint16(data[8:10])
+	m.Capabilities = binary.LittleEndian.Uint16(data[10:12])
+	m.BaseLayer = BaseLayer{Contents: data[:length], Payload: data[length:]}
+	return nil
+}
+
+func decodeDot11FixedElement(data []byte, p gopacket.PacketBuilder) error {
+	d := &Dot11FixedElement{}
+	return decodingLayerDecoder(d, data, p)
+}
+
 type Dot11CtrlCTS struct {
 	Dot11Ctrl
 }
@@ -1087,7 +1123,7 @@ func decodeDot11MgmtProbeResp(data []byte, p gopacket.PacketBuilder) error {
 func (m *Dot11MgmtProbeResp) LayerType() gopacket.LayerType  { return LayerTypeDot11MgmtProbeResp }
 func (m *Dot11MgmtProbeResp) CanDecode() gopacket.LayerClass { return LayerTypeDot11MgmtProbeResp }
 func (m *Dot11MgmtProbeResp) NextLayerType() gopacket.LayerType {
-	return LayerTypeDot11InformationElement
+	return LayerTypeDot11FixedElement
 }
 func (m *Dot11MgmtProbeResp) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 	m.Payload = data

--- a/layers/layertypes.go
+++ b/layers/layertypes.go
@@ -117,6 +117,7 @@ var (
 	LayerTypeLinuxSLL                    = gopacket.RegisterLayerType(113, gopacket.LayerTypeMetadata{"Linux SLL", gopacket.DecodeFunc(decodeLinuxSLL)})
 	LayerTypeSFlow                       = gopacket.RegisterLayerType(114, gopacket.LayerTypeMetadata{"SFlow", gopacket.DecodeFunc(decodeSFlow)})
 	LayerTypePrismHeader                 = gopacket.RegisterLayerType(115, gopacket.LayerTypeMetadata{"Prism monitor mode header", gopacket.DecodeFunc(decodePrismHeader)})
+	LayerTypeDot11FixedElement           = gopacket.RegisterLayerType(116, gopacket.LayerTypeMetadata{"Dot11FixedElement", gopacket.DecodeFunc(decodeDot11FixedElement)})
 )
 
 var (


### PR DESCRIPTION
The next protocol `LayerTypeDot11InformationElement` is never decoded because bytes placed in contents instead of payload