### PR TITLE
check length of data in decodeName

### DIFF
--- a/layers/dns.go
+++ b/layers/dns.go
@@ -436,6 +436,9 @@ func decodeName(data []byte, offset int, buffer *[]byte, level int) ([]byte, int
 		return nil, 0, errMaxRecursion
 	}
 	start := len(*buffer)
+	if len(data) < offset {
+		return nil, 0, fmt.Errorf("data length %d less than offset %d", len(data), offset)
+	}
 	index := offset
 	if data[index] == 0x00 {
 		return nil, index + 1, nil


### PR DESCRIPTION
When parsing malformed DNS, possible index out of range here.  Discovered this trying to parse an iodine session.