### PR TITLE
Added raw IPv4 and IPv6 packet wrapping linktype

### DIFF
--- a/layers/enums.go
+++ b/layers/enums.go
@@ -92,7 +92,7 @@ const (
 type LinkType uint8
 
 const (
-	// According to pcap-linktype(7).
+	// According to pcap-linktype(7) and http://www.tcpdump.org/linktypes.html
 	LinkTypeNull           LinkType = 0
 	LinkTypeEthernet       LinkType = 1
 	LinkTypeTokenRing      LinkType = 6
@@ -119,6 +119,8 @@ const (
 	LinkTypeLinuxIRDA      LinkType = 144
 	LinkTypeLinuxLAPD      LinkType = 177
 	LinkTypeLinuxUSB       LinkType = 220
+	LinkTypeIPv4           LinkType = 228
+	LinkTypeIPv6           LinkType = 229
 )
 
 // PPPoECode is the PPPoE code enum, taken from http://tools.ietf.org/html/rfc2516


### PR DESCRIPTION
These link types are perfectly supported by tcpdump & wireshark. Instead of specifying a LinkTypeEthernet and wrapping ethernet frames, you can specify a LinkTypeIPv4 and wrap IPv4 frames (skipping the ethernet wrapping).