### PR TITLE
Fix SmartOS compatibility

### DIFF
--- a/pcap/pcap.go
+++ b/pcap/pcap.go
@@ -8,6 +8,7 @@
 package pcap
 
 /*
+#cgo smartos LDFLAGS: -L /opt/local/lib -lpcap
 #cgo linux LDFLAGS: -lpcap
 #cgo dragonfly LDFLAGS: -lpcap
 #cgo freebsd LDFLAGS: -lpcap


### PR DESCRIPTION

This adds the build flags so that the libpcap driver builds on smartos... which is a fork of Solaris/Illumos/OpenSolaris. I've tested this on a native SmartOS zone... and I verified that I was able to capture packets with the pcap driver.

In my git commit the "smartos" OS label could be replaced with "solaris" and it still builds however I don't know where other Solaris forks would keep it's libpcap.

I have not yet tried to build gopacket on other Solaris forks.
