### PR TITLE
avoid call to header.next after poll error

### DIFF
--- a/afpacket/afpacket.go
+++ b/afpacket/afpacket.go
@@ -86,6 +86,8 @@ type TPacket struct {
 	pollset unix.PollFd
 	// shouldReleasePacket is set to true whenever we return packet data, to make sure we remember to release that data back to the kernel.
 	shouldReleasePacket bool
+	// headerNextNeeded is set to true when header need to move to the next packet. No need to move it case of poll error.
+	headerNextNeeded bool
 	// stats is simple statistics on TPacket's run.
 	stats Stats
 	// socketStats contains stats from the socket
@@ -241,7 +243,7 @@ func (h *TPacket) releaseCurrentPacket() error {
 // TPacket.  Each call to ZeroCopyReadPacketData invalidates any data previously
 // returned by ZeroCopyReadPacketData.  Care must be taken not to keep pointers
 // to old bytes when using ZeroCopyReadPacketData... if you need to keep data past
-// the next time you call ZeroCopyReadPacketData, use ReadPacketDataData, which copies
+// the next time you call ZeroCopyReadPacketData, use ReadPacketData, which copies
 // the bytes into a new buffer for you.
 //  tp, _ := NewTPacket(...)
 //  data1, _, _ := tp.ZeroCopyReadPacketData()
@@ -250,12 +252,13 @@ func (h *TPacket) releaseCurrentPacket() error {
 func (h *TPacket) ZeroCopyReadPacketData() (data []byte, ci gopacket.CaptureInfo, err error) {
 	h.mu.Lock()
 retry:
-	if h.current == nil || !h.current.next() {
+	if h.current == nil || !h.headerNextNeeded || !h.current.next() {
 		if h.shouldReleasePacket {
 			h.releaseCurrentPacket()
 		}
 		h.current = h.getTPacketHeader()
 		if err = h.pollForFirstPacket(h.current); err != nil {
+			h.headerNextNeeded = false
 			h.mu.Unlock()
 			return
 		}
@@ -270,6 +273,7 @@ retry:
 	ci.Length = h.current.getLength()
 	ci.InterfaceIndex = h.current.getIfaceIndex()
 	h.stats.Packets++
+	h.headerNextNeeded = true
 	h.mu.Unlock()
 	return
 }
@@ -415,6 +419,7 @@ func (h *TPacket) pollForFirstPacket(hdr header) error {
 			return err
 		}
 	}
+
 	h.shouldReleasePacket = true
 	return nil
 }


### PR DESCRIPTION
In case of a poll error it is a mistake to call
next to the header. This patch introduces a
variable that protect this call.