### PR TITLE
DNS serialization fixes

### DIFF
--- a/layers/dns.go
+++ b/layers/dns.go
@@ -606,7 +606,7 @@ func (rr *DNSResourceRecord) encode(data []byte, offset int, opts gopacket.Seria
 
 	switch rr.Type {
 	case DNSTypeA:
-		copy(data[noff+10:], rr.IP)
+		copy(data[noff+10:], rr.IP.To4())
 	case DNSTypeAAAA:
 		copy(data[noff+10:], rr.IP)
 	case DNSTypeNS:

--- a/layers/dns.go
+++ b/layers/dns.go
@@ -335,7 +335,6 @@ func (d *DNS) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeOpt
 	dsz += computeSize(d.Answers)
 	dsz += computeSize(d.Authorities)
 	dsz += computeSize(d.Additionals)
-	dsz += computeSize(d.Additionals)
 
 	bytes, err := b.PrependBytes(12 + dsz)
 	if err != nil {

--- a/layers/dns.go
+++ b/layers/dns.go
@@ -373,7 +373,7 @@ func (d *DNS) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeOpt
 	}
 
 	for i := range d.Authorities {
-		qa := &d.Answers[i]
+		qa := &d.Authorities[i]
 		n, err := qa.encode(bytes, off, opts)
 		if err != nil {
 			return err
@@ -381,7 +381,7 @@ func (d *DNS) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeOpt
 		off += n
 	}
 	for i := range d.Additionals {
-		qa := &d.Answers[i]
+		qa := &d.Additionals[i]
 		n, err := qa.encode(bytes, off, opts)
 		if err != nil {
 			return err

--- a/layers/dns.go
+++ b/layers/dns.go
@@ -325,6 +325,12 @@ func recSize(rr *DNSResourceRecord) int {
 		return len(rr.SOA.MName) + 2 + len(rr.SOA.RName) + 2 + 20
 	case DNSTypeMX:
 		return 2 + len(rr.MX.Name) + 2
+	case DNSTypeTXT:
+		l := len(rr.TXTs)
+		for _, txt := range rr.TXTs {
+			l += len(txt)
+		}
+		return l
 	case DNSTypeSRV:
 		return 6 + len(rr.SRV.Name) + 2
 	}
@@ -626,6 +632,13 @@ func (rr *DNSResourceRecord) encode(data []byte, offset int, opts gopacket.Seria
 	case DNSTypeMX:
 		binary.BigEndian.PutUint16(data[noff+10:], rr.MX.Preference)
 		encodeName(rr.MX.Name, data, noff+12)
+	case DNSTypeTXT:
+		noff2 := noff + 10
+		for _, txt := range rr.TXTs {
+			data[noff2] = byte(len(txt))
+			copy(data[noff2+1:], txt)
+			noff2 += 1 + len(txt)
+		}
 	case DNSTypeSRV:
 		binary.BigEndian.PutUint16(data[noff+10:], rr.SRV.Priority)
 		binary.BigEndian.PutUint16(data[noff+12:], rr.SRV.Weight)

--- a/layers/dns.go
+++ b/layers/dns.go
@@ -609,8 +609,12 @@ func (rr *DNSResourceRecord) encode(data []byte, offset int, opts gopacket.Seria
 		copy(data[noff+10:], rr.IP)
 	case DNSTypeAAAA:
 		copy(data[noff+10:], rr.IP)
+	case DNSTypeNS:
+		encodeName(rr.NS, data, noff+10)
 	case DNSTypeCNAME:
 		encodeName(rr.CNAME, data, noff+10)
+	case DNSTypePTR:
+		encodeName(rr.PTR, data, noff+10)
 	case DNSTypeSOA:
 		noff2 := encodeName(rr.SOA.MName, data, noff+10)
 		noff2 = encodeName(rr.SOA.RName, data, noff2)
@@ -619,6 +623,14 @@ func (rr *DNSResourceRecord) encode(data []byte, offset int, opts gopacket.Seria
 		binary.BigEndian.PutUint32(data[noff2+8:], rr.SOA.Retry)
 		binary.BigEndian.PutUint32(data[noff2+12:], rr.SOA.Expire)
 		binary.BigEndian.PutUint32(data[noff2+16:], rr.SOA.Minimum)
+	case DNSTypeMX:
+		binary.BigEndian.PutUint16(data[noff+10:], rr.MX.Preference)
+		encodeName(rr.MX.Name, data, noff+12)
+	case DNSTypeSRV:
+		binary.BigEndian.PutUint16(data[noff+10:], rr.SRV.Priority)
+		binary.BigEndian.PutUint16(data[noff+12:], rr.SRV.Weight)
+		binary.BigEndian.PutUint16(data[noff+14:], rr.SRV.Port)
+		encodeName(rr.SRV.Name, data, noff+16)
 	default:
 		return 0, fmt.Errorf("serializing resource record of type %v not supported", rr.Type)
 	}


### PR DESCRIPTION
In attempting to port some code to use gopacket, I noticed some errors and gaps in the DNS packet encoding. Here are some fixes for them.