### PR TITLE
layers/tcpip: remove dead code in csum computation

### DIFF
--- a/layers/tcpip.go
+++ b/layers/tcpip.go
@@ -66,7 +66,7 @@ func tcpipChecksum(data []byte, csum uint32) uint16 {
 	for csum > 0xffff {
 		csum = (csum >> 16) + (csum & 0xffff)
 	}
-	return ^uint16(csum + (csum >> 16))
+	return ^uint16(csum)
 }
 
 // computeChecksum computes a TCP or UDP checksum.  headerAndPayload is the


### PR DESCRIPTION
Since the loop exits when csum fits in 16 bits, csum >> 16 is always 0.
It was probably an attempt to remove the loop (9688856 "Add serialization
to a number of layers.")