### PR TITLE
Fix possible IP comparison error

### DIFF
--- a/examples/synscan/main.go
+++ b/examples/synscan/main.go
@@ -130,7 +130,7 @@ func (s *scanner) getHwAddr() (net.HardwareAddr, error) {
 		packet := gopacket.NewPacket(data, layers.LayerTypeEthernet, gopacket.NoCopy)
 		if arpLayer := packet.Layer(layers.LayerTypeARP); arpLayer != nil {
 			arp := arpLayer.(*layers.ARP)
-			if bytes.Equal(arp.SourceProtAddress, arpDst) {
+			if arp.SourceProtAddress.Equal(arpDst) {
 				return net.HardwareAddr(arp.SourceHwAddress), nil
 			}
 		}


### PR DESCRIPTION
A net.IP may be represented by both by a 4 as well as a 16 byte long byte slice. Because of this, it is not safe to compare IP addresses using bytes.Equal as the same IP address using a different internal representation will produce mismatches.

*Note, this PR was not initiated by my use of this package and noticing a bug, rather by creating an extension proposal for `go vet` and that signalling the possible misuse in this library.*

Cheers :)