### PR TITLE
Add linking flags for DragonFly BSD libpcap

### DIFF
--- a/pcap/pcap.go
+++ b/pcap/pcap.go
@@ -9,6 +9,7 @@ package pcap
 
 /*
 #cgo linux LDFLAGS: -lpcap
+#cgo dragonfly LDFLAGS: -lpcap
 #cgo freebsd LDFLAGS: -lpcap
 #cgo openbsd LDFLAGS: -lpcap
 #cgo darwin LDFLAGS: -lpcap


### PR DESCRIPTION
This fixes build issue on DragonFly BSD.