### PR TITLE
Remove clipboard error

### DIFF
--- a/layers/layertypes.go
+++ b/layers/layertypes.go
@@ -1,4 +1,4 @@
-// Copyright 2012 Google, gopacket.LayerTypeMetadata{Inc. All rights reserved}.
+// Copyright 2012 Google, Inc. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file in the root of the source


### PR DESCRIPTION
Non-code change to fix accidental garbage copy-pasted into the copyright header.