### PR TITLE
Use errors.New instead of fmt.Errorf when it is possible.

### DIFF
--- a/afpacket/options.go
+++ b/afpacket/options.go
@@ -9,6 +9,7 @@
 package afpacket
 
 import (
+	"errors"
 	"fmt"
 	"time"
 )
@@ -134,7 +135,7 @@ func parseOptions(opts ...interface{}) (ret options, err error) {
 		case OptSocketType:
 			ret.socktype = v
 		default:
-			err = fmt.Errorf("unknown type in options")
+			err = errors.New("unknown type in options")
 			return
 		}
 	}

--- a/bsdbpf/bsd_bpf_sniffer.go
+++ b/bsdbpf/bsd_bpf_sniffer.go
@@ -9,13 +9,14 @@
 package bsdbpf
 
 import (
-	"github.com/google/gopacket"
-	"golang.org/x/sys/unix"
-
+	"errors"
 	"fmt"
 	"syscall"
 	"time"
 	"unsafe"
+
+	"github.com/google/gopacket"
+	"golang.org/x/sys/unix"
 )
 
 const wordSize = int(unsafe.Sizeof(uintptr(0)))
@@ -196,7 +197,7 @@ func (b *BPFSniffer) ReadPacketData() ([]byte, gopacket.CaptureInfo, error) {
 			CaptureLength: 0,
 			Length:        0,
 		}
-		return nil, captureInfo, fmt.Errorf("BPF captured frame received with corrupted BpfHdr struct.")
+		return nil, captureInfo, errors.New("BPF captured frame received with corrupted BpfHdr struct.")
 	}
 
 	rawFrame := b.readBuffer[frameStart : frameStart+int(hdr.Caplen)]

--- a/examples/arpscan/arpscan.go
+++ b/examples/arpscan/arpscan.go
@@ -14,7 +14,7 @@ package main
 import (
 	"bytes"
 	"encoding/binary"
-	"fmt"
+	"errors"
 	"log"
 	"net"
 	"sync"
@@ -73,11 +73,11 @@ func scan(iface *net.Interface) error {
 	}
 	// Sanity-check that the interface has a good address.
 	if addr == nil {
-		return fmt.Errorf("no good IP network found")
+		return errors.New("no good IP network found")
 	} else if addr.IP[0] == 127 {
-		return fmt.Errorf("skipping localhost")
+		return errors.New("skipping localhost")
 	} else if addr.Mask[0] != 0xff || addr.Mask[1] != 0xff {
-		return fmt.Errorf("mask means network is too large")
+		return errors.New("mask means network is too large")
 	}
 	log.Printf("Using network range %v for interface %v", addr, iface.Name)
 

--- a/examples/synscan/main.go
+++ b/examples/synscan/main.go
@@ -19,8 +19,8 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"flag"
-	"fmt"
 	"log"
 	"net"
 	"time"
@@ -119,7 +119,7 @@ func (s *scanner) getHwAddr() (net.HardwareAddr, error) {
 	// Wait 3 seconds for an ARP reply.
 	for {
 		if time.Since(start) > time.Second*3 {
-			return nil, fmt.Errorf("timeout getting ARP reply")
+			return nil, errors.New("timeout getting ARP reply")
 		}
 		data, _, err := s.handle.ReadPacketData()
 		if err == pcap.NextErrorTimeoutExpired {

--- a/ip4defrag/defrag.go
+++ b/ip4defrag/defrag.go
@@ -9,6 +9,7 @@ package ip4defrag
 
 import (
 	"container/list"
+	"errors"
 	"fmt"
 	"log"
 	"sync"
@@ -248,7 +249,7 @@ func (f *fragmentList) build(in *layers.IPv4) (*layers.IPv4, error) {
 			debug.Printf("defrag: building - overlapping, starting at %d\n",
 				startAt)
 			if startAt > frag.Length-20 {
-				return nil, fmt.Errorf("defrag: building - invalid fragment")
+				return nil, errors.New("defrag: building - invalid fragment")
 			}
 			final = append(final, frag.Payload[startAt:]...)
 			currentOffset = currentOffset + frag.FragOffset*8
@@ -256,7 +257,7 @@ func (f *fragmentList) build(in *layers.IPv4) (*layers.IPv4, error) {
 			// Houston - we have an hole !
 			debug.Printf("defrag: hole found while building, " +
 				"stopping the defrag process\n")
-			return nil, fmt.Errorf("defrag: building - hole found")
+			return nil, errors.New("defrag: building - hole found")
 		}
 		debug.Printf("defrag: building - next is %d\n", currentOffset)
 	}

--- a/layers/arp.go
+++ b/layers/arp.go
@@ -9,7 +9,8 @@ package layers
 
 import (
 	"encoding/binary"
-	"fmt"
+	"errors"
+
 	"github.com/google/gopacket"
 )
 
@@ -64,11 +65,11 @@ func (arp *ARP) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeO
 	}
 	if opts.FixLengths {
 		if len(arp.SourceHwAddress) != len(arp.DstHwAddress) {
-			return fmt.Errorf("mismatched hardware address sizes")
+			return errors.New("mismatched hardware address sizes")
 		}
 		arp.HwAddressSize = uint8(len(arp.SourceHwAddress))
 		if len(arp.SourceProtAddress) != len(arp.DstProtAddress) {
-			return fmt.Errorf("mismatched prot address sizes")
+			return errors.New("mismatched prot address sizes")
 		}
 		arp.ProtAddressSize = uint8(len(arp.SourceProtAddress))
 	}

--- a/layers/dns.go
+++ b/layers/dns.go
@@ -209,7 +209,7 @@ func (d *DNS) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 
 	if len(data) < 12 {
 		df.SetTruncated()
-		return fmt.Errorf("DNS packet too short")
+		return errors.New("DNS packet too short")
 	}
 
 	// since there are no further layers, the baselayer's content is
@@ -442,7 +442,7 @@ loop:
 			index2 := index + int(data[index]) + 1
 			if index2-offset > 255 {
 				return nil, 0,
-					fmt.Errorf("dns name is too long")
+					errors.New("dns name is too long")
 			}
 			*buffer = append(*buffer, '.')
 			*buffer = append(*buffer, data[index+1:index2]...)

--- a/layers/icmp4.go
+++ b/layers/icmp4.go
@@ -9,9 +9,11 @@ package layers
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
-	"github.com/google/gopacket"
 	"reflect"
+
+	"github.com/google/gopacket"
 )
 
 const (
@@ -219,7 +221,7 @@ func (i *ICMPv4) LayerType() gopacket.LayerType { return LayerTypeICMPv4 }
 func (i *ICMPv4) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 	if len(data) < 8 {
 		df.SetTruncated()
-		return fmt.Errorf("ICMP layer less then 8 bytes for ICMPv4 packet")
+		return errors.New("ICMP layer less then 8 bytes for ICMPv4 packet")
 	}
 	i.TypeCode = CreateICMPv4TypeCode(data[0], data[1])
 	i.Checksum = binary.BigEndian.Uint16(data[2:4])

--- a/layers/icmp6.go
+++ b/layers/icmp6.go
@@ -9,9 +9,11 @@ package layers
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
-	"github.com/google/gopacket"
 	"reflect"
+
+	"github.com/google/gopacket"
 )
 
 const (
@@ -176,7 +178,7 @@ func (i *ICMPv6) LayerType() gopacket.LayerType { return LayerTypeICMPv6 }
 func (i *ICMPv6) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 	if len(data) < 8 {
 		df.SetTruncated()
-		return fmt.Errorf("ICMP layer less then 8 bytes for ICMPv6 packet")
+		return errors.New("ICMP layer less then 8 bytes for ICMPv6 packet")
 	}
 	i.TypeCode = CreateICMPv6TypeCode(data[0], data[1])
 	i.Checksum = binary.BigEndian.Uint16(data[2:4])

--- a/layers/ip4.go
+++ b/layers/ip4.go
@@ -9,6 +9,7 @@ package layers
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -140,7 +141,7 @@ func (ip *IPv4) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeO
 
 			// sanity checking to protect us from buffer overrun
 			if len(opt.OptionData) > int(opt.OptionLength-2) {
-				return fmt.Errorf("option length is smaller than length of option data")
+				return errors.New("option length is smaller than length of option data")
 			}
 			copy(bytes[curLocation+2:curLocation+int(opt.OptionLength)], opt.OptionData)
 			curLocation += int(opt.OptionLength)
@@ -222,7 +223,7 @@ func (ip *IPv4) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 	} else if cmp < 0 {
 		df.SetTruncated()
 		if int(ip.IHL)*4 > len(data) {
-			return fmt.Errorf("Not all IP header bytes available")
+			return errors.New("Not all IP header bytes available")
 		}
 	}
 	ip.Contents = data[:ip.IHL*4]
@@ -285,7 +286,7 @@ func checkIPv4Address(addr net.IP) (net.IP, error) {
 		return c, nil
 	}
 	if len(addr) == net.IPv6len {
-		return nil, fmt.Errorf("address is IPv6")
+		return nil, errors.New("address is IPv6")
 	}
 	return nil, fmt.Errorf("wrong length of %d bytes instead of %d", len(addr), net.IPv4len)
 }

--- a/layers/ip6.go
+++ b/layers/ip6.go
@@ -9,9 +9,11 @@ package layers
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
-	"github.com/google/gopacket"
 	"net"
+
+	"github.com/google/gopacket"
 )
 
 const (
@@ -61,7 +63,7 @@ func getIPv6HopByHopJumboLength(hopopts *IPv6HopByHop) (uint32, bool, error) {
 		return 0, false, nil
 	}
 	if len(tlv.OptionData) != 4 {
-		return 0, false, fmt.Errorf("Jumbo length TLV data must have length 4")
+		return 0, false, errors.New("Jumbo length TLV data must have length 4")
 	}
 	l := binary.BigEndian.Uint32(tlv.OptionData)
 	if l <= ipv6MaxPayloadLength {
@@ -126,7 +128,7 @@ func setIPv6PayloadJumboLength(hbh []byte) error {
 		}
 		offset += 2 + optLen
 	}
-	return fmt.Errorf("Jumbo TLV not found")
+	return errors.New("Jumbo TLV not found")
 }
 
 // SerializeTo writes the serialized form of this layer into the
@@ -152,7 +154,7 @@ func (ip6 *IPv6) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.Serialize
 				return err
 			}
 			if !ok {
-				return fmt.Errorf("Missing jumbo length hop-by-hop option")
+				return errors.New("Missing jumbo length hop-by-hop option")
 			}
 		}
 	}
@@ -175,7 +177,7 @@ func (ip6 *IPv6) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.Serialize
 		}
 	}
 	if !jumbo && pLen > ipv6MaxPayloadLength {
-		return fmt.Errorf("Cannot fit payload into IPv6 header")
+		return errors.New("Cannot fit payload into IPv6 header")
 	}
 	bytes, err := b.PrependBytes(40)
 	if err != nil {
@@ -235,9 +237,9 @@ func (ip6 *IPv6) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error 
 			ip6.Payload = ip6.Payload[:pEnd]
 			return nil
 		} else if jumbo && ip6.Length != 0 {
-			return fmt.Errorf("IPv6 has jumbo length and IPv6 length is not 0")
+			return errors.New("IPv6 has jumbo length and IPv6 length is not 0")
 		} else if !jumbo && ip6.Length == 0 {
-			return fmt.Errorf("IPv6 length 0, but HopByHop header does not have jumbogram option")
+			return errors.New("IPv6 length 0, but HopByHop header does not have jumbogram option")
 		}
 	}
 
@@ -447,7 +449,7 @@ func (i *IPv6HopByHop) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.Ser
 
 	length := len(bytes) + 2
 	if length%8 != 0 {
-		return fmt.Errorf("IPv6HopByHop actual length must be multiple of 8")
+		return errors.New("IPv6HopByHop actual length must be multiple of 8")
 	}
 	bytes, err = b.PrependBytes(2)
 	if err != nil {
@@ -616,7 +618,7 @@ func (i *IPv6Destination) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.
 
 	length := len(bytes) + 2
 	if length%8 != 0 {
-		return fmt.Errorf("IPv6Destination actual length must be multiple of 8")
+		return errors.New("IPv6Destination actual length must be multiple of 8")
 	}
 	bytes, err = b.PrependBytes(2)
 	if err != nil {
@@ -635,7 +637,7 @@ func checkIPv6Address(addr net.IP) error {
 		return nil
 	}
 	if len(addr) == net.IPv4len {
-		return fmt.Errorf("address is IPv4")
+		return errors.New("address is IPv4")
 	}
 	return fmt.Errorf("wrong length of %d bytes instead of %d", len(addr), net.IPv6len)
 }

--- a/layers/llc.go
+++ b/layers/llc.go
@@ -8,7 +8,8 @@ package layers
 
 import (
 	"encoding/binary"
-	"fmt"
+	"errors"
+
 	"github.com/google/gopacket"
 )
 
@@ -91,11 +92,11 @@ func (l *LLC) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeOpt
 	}
 
 	if l.DSAP&0x1 != 0 {
-		return fmt.Errorf("DSAP value invalid, should not include IG flag bit")
+		return errors.New("DSAP value invalid, should not include IG flag bit")
 	}
 
 	if l.SSAP&0x1 != 0 {
-		return fmt.Errorf("SSAP value invalid, should not include CR flag bit")
+		return errors.New("SSAP value invalid, should not include CR flag bit")
 	}
 
 	if buf, err := b.PrependBytes(length); err != nil {

--- a/layers/lldp.go
+++ b/layers/lldp.go
@@ -8,7 +8,9 @@ package layers
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
+
 	"github.com/google/gopacket"
 )
 
@@ -746,12 +748,12 @@ func decodeLinkLayerDiscovery(data []byte, p gopacket.PacketBuilder) error {
 			break
 		}
 		if len(vData) < int(2+val.Length) {
-			return fmt.Errorf("Malformed LinkLayerDiscovery Header")
+			return errors.New("Malformed LinkLayerDiscovery Header")
 		}
 		vData = vData[2+val.Length:]
 	}
 	if len(vals) < 4 {
-		return fmt.Errorf("Missing mandatory LinkLayerDiscovery TLV")
+		return errors.New("Missing mandatory LinkLayerDiscovery TLV")
 	}
 	c := &LinkLayerDiscovery{}
 	gotEnd := false
@@ -761,19 +763,19 @@ func decodeLinkLayerDiscovery(data []byte, p gopacket.PacketBuilder) error {
 			gotEnd = true
 		case LLDPTLVChassisID:
 			if len(v.Value) < 2 {
-				return fmt.Errorf("Malformed LinkLayerDiscovery ChassisID TLV")
+				return errors.New("Malformed LinkLayerDiscovery ChassisID TLV")
 			}
 			c.ChassisID.Subtype = LLDPChassisIDSubType(v.Value[0])
 			c.ChassisID.ID = v.Value[1:]
 		case LLDPTLVPortID:
 			if len(v.Value) < 2 {
-				return fmt.Errorf("Malformed LinkLayerDiscovery PortID TLV")
+				return errors.New("Malformed LinkLayerDiscovery PortID TLV")
 			}
 			c.PortID.Subtype = LLDPPortIDSubType(v.Value[0])
 			c.PortID.ID = v.Value[1:]
 		case LLDPTLVTTL:
 			if len(v.Value) < 2 {
-				return fmt.Errorf("Malformed LinkLayerDiscovery TTL TLV")
+				return errors.New("Malformed LinkLayerDiscovery TTL TLV")
 			}
 			c.TTL = binary.BigEndian.Uint16(v.Value[0:2])
 		default:
@@ -781,7 +783,7 @@ func decodeLinkLayerDiscovery(data []byte, p gopacket.PacketBuilder) error {
 		}
 	}
 	if c.ChassisID.Subtype == 0 || c.PortID.Subtype == 0 || !gotEnd {
-		return fmt.Errorf("Missing mandatory LinkLayerDiscovery TLV")
+		return errors.New("Missing mandatory LinkLayerDiscovery TLV")
 	}
 	c.Contents = data
 	p.AddLayer(c)

--- a/layers/loopback.go
+++ b/layers/loopback.go
@@ -8,6 +8,7 @@ package layers
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 
 	"github.com/google/gopacket"
@@ -27,7 +28,7 @@ func (l *Loopback) LayerType() gopacket.LayerType { return LayerTypeLoopback }
 // DecodeFromBytes decodes the given bytes into this layer.
 func (l *Loopback) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 	if len(data) < 4 {
-		return fmt.Errorf("Loopback packet too small")
+		return errors.New("Loopback packet too small")
 	}
 
 	// The protocol could be either big-endian or little-endian, we're

--- a/layers/ntp.go
+++ b/layers/ntp.go
@@ -10,7 +10,8 @@ package layers
 
 import (
 	"encoding/binary"
-	"fmt"
+	"errors"
+
 	"github.com/google/gopacket"
 )
 
@@ -296,7 +297,7 @@ func (d *NTP) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 	// If the data block is too short to be a NTP record, then return an error.
 	if len(data) < ntpMinimumRecordSizeInBytes {
 		df.SetTruncated()
-		return fmt.Errorf("NTP packet too short")
+		return errors.New("NTP packet too short")
 	}
 
 	// RFC 5905 does not appear to define a maximum NTP record length.

--- a/layers/sctp.go
+++ b/layers/sctp.go
@@ -8,6 +8,7 @@ package layers
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"hash/crc32"
 
@@ -69,7 +70,7 @@ func (s SCTP) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeOpt
 
 func (sctp *SCTP) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 	if len(data) < 12 {
-		return fmt.Errorf("Invalid SCTP common header length")
+		return errors.New("Invalid SCTP common header length")
 	}
 	sctp.SrcPort = SCTPPort(binary.BigEndian.Uint16(data[:2]))
 	sctp.sPort = data[:2]
@@ -114,7 +115,7 @@ func roundUpToNearest4(i int) int {
 func decodeSCTPChunk(data []byte) (SCTPChunk, error) {
 	length := binary.BigEndian.Uint16(data[2:4])
 	if length < 4 {
-		return SCTPChunk{}, fmt.Errorf("invalid SCTP chunk length")
+		return SCTPChunk{}, errors.New("invalid SCTP chunk length")
 	}
 	actual := roundUpToNearest4(int(length))
 	ct := SCTPChunkType(data[0])

--- a/layers/sflow.go
+++ b/layers/sflow.go
@@ -73,9 +73,11 @@ package layers
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
-	"github.com/google/gopacket"
 	"net"
+
+	"github.com/google/gopacket"
 )
 
 // SFlowRecord holds both flow sample records and counter sample records.
@@ -526,43 +528,43 @@ func decodeFlowSample(data *[]byte, expanded bool) (SFlowFlowSample, error) {
 		case SFlowTypeEthernetFrameFlow:
 			// TODO
 			skipRecord(data)
-			return s, fmt.Errorf("skipping TypeEthernetFrameFlow")
+			return s, errors.New("skipping TypeEthernetFrameFlow")
 		case SFlowTypeIpv4Flow:
 			// TODO
 			skipRecord(data)
-			return s, fmt.Errorf("skipping TypeIpv4Flow")
+			return s, errors.New("skipping TypeIpv4Flow")
 		case SFlowTypeIpv6Flow:
 			// TODO
 			skipRecord(data)
-			return s, fmt.Errorf("skipping TypeIpv6Flow")
+			return s, errors.New("skipping TypeIpv6Flow")
 		case SFlowTypeExtendedMlpsFlow:
 			// TODO
 			skipRecord(data)
-			return s, fmt.Errorf("skipping TypeExtendedMlpsFlow")
+			return s, errors.New("skipping TypeExtendedMlpsFlow")
 		case SFlowTypeExtendedNatFlow:
 			// TODO
 			skipRecord(data)
-			return s, fmt.Errorf("skipping TypeExtendedNatFlow")
+			return s, errors.New("skipping TypeExtendedNatFlow")
 		case SFlowTypeExtendedMlpsTunnelFlow:
 			// TODO
 			skipRecord(data)
-			return s, fmt.Errorf("skipping TypeExtendedMlpsTunnelFlow")
+			return s, errors.New("skipping TypeExtendedMlpsTunnelFlow")
 		case SFlowTypeExtendedMlpsVcFlow:
 			// TODO
 			skipRecord(data)
-			return s, fmt.Errorf("skipping TypeExtendedMlpsVcFlow")
+			return s, errors.New("skipping TypeExtendedMlpsVcFlow")
 		case SFlowTypeExtendedMlpsFecFlow:
 			// TODO
 			skipRecord(data)
-			return s, fmt.Errorf("skipping TypeExtendedMlpsFecFlow")
+			return s, errors.New("skipping TypeExtendedMlpsFecFlow")
 		case SFlowTypeExtendedMlpsLvpFecFlow:
 			// TODO
 			skipRecord(data)
-			return s, fmt.Errorf("skipping TypeExtendedMlpsLvpFecFlow")
+			return s, errors.New("skipping TypeExtendedMlpsLvpFecFlow")
 		case SFlowTypeExtendedVlanFlow:
 			// TODO
 			skipRecord(data)
-			return s, fmt.Errorf("skipping TypeExtendedVlanFlow")
+			return s, errors.New("skipping TypeExtendedVlanFlow")
 		default:
 			return s, fmt.Errorf("Unsupported flow record type: %d", flowRecordType)
 		}
@@ -690,13 +692,13 @@ func decodeCounterSample(data *[]byte, expanded bool) (SFlowCounterSample, error
 			}
 		case SFlowTypeTokenRingInterfaceCounters:
 			skipRecord(data)
-			return s, fmt.Errorf("skipping TypeTokenRingInterfaceCounters")
+			return s, errors.New("skipping TypeTokenRingInterfaceCounters")
 		case SFlowType100BaseVGInterfaceCounters:
 			skipRecord(data)
-			return s, fmt.Errorf("skipping Type100BaseVGInterfaceCounters")
+			return s, errors.New("skipping Type100BaseVGInterfaceCounters")
 		case SFlowTypeVLANCounters:
 			skipRecord(data)
-			return s, fmt.Errorf("skipping TypeVLANCounters")
+			return s, errors.New("skipping TypeVLANCounters")
 		case SFlowTypeProcessorCounters:
 			if record, err := decodeProcessorCounters(data); err == nil {
 				s.Records = append(s.Records, record)

--- a/layers/tcpip.go
+++ b/layers/tcpip.go
@@ -8,7 +8,9 @@
 package layers
 
 import (
+	"errors"
 	"fmt"
+
 	"github.com/google/gopacket"
 )
 
@@ -72,7 +74,7 @@ func tcpipChecksum(data []byte, csum uint32) uint16 {
 // out. headerProtocol is the IP protocol number of the upper-layer header.
 func (c *tcpipchecksum) computeChecksum(headerAndPayload []byte, headerProtocol IPProtocol) (uint16, error) {
 	if c.pseudoheader == nil {
-		return 0, fmt.Errorf("TCP/IP layer 4 checksum cannot be computed without network layer... call SetNetworkLayerForChecksum to set which layer to use")
+		return 0, errors.New("TCP/IP layer 4 checksum cannot be computed without network layer... call SetNetworkLayerForChecksum to set which layer to use")
 	}
 	length := uint32(len(headerAndPayload))
 	csum, err := c.pseudoheader.pseudoheaderChecksum()

--- a/layers/vrrp.go
+++ b/layers/vrrp.go
@@ -8,7 +8,7 @@ package layers
 
 import (
 	"encoding/binary"
-	"fmt"
+	"errors"
 	"net"
 
 	"github.com/google/gopacket"
@@ -98,7 +98,7 @@ func (v *VRRPv2) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error 
 	v.Type = VRRPv2Type(data[0] & 0x0F) // low nibble == VRRP type. Expecting 1 (advertisement)
 	if v.Type != 1 {
 		// rfc3768: A packet with unknown type MUST be discarded.
-		return fmt.Errorf("Unrecognized VRRPv2 type field.")
+		return errors.New("Unrecognized VRRPv2 type field.")
 	}
 
 	v.VirtualRtrID = data[1]
@@ -106,7 +106,7 @@ func (v *VRRPv2) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error 
 
 	v.CountIPAddr = data[3]
 	if v.CountIPAddr < 1 {
-		return fmt.Errorf("VRRPv2 number of IP addresses is not valid.")
+		return errors.New("VRRPv2 number of IP addresses is not valid.")
 	}
 
 	v.AuthType = VRRPv2AuthType(data[4])
@@ -149,7 +149,7 @@ func (v *VRRPv2) Payload() []byte {
 // decodeVRRP will parse VRRP v2
 func decodeVRRP(data []byte, p gopacket.PacketBuilder) error {
 	if len(data) < 8 {
-		return fmt.Errorf("Not a valid VRRP packet. Packet length is too small.")
+		return errors.New("Not a valid VRRP packet. Packet length is too small.")
 	}
 	v := &VRRPv2{}
 	return decodingLayerDecoder(v, data, p)

--- a/pcap/pcap_tester.go
+++ b/pcap/pcap_tester.go
@@ -11,14 +11,16 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
-	"github.com/google/gopacket/pcap"
 	"log"
 	"net"
 	"net/http"
 	"os"
 	"time"
+
+	"github.com/google/gopacket/pcap"
 )
 
 var mode = flag.String("mode", "basic", "One of: basic,filtered,timestamp")
@@ -51,7 +53,7 @@ func main() {
 
 func tryCapture(iface net.Interface) error {
 	if iface.Name[:2] == "lo" {
-		return fmt.Errorf("skipping loopback")
+		return errors.New("skipping loopback")
 	}
 	var h *pcap.Handle
 	var err error
@@ -86,7 +88,7 @@ func tryCapture(iface net.Interface) error {
 		}
 		sources := u.SupportedTimestamps()
 		if len(sources) == 0 {
-			return fmt.Errorf("no supported timestamp sources")
+			return errors.New("no supported timestamp sources")
 		} else if err := u.SetTimestampSource(sources[0]); err != nil {
 			return fmt.Errorf("settimestampsource(%v): %v", sources[0], err)
 		} else if h, err = u.Activate(); err != nil {

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -18,6 +18,7 @@ package routing
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net"
 	"sort"
@@ -99,7 +100,7 @@ func (r *router) RouteWithSrc(input net.HardwareAddr, src, dst net.IP) (iface *n
 	case 16:
 		ifaceIndex, gateway, preferredSrc, err = r.route(r.v6, input, src, dst)
 	default:
-		err = fmt.Errorf("IP length is not 4 or 16")
+		err = errors.New("IP length is not 4 or 16")
 		return
 	}
 


### PR DESCRIPTION
Use errors.New instead of fmt.Errorf when it is possible, and goimports.