### PR TITLE
Fix packet size calculation and record serialization

### DIFF
--- a/layers/dns_test.go
+++ b/layers/dns_test.go
@@ -321,6 +321,15 @@ func TestDNSEncodeResponse(t *testing.T) {
 			CNAME: []byte("example2.com"),
 		})
 
+	dns.Authorities = append(dns.Authorities,
+		DNSResourceRecord{
+			Name:  []byte("www.example2.com"),
+			Type:  DNSTypeNS,
+			Class: DNSClassIN,
+			TTL:   1024,
+			NS:    []byte("ns.example2.com"),
+		})
+
 	buf := gopacket.NewSerializeBuffer()
 	opts := gopacket.SerializeOptions{FixLengths: true}
 	err := gopacket.SerializeLayers(buf, opts, dns)


### PR DESCRIPTION
I noticed issues when capturing serialized packets with wireshark.
I added a test for the additional records that weren't being serialized
and added support for NS records to implement the test.

There is no test for the packet size calculation, but it would panic
if we were not reserving enough space. Previously we were reserving
a few bytes per record too much.