### PR TITLE
fix typo in docs

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -288,7 +288,7 @@ the packet's information.  A quick example:
    parser := gopacket.NewDecodingLayerParser(layers.LayerTypeEthernet, &eth, &ip4, &ip6, &tcp)
    decoded := []gopacket.LayerType{}
    for packetData := range somehowGetPacketData() {
-     err := parser.DecodeLayers(packetDat, &decoded)
+     err := parser.DecodeLayers(packetData, &decoded)
      for _, layerType := range decoded {
        switch layerType {
          case layers.LayerTypeIPv6:


### PR DESCRIPTION
Fix typo in DecodingLayerParser docs example.