### PR TITLE
Adding additional parsing capabilities to layers/igmp.go

### DIFF
--- a/layers/igmp.go
+++ b/layers/igmp.go
@@ -16,18 +16,210 @@ import (
 
 type IGMPType uint8
 
+const (
+	MembershipQuery    IGMPType = 0x11 // General or group specific query
+	MembershipReportV1 IGMPType = 0x12 // Version 1 Membership Report
+	MembershipReportV2 IGMPType = 0x16 // Version 2 Membership Report
+	LeaveGroup         IGMPType = 0x17 // Leave Group
+	MembershipReportV3 IGMPType = 0x22 // Version 3 Membership Report
+)
+
+// String conversions for IGMP message types
+func (i IGMPType) String() string {
+	switch i {
+	case MembershipQuery:
+		return "IGMP Membership Query"
+	case MembershipReportV1:
+		return "IGMPv1 Membership Report"
+	case MembershipReportV2:
+		return "IGMPv2 Membership Report"
+	case MembershipReportV3:
+		return "IGMPv3 Membership Report"
+	case LeaveGroup:
+		return "Leave Group"
+	default:
+		return ""
+	}
+}
+
+type IGMPQuery interface {
+	decodeResponse(data []byte) error
+}
+
 // IGMP is the packet structure for IGMP messages.
 type IGMP struct {
 	BaseLayer
-	Type            IGMPType
-	MaxResponseTime time.Duration
-	Checksum        uint16
-	GroupAddress    net.IP
-	// The following are used only by IGMPv3
-	SupressRouterProcessing bool
-	RobustnessValue         uint8
-	IntervalTime            time.Duration
-	SourceAddresses         []net.IP
+	Type    IGMPType  // IGMP message type
+	Message IGMPQuery // Container for message payload
+	Version uint8     // IGMP protocol version
+}
+
+type GroupRecordType uint8
+
+const (
+	IsIn  GroupRecordType = 0x01 // Type MODE_IS_INCLUDE, source addresses x
+	IsEx  GroupRecordType = 0x02 // Type MODE_IS_EXCLUDE, source addresses x
+	ToIn  GroupRecordType = 0x03 // Type CHANGE_TO_INCLUDE_MODE, source addresses x
+	ToEx  GroupRecordType = 0x04 // Type CHANGE_TO_EXCLUDE_MODE, source addresses x
+	Allow GroupRecordType = 0x05 // Type ALLOW_NEW_SOURCES, source addresses x
+	Block GroupRecordType = 0x06 // Type BLOCK_OLD_SOURCES, source addresses x
+)
+
+func (i GroupRecordType) String() string {
+	switch i {
+	case IsIn:
+		return "MODE_IS_INCLUDE"
+	case IsEx:
+		return "MODE_IS_EXCLUDE"
+	case ToIn:
+		return "CHANGE_TO_INCLUDE_MODE"
+	case ToEx:
+		return "CHANGE_TO_EXCLUDE_MODE"
+	case Allow:
+		return "ALLOW_NEW_SOURCES"
+	case Block:
+		return "BLOCK_OLD_SOURCES"
+	default:
+		return ""
+	}
+}
+
+//  0                   1                   2                   3
+//  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |      Type     | Max Resp Time |           Checksum            |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |                         Group Address                         |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// IGMPv1or2 stores header details for an IGMPv1 or IGMPv2 packet.
+type IGMPv1or2 struct {
+	MaxRespTime  time.Duration // meaningful only in Membership Query messages
+	Checksum     uint16        // 16-bit checksum of entire ip payload
+	GroupAddress net.IP        // either 0 or an IP multicast address
+}
+
+// decodeResponse dissects IGMPv1 or IGMPv2 packet.
+func (i *IGMPv1or2) decodeResponse(data []byte) error {
+	i.MaxRespTime = igmpTimeDecode(data[1])
+	i.Checksum = binary.BigEndian.Uint16(data[2:4])
+	i.GroupAddress = net.IP(data[4:8])
+
+	return nil
+}
+
+//  0                   1                   2                   3
+//  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |  Type = 0x22  |    Reserved   |           Checksum            |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |           Reserved            |  Number of Group Records (M)  |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |                                                               |
+// .                        Group Record [1]                       .
+// |                                                               |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |                                                               |
+// .                        Group Record [2]                       .
+// |                                                               |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |                                                               |
+// .                        Group Record [M]                       .
+// |                                                               |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// IGMPv3MembershipReport stores bytes 2: of the V3 Membership Report packet
+type IGMPv3MembershipReport struct {
+	Checksum             uint16 // 16-bit checksum of entire ip payload
+	NumberofGroupRecords uint16
+	GroupRecords         []GroupRecord
+}
+
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |  Record Type  |  Aux Data Len |     Number of Sources (N)     |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |                       Multicast Address                       |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |                       Source Address [1]                      |
+// +-                                                             -+
+// |                       Source Address [2]                      |
+// +-                                                             -+
+// |                       Source Address [N]                      |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |                                                               |
+// .                         Auxiliary Data                        .
+// |                                                               |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// GroupRecord stores individual group records for a V3 Membership Report message.
+type GroupRecord struct {
+	Type             GroupRecordType
+	AuxDataLen       uint8 // this should always be 0 as per IGMPv3 spec.
+	NumberOfSources  uint16
+	MulticastAddress net.IP
+	SourceAddresses  []net.IP
+	AuxData          uint32 // NOT USED
+}
+
+// decodeResponse decodes an IGMPv3MembershipReport message.
+func (i *IGMPv3MembershipReport) decodeResponse(data []byte) error {
+	i.Checksum = binary.BigEndian.Uint16(data[2:4])
+	i.NumberofGroupRecords = binary.BigEndian.Uint16(data[6:8])
+
+	for j := 0; j < int(i.NumberofGroupRecords); j++ {
+		var gr GroupRecord
+		gr.Type = GroupRecordType(data[8])
+		gr.AuxDataLen = data[9]
+		gr.NumberOfSources = binary.BigEndian.Uint16(data[10:12])
+		gr.MulticastAddress = net.IP(data[12:16])
+
+		// append source address records.
+		for i := 0; i < int(gr.NumberOfSources); i++ {
+			gr.SourceAddresses = append(gr.SourceAddresses, net.IP(data[16+i*4:20+i*4]))
+		}
+
+		i.GroupRecords = append(i.GroupRecords, gr)
+	}
+	return nil
+}
+
+//  0                   1                   2                   3
+//  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |  Type = 0x11  | Max Resp Code |           Checksum            |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |                         Group Address                         |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// | Resv  |S| QRV |     QQIC      |     Number of Sources (N)     |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |                       Source Address [1]                      |
+// +-                                                             -+
+// |                       Source Address [2]                      |
+// +-                              .                              -+
+// |                       Source Address [N]                      |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+type IGMPv3MembershipQuery struct {
+	MaxResponseTime time.Duration // IGMP Max response code/time
+	Checksum        uint16        // 16-bit checksum of entire ip payload
+	GroupAddress    net.IP        // IP multicast address.
+	SFlag           bool          // Suppress Router-Side Processing
+	QRV             uint8         // Querier's Robustness Variable
+	QQIC            time.Duration // Querier's Query Interval Code
+	NumberofSources uint16
+	SourceAddresses []net.IP
+}
+
+func (i *IGMPv3MembershipQuery) decodeResponse(data []byte) error {
+
+	i.Checksum = binary.BigEndian.Uint16(data[2:4])
+	i.SFlag = data[8]&0x8 != 0
+	i.GroupAddress = net.IP(data[4:8])
+	i.QRV = data[8] & 0x7
+	i.QQIC = igmpTimeDecode(data[9])
+	i.NumberofSources = binary.BigEndian.Uint16(data[10:12])
+
+	for j := 0; j < int(i.NumberofSources); j++ {
+		i.SourceAddresses = append(i.SourceAddresses, net.IP(data[12+j*4:16+j*4]))
+	}
+
+	return nil
 }
 
 // LayerType returns LayerTypeIGMP
@@ -46,24 +238,49 @@ func igmpTimeDecode(t uint8) time.Duration {
 
 // DecodeFromBytes decodes the given bytes into this layer.
 func (i *IGMP) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
+
+	// common IGMP header values between versions 1..3 of IGMP specification..
 	i.Type = IGMPType(data[0])
-	i.MaxResponseTime = igmpTimeDecode(data[1])
-	i.Checksum = binary.BigEndian.Uint16(data[2:4])
-	i.GroupAddress = net.IP(data[4:8])
-	if i.Type == 0x11 && len(data) > 8 {
-		i.SupressRouterProcessing = data[8]&0x8 != 0
-		i.RobustnessValue = data[8] & 0x7
-		i.IntervalTime = igmpTimeDecode(data[9])
-		numSources := int(binary.BigEndian.Uint16(data[10:12]))
-		for j := 0; j < numSources; j++ {
-			i.SourceAddresses = append(i.SourceAddresses, net.IP(data[12+j*4:16+j*4]))
+
+	switch i.Type {
+
+	case MembershipQuery:
+
+		// IGMPv3 Membership Query payload is >= 12
+		if len(data) >= 12 {
+			i.Version = 3
+			i.Message = new(IGMPv3MembershipQuery)
+			i.Message.decodeResponse(data)
+
+		} else if len(data) == 8 {
+
+			if data[1] == 0x00 {
+				i.Version = 1 // IGMPv1 has a query length of 8 and MaxResp = 0
+			} else {
+				i.Version = 2 // IGMPv2 has a query length of 8 and MaxResp != 0
+			}
+
+			i.Message = new(IGMPv1or2)
+			i.Message.decodeResponse(data)
 		}
-	} else {
-		i.SupressRouterProcessing = false
-		i.RobustnessValue = 0
-		i.IntervalTime = 0
-		i.SourceAddresses = nil
+
+	case MembershipReportV3:
+		i.Version = 3
+		i.Message = new(IGMPv3MembershipReport)
+		i.Message.decodeResponse(data)
+
+	case MembershipReportV1:
+		i.Version = 1
+		i.Message = new(IGMPv1or2)
+		i.Message.decodeResponse(data)
+
+	case LeaveGroup, MembershipReportV2:
+		// leave group and Query Report v2 used in IGMPv2 only.
+		i.Version = 2
+		i.Message = new(IGMPv1or2)
+		i.Message.decodeResponse(data)
 	}
+
 	return nil
 }
 

--- a/layers/igmp_test.go
+++ b/layers/igmp_test.go
@@ -1,0 +1,144 @@
+// Copyright 2016, Google, Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file in the root of the source
+// tree.
+
+package layers
+
+import (
+	"github.com/google/gopacket"
+	"testing"
+)
+
+// igmpv1MembershipReportPacket is the packet:
+//   02:45:36.033916 IP 10.60.0.132 > 224.0.1.60: igmp v1 report 224.0.1.60
+//   	0x0000:  0100 5e00 013c 0030 c1bf 5755 0800 4500  ..^..<.0..WU..E.
+//   	0x0010:  001c 6a7f 0000 0102 6365 0a3c 0084 e000  ..j.....ce.<....
+//   	0x0020:  013c 1200 0cc3 e000 013c 0000 0000 0000  .<.......<......
+//   	0x0030:  ffff ffff ffff 0452 0000 0000            .......R....
+var igmpv1MembershipReportPacket = []byte{
+	0x01, 0x00, 0x5e, 0x00, 0x01, 0x3c, 0x00, 0x30, 0xc1, 0xbf, 0x57, 0x55, 0x08, 0x00, 0x45, 0x00,
+	0x00, 0x1c, 0x6a, 0x7f, 0x00, 0x00, 0x01, 0x02, 0x63, 0x65, 0x0a, 0x3c, 0x00, 0x84, 0xe0, 0x00,
+	0x01, 0x3c, 0x12, 0x00, 0x0c, 0xc3, 0xe0, 0x00, 0x01, 0x3c, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x04, 0x52, 0x00, 0x00, 0x00, 0x00,
+}
+
+func TestIGMPv1MembershipReportPacket(t *testing.T) {
+	p := gopacket.NewPacket(igmpv1MembershipReportPacket, LinkTypeEthernet, gopacket.Default)
+	if p.ErrorLayer() != nil {
+		t.Error("Failed to decode packet:", p.ErrorLayer().Error())
+	}
+	checkLayers(p, []gopacket.LayerType{LayerTypeEthernet, LayerTypeIPv4, LayerTypeIGMP}, t)
+}
+
+func BenchmarkDecodeigmpv1MembershipReportPacket(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		gopacket.NewPacket(igmpv1MembershipReportPacket, LinkTypeEthernet, gopacket.NoCopy)
+	}
+}
+
+// igmpv2MembershipQueryPacket is the packet:
+//   02:45:28.071636 IP 10.60.0.189 > 224.0.0.1: igmp query v2
+//   	0x0000:  0100 5e00 0001 0001 636f c800 0800 45c0  ..^.....co....E.
+//   	0x0010:  001c 0153 0000 0102 ccd3 0a3c 00bd e000  ...S.......<....
+//   	0x0020:  0001 1164 ee9b 0000 0000 0000 0000 0000  ...d............
+//   	0x0030:  0000 0000 0000 0000 0000 0000            ............
+var igmpv2MembershipQueryPacket = []byte{
+	0x01, 0x00, 0x5e, 0x00, 0x00, 0x01, 0x00, 0x01, 0x63, 0x6f, 0xc8, 0x00, 0x08, 0x00, 0x45, 0xc0,
+	0x00, 0x1c, 0x01, 0x53, 0x00, 0x00, 0x01, 0x02, 0xcc, 0xd3, 0x0a, 0x3c, 0x00, 0xbd, 0xe0, 0x00,
+	0x00, 0x01, 0x11, 0x64, 0xee, 0x9b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+}
+
+func TestIGMPv2MembershipQuery(t *testing.T) {
+	p := gopacket.NewPacket(igmpv2MembershipQueryPacket, LinkTypeEthernet, gopacket.Default)
+	if p.ErrorLayer() != nil {
+		t.Error("Failed to decode packet:", p.ErrorLayer().Error())
+	}
+	checkLayers(p, []gopacket.LayerType{LayerTypeEthernet, LayerTypeIPv4, LayerTypeIGMP}, t)
+}
+func BenchmarkDecodeigmpv2MembershipQueryPacket(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		gopacket.NewPacket(igmpv2MembershipQueryPacket, LinkTypeEthernet, gopacket.NoCopy)
+	}
+}
+
+// igmpv2MembershipReportPacket is the packet:
+//   02:47:32.417288 IP 10.60.5.103 > 239.255.255.253: igmp v2 report 239.255.255.253
+//   	0x0000:  0100 5e7f fffd 0015 58dc d9f6 0800 4600  ..^.....X.....F.
+//   	0x0010:  0020 79f0 0000 0102 ab47 0a3c 0567 efff  ..y......G.<.g..
+//   	0x0020:  fffd 9404 0000 1600 fa01 efff fffd 0000  ................
+//   	0x0030:  0000 0000 0000 0000 0000 0000            ............
+var igmpv2MembershipReportPacket = []byte{
+	0x01, 0x00, 0x5e, 0x7f, 0xff, 0xfd, 0x00, 0x15, 0x58, 0xdc, 0xd9, 0xf6, 0x08, 0x00, 0x46, 0x00,
+	0x00, 0x20, 0x79, 0xf0, 0x00, 0x00, 0x01, 0x02, 0xab, 0x47, 0x0a, 0x3c, 0x05, 0x67, 0xef, 0xff,
+	0xff, 0xfd, 0x94, 0x04, 0x00, 0x00, 0x16, 0x00, 0xfa, 0x01, 0xef, 0xff, 0xff, 0xfd, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+}
+
+func TestIGMPv2MembershipReport(t *testing.T) {
+	p := gopacket.NewPacket(igmpv2MembershipReportPacket, LinkTypeEthernet, gopacket.Default)
+	if p.ErrorLayer() != nil {
+		t.Error("Failed to decode packet:", p.ErrorLayer().Error())
+	}
+	checkLayers(p, []gopacket.LayerType{LayerTypeEthernet, LayerTypeIPv4, LayerTypeIGMP}, t)
+}
+func BenchmarkDecodeigmpv2MembershipReportPacket(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		gopacket.NewPacket(igmpv2MembershipReportPacket, LinkTypeEthernet, gopacket.NoCopy)
+	}
+}
+
+// igmp3v3MembershipQueryPacket is the packet:
+//   10:07:30.488511 IP 192.168.1.254 > 224.0.0.1: igmp query v3 [max resp time 2.4s]
+//      0x0000:  0100 5e00 0001 0026 446c 1eda 0800 46c0  ..^....&Dl....F.
+//      0x0010:  0024 17f1 4000 0102 297b c0a8 01fe e000  .$..@...){......
+//      0x0020:  0001 9404 0000 1118 ecd3 0000 0000 0214  ................
+//      0x0030:  0000 0000 0000 0000 0000 0000            ............
+var igmp3v3MembershipQueryPacket = []byte{
+	0x01, 0x00, 0x5e, 0x00, 0x00, 0x01, 0x00, 0x26, 0x44, 0x6c, 0x1e, 0xda, 0x08, 0x00, 0x46, 0xc0,
+	0x00, 0x24, 0x17, 0xf1, 0x40, 0x00, 0x01, 0x02, 0x29, 0x7b, 0xc0, 0xa8, 0x01, 0xfe, 0xe0, 0x00,
+	0x00, 0x01, 0x94, 0x04, 0x00, 0x00, 0x11, 0x18, 0xec, 0xd3, 0x00, 0x00, 0x00, 0x00, 0x02, 0x14,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+}
+
+func TestIGMPv3MembershipQuery(t *testing.T) {
+	p := gopacket.NewPacket(igmp3v3MembershipQueryPacket, LinkTypeEthernet, gopacket.Default)
+	if p.ErrorLayer() != nil {
+		t.Error("Failed to decode packet:", p.ErrorLayer().Error())
+	}
+	checkLayers(p, []gopacket.LayerType{LayerTypeEthernet, LayerTypeIPv4, LayerTypeIGMP}, t)
+}
+
+func BenchmarkDecodeigmp3v3MembershipQueryPacket(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		gopacket.NewPacket(igmp3v3MembershipQueryPacket, LinkTypeEthernet, gopacket.NoCopy)
+	}
+}
+
+// igmpv3MembershipReport2Records is the packet:
+//   10:07:29.756202 IP 192.168.1.66 > 224.0.0.22: igmp v3 report, 2 group record(s)
+//      0x0000:  0100 5e00 0016 0025 2e51 c381 0800 4658  ..^....%.Q....FX
+//      0x0010:  0030 013c 0000 0102 8133 c0a8 0142 e000  .0.<.....3...B..
+//      0x0020:  0016 9404 0000 2200 f33c 0000 0002 0200  ......"..<......
+//      0x0030:  0000 efc3 0702 0200 0000 efff fffa       ..............
+var igmpv3MembershipReport2Records = []byte{
+	0x01, 0x00, 0x5e, 0x00, 0x00, 0x16, 0x00, 0x25, 0x2e, 0x51, 0xc3, 0x81, 0x08, 0x00, 0x46, 0x58,
+	0x00, 0x30, 0x01, 0x3c, 0x00, 0x00, 0x01, 0x02, 0x81, 0x33, 0xc0, 0xa8, 0x01, 0x42, 0xe0, 0x00,
+	0x00, 0x16, 0x94, 0x04, 0x00, 0x00, 0x22, 0x00, 0xf3, 0x3c, 0x00, 0x00, 0x00, 0x02, 0x02, 0x00,
+	0x00, 0x00, 0xef, 0xc3, 0x07, 0x02, 0x02, 0x00, 0x00, 0x00, 0xef, 0xff, 0xff, 0xfa,
+}
+
+func TestIGMPv3MembershipReport2Records(t *testing.T) {
+	p := gopacket.NewPacket(igmpv3MembershipReport2Records, LinkTypeEthernet, gopacket.Default)
+	if p.ErrorLayer() != nil {
+		t.Error("Failed to decode packet:", p.ErrorLayer().Error())
+	}
+	checkLayers(p, []gopacket.LayerType{LayerTypeEthernet, LayerTypeIPv4, LayerTypeIGMP}, t)
+}
+func BenchmarkDecodeigmpv3MembershipReport2Records(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		gopacket.NewPacket(igmpv3MembershipReport2Records, LinkTypeEthernet, gopacket.NoCopy)
+	}
+}


### PR DESCRIPTION
Added support for IGMPv1 and IGMPv2 types. Included here is
MembershipQuery (v[123]), MembershipReportV1, MembershipReportV2,
MembershipReportV3 and LeaveGroup (v2)

Including tests supplied in layers/igmp_test.go