### PR TITLE
[pcap][workaround] Avoid deadlocking on waiting on packets

### DIFF
--- a/pcap/pcap.go
+++ b/pcap/pcap.go
@@ -279,6 +279,9 @@ func (p *Handle) ReadPacketData() (data []byte, ci gopacket.CaptureInfo, err err
 		data = C.GoBytes(unsafe.Pointer(p.buf_ptr), C.int(ci.CaptureLength))
 	}
 	p.mu.Unlock()
+	if err == NextErrorTimeoutExpired {
+		runtime.Gosched()
+	}
 	return
 }
 
@@ -360,6 +363,9 @@ func (p *Handle) ZeroCopyReadPacketData() (data []byte, ci gopacket.CaptureInfo,
 		slice.Cap = ci.CaptureLength
 	}
 	p.mu.Unlock()
+	if err == NextErrorTimeoutExpired {
+		runtime.Gosched()
+	}
 	return
 }
 


### PR DESCRIPTION
As ReadPacketData() is called usually in loop, goroutine scheduler seems
to be not very fair when running on a 1 core CPU (GOMAXPROCS = 1 as NumCPU
= 1)
As the p.mu lock is re-acquired (on the next loop), a call to Close() have
poor chance to acquire the lock.
So the workaround is to give a chance to other goroutine waiting on a same
Mutex if pcap handler return timeout.