### PR TITLE
Added ability to listen on all interfaces with afpacket.

### DIFF
--- a/packet.go
+++ b/packet.go
@@ -29,6 +29,8 @@ type CaptureInfo struct {
 	// Length is the size of the original packet.  Should always be >=
 	// CaptureLength.
 	Length int
+	// InterfaceIndex
+	InterfaceIndex int
 }
 
 // PacketMetadata contains metadata for a packet.


### PR DESCRIPTION
As discussed in #104, exposing the port on which the packet came in is useful in certain situations. I have added the ability to extract this information from the packet header, with the index of the port now stored in the CaptureInfo metadata field of the packet. This index can later be translated to a name by invoking e.g. net.InterfaceByIndex().

Note: To perform the proper tpacket alignment calculations, I had to add a different alignment function "tpAlign" which seems to work, where the included "tpacketAlign" did not. I see that "tpacketAlign" is used for processing of the packets in the blocks in v3-headers, but I'm not sure how that is working if the alignment is incorrect. I tested using my "tpAlign" function in place of "tpacketAlign", which seemed to work fine, but I didn't want to make the change in this PR. Since "tpacketAlign" is only used one place, it would be an easy fix in the future.