### PR TITLE
Fix previous mistake, solaris not smartos

### DIFF
--- a/pcap/pcap.go
+++ b/pcap/pcap.go
@@ -8,7 +8,7 @@
 package pcap
 
 /*
-#cgo smartos LDFLAGS: -L /opt/local/lib -lpcap
+#cgo solaris LDFLAGS: -L /opt/local/lib -lpcap
 #cgo linux LDFLAGS: -lpcap
 #cgo dragonfly LDFLAGS: -lpcap
 #cgo freebsd LDFLAGS: -lpcap


### PR DESCRIPTION

This fix makes gopacket compile on Solaris machines with the libpcap from pkgsrc.
It's not a SmartOS specific change... it's Solaris. I was mistaken in the previous commit. Sorry about that!

