### PR TITLE
Fix go vet issue in pcapdump

### DIFF
--- a/examples/pcapdump/main.go
+++ b/examples/pcapdump/main.go
@@ -40,15 +40,15 @@ func main() {
 		// just call pcap.OpenLive if you want a simple handle.
 		inactive, err := pcap.NewInactiveHandle(*iface)
 		if err != nil {
-			log.Fatal("could not create: %v", err)
+			log.Fatalf("could not create: %v", err)
 		}
 		defer inactive.CleanUp()
 		if err = inactive.SetSnapLen(*snaplen); err != nil {
-			log.Fatal("could not set snap length: %v", err)
+			log.Fatalf("could not set snap length: %v", err)
 		} else if err = inactive.SetPromisc(*promisc); err != nil {
-			log.Fatal("could not set promisc mode: %v", err)
+			log.Fatalf("could not set promisc mode: %v", err)
 		} else if err = inactive.SetTimeout(time.Second); err != nil {
-			log.Fatal("could not set timeout: %v", err)
+			log.Fatalf("could not set timeout: %v", err)
 		}
 		if *tstype != "" {
 			if t, err := pcap.TimestampSourceFromString(*tstype); err != nil {


### PR DESCRIPTION
Formatted fatal error message should be sent via log.Fatalf, not log.Fatal