### PR TITLE
layers/dhcp: remove debug print stmt from TestDHCPv4EncodeResponse

### DIFF
--- a/layers/dhcp_test.go
+++ b/layers/dhcp_test.go
@@ -8,7 +8,6 @@ package layers
 
 import (
 	"bytes"
-	"fmt"
 	"net"
 	"testing"
 
@@ -64,7 +63,6 @@ func TestDHCPv4EncodeResponse(t *testing.T) {
 	p2 := gopacket.NewPacket(buf.Bytes(), LayerTypeDHCPv4, testDecodeOptions)
 	dhcp2 := p2.Layer(LayerTypeDHCPv4).(*DHCPv4)
 	testDHCPEqual(t, dhcp, dhcp2)
-	fmt.Print(p2)
 }
 
 func testDHCPEqual(t *testing.T, d1, d2 *DHCPv4) {


### PR DESCRIPTION
It shows up in `go test` output and it was probably not meant to land on
master.