### PR TITLE
pcapdump: support BPF filtering offline capture files

### DIFF
--- a/examples/pcapdump/main.go
+++ b/examples/pcapdump/main.go
@@ -61,12 +61,12 @@ func main() {
 			log.Fatal("PCAP Activate error:", err)
 		}
 		defer handle.Close()
-		if len(flag.Args()) > 0 {
-			bpffilter := strings.Join(flag.Args(), " ")
-			fmt.Fprintf(os.Stderr, "Using BPF filter %q\n", bpffilter)
-			if err = handle.SetBPFFilter(bpffilter); err != nil {
-				log.Fatal("BPF filter error:", err)
-			}
+	}
+	if len(flag.Args()) > 0 {
+		bpffilter := strings.Join(flag.Args(), " ")
+		fmt.Fprintf(os.Stderr, "Using BPF filter %q\n", bpffilter)
+		if err = handle.SetBPFFilter(bpffilter); err != nil {
+			log.Fatal("BPF filter error:", err)
 		}
 	}
 	dumpcommand.Run(handle)


### PR DESCRIPTION
This can be convenient when working on larger captures without having to
cherry-pick the packets into another PCAP file.