### PR TITLE
This commit removes a lot of the CGo used by AF_PACKET

### DIFF
--- a/afpacket/sockopt_linux.go
+++ b/afpacket/sockopt_linux.go
@@ -5,6 +5,7 @@
 // tree.
 
 // +build linux
+
 package afpacket
 
 import (

--- a/afpacket/sockopt_linux.go
+++ b/afpacket/sockopt_linux.go
@@ -1,0 +1,50 @@
+package afpacket
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// setsockopt provides access to the setsockopt syscall.
+func setsockopt(fd, level, name int, val unsafe.Pointer, vallen uintptr) error {
+	_, _, errno := unix.Syscall6(
+		unix.SYS_SETSOCKOPT,
+		uintptr(fd),
+		uintptr(level),
+		uintptr(name),
+		uintptr(val),
+		vallen,
+		0,
+	)
+	if errno != 0 {
+		return error(errno)
+	}
+
+	return nil
+}
+
+// getsockopt provides access to the getsockopt syscall.
+func getsockopt(fd, level, name int, val unsafe.Pointer, vallen uintptr) error {
+	_, _, errno := unix.Syscall6(
+		unix.SYS_GETSOCKOPT,
+		uintptr(fd),
+		uintptr(level),
+		uintptr(name),
+		uintptr(val),
+		vallen,
+		0,
+	)
+	if errno != 0 {
+		return error(errno)
+	}
+
+	return nil
+}
+
+// htons converts a short (uint16) from host-to-network byte order.
+// Thanks to mikioh for this neat trick:
+// https://github.com/mikioh/-stdyng/blob/master/afpacket.go
+func htons(i uint16) uint16 {
+	return (i<<8)&0xff00 | i>>8
+}

--- a/afpacket/sockopt_linux.go
+++ b/afpacket/sockopt_linux.go
@@ -1,3 +1,10 @@
+// Copyright 2012 Google, Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file in the root of the source
+// tree.
+
+// +build linux
 package afpacket
 
 import (

--- a/afpacket/sockopt_linux_386.go
+++ b/afpacket/sockopt_linux_386.go
@@ -6,7 +6,7 @@
 
 // +build linux,386
 
-package raw
+package afpacket
 
 import (
 	"unsafe"

--- a/afpacket/sockopt_linux_386.go
+++ b/afpacket/sockopt_linux_386.go
@@ -1,6 +1,8 @@
-// Copyright 2014 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
+// Copyright 2012 Google, Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file in the root of the source
+// tree.
 
 // +build linux,386
 

--- a/afpacket/sockopt_linux_386.go
+++ b/afpacket/sockopt_linux_386.go
@@ -1,0 +1,55 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build linux,386
+
+package raw
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	sysSETSOCKOPT = 0xe
+	sysGETSOCKOPT = 0xf
+)
+
+func socketcall(call int, a0, a1, a2, a3, a4, a5 uintptr) (int, unix.Errno)
+
+// setsockopt provides access to the setsockopt syscall.
+func setsockopt(fd, level, name int, v unsafe.Pointer, l uintptr) error {
+	_, errno := socketcall(
+		sysSETSOCKOPT,
+		uintptr(fd),
+		uintptr(level),
+		uintptr(name),
+		uintptr(v),
+		l,
+		0,
+	)
+	if errno != 0 {
+		return error(errno)
+	}
+
+	return nil
+}
+
+func getsockopt(fd, level, name int, v unsafe.Pointer, l uintptr) error {
+	_, errno := socketcall(
+		sysGETSOCKOPT,
+		uintptr(fd),
+		uintptr(level),
+		uintptr(name),
+		uintptr(v),
+		l,
+		0,
+	)
+	if errno != 0 {
+		return error(errno)
+	}
+
+	return nil
+}

--- a/afpacket/sockopt_linux_386.s
+++ b/afpacket/sockopt_linux_386.s
@@ -1,0 +1,6 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+TEXT	·socketcall(SB),4,$0-36
+	JMP	syscall·socketcall(SB)

--- a/afpacket/sockopt_linux_386.s
+++ b/afpacket/sockopt_linux_386.s
@@ -1,6 +1,8 @@
-// Copyright 2014 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
+// Copyright 2012 Google, Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file in the root of the source
+// tree.
 
 TEXT	·socketcall(SB),4,$0-36
 	JMP	syscall·socketcall(SB)


### PR DESCRIPTION
It does this by enabling afpacket to make raw set/getsockopt syscalls and
making use of the golang.org/x/unix syscall interface.

Signed-off-by: Levi Gross <levi@levigross.com>