### PR TITLE
add ability to compile pcap filters offline

### DIFF
--- a/pcap/pcap.go
+++ b/pcap/pcap.go
@@ -487,6 +487,18 @@ func (p *Handle) compileBPFFilter(expr string) (_Ctype_struct_bpf_program, error
 	return bpf, nil
 }
 
+// CompileBPFFilter compiles and returns a BPF filter with given a link type and capture length.
+func CompileBPFFilter(linkType layers.LinkType, captureLength int, expr string) ([]BPFInstruction, error) {
+	cptr := C.pcap_open_dead(C.int(linkType), C.int(captureLength))
+	if cptr == nil {
+		return nil, errors.New("error opening dead capture")
+	}
+
+	h := Handle{cptr: cptr}
+	defer h.Close()
+	return h.CompileBPFFilter(expr)
+}
+
 // CompileBPFFilter compiles and returns a BPF filter for the pcap handle.
 func (p *Handle) CompileBPFFilter(expr string) ([]BPFInstruction, error) {
 	bpf, err := p.compileBPFFilter(expr)

--- a/pcap/pcap_test.go
+++ b/pcap/pcap_test.go
@@ -116,71 +116,73 @@ func TestBPFInstruction(t *testing.T) {
 	oversizedBpfInstructionBuffer := [MaxBpfInstructions + 1]BPFInstruction{}
 
 	for _, expected := range []struct {
+		Filter         string
 		BpfInstruction []BPFInstruction
 		Error          bool
 		Result         bool
 	}{
 		// {"foobar", true, false},
-		{[]BPFInstruction{}, true, false},
+		{"foobar", []BPFInstruction{}, true, false},
 
-		// {"tcp[tcpflags] & (tcp-syn|tcp-ack) == (tcp-syn|tcp-ack)", false, true},
 		// tcpdump -dd 'tcp[tcpflags] & (tcp-syn|tcp-ack) == (tcp-syn|tcp-ack)'
-		{[]BPFInstruction{
-			{0x28, 0, 0, 0x0000000c},
-			{0x15, 0, 9, 0x00000800},
-			{0x30, 0, 0, 0x00000017},
-			{0x15, 0, 7, 0x00000006},
-			{0x28, 0, 0, 0x00000014},
-			{0x45, 5, 0, 0x00001fff},
-			{0xb1, 0, 0, 0x0000000e},
-			{0x50, 0, 0, 0x0000001b},
-			{0x54, 0, 0, 0x00000012},
-			{0x15, 0, 1, 0x00000012},
-			{0x6, 0, 0, 0x0000ffff},
-			{0x6, 0, 0, 0x00000000},
-		}, false, true},
+		{"tcp[tcpflags] & (tcp-syn|tcp-ack) == (tcp-syn|tcp-ack)",
+			[]BPFInstruction{
+				{0x28, 0, 0, 0x0000000c},
+				{0x15, 0, 9, 0x00000800},
+				{0x30, 0, 0, 0x00000017},
+				{0x15, 0, 7, 0x00000006},
+				{0x28, 0, 0, 0x00000014},
+				{0x45, 5, 0, 0x00001fff},
+				{0xb1, 0, 0, 0x0000000e},
+				{0x50, 0, 0, 0x0000001b},
+				{0x54, 0, 0, 0x00000012},
+				{0x15, 0, 1, 0x00000012},
+				{0x6, 0, 0, 0x0000ffff},
+				{0x6, 0, 0, 0x00000000},
+			}, false, true},
 
-		// {"tcp[tcpflags] & (tcp-syn|tcp-ack) == tcp-ack", false, true},
 		// tcpdump -dd 'tcp[tcpflags] & (tcp-syn|tcp-ack) == tcp-ack'
-		{[]BPFInstruction{
-			{0x28, 0, 0, 0x0000000c},
-			{0x15, 0, 9, 0x00000800},
-			{0x30, 0, 0, 0x00000017},
-			{0x15, 0, 7, 0x00000006},
-			{0x28, 0, 0, 0x00000014},
-			{0x45, 5, 0, 0x00001fff},
-			{0xb1, 0, 0, 0x0000000e},
-			{0x50, 0, 0, 0x0000001b},
-			{0x54, 0, 0, 0x00000012},
-			{0x15, 0, 1, 0x00000010},
-			{0x6, 0, 0, 0x0000ffff},
-			{0x6, 0, 0, 0x00000000},
-		}, false, true},
+		{"tcp[tcpflags] & (tcp-syn|tcp-ack) == tcp-ack",
+			[]BPFInstruction{
+				{0x28, 0, 0, 0x0000000c},
+				{0x15, 0, 9, 0x00000800},
+				{0x30, 0, 0, 0x00000017},
+				{0x15, 0, 7, 0x00000006},
+				{0x28, 0, 0, 0x00000014},
+				{0x45, 5, 0, 0x00001fff},
+				{0xb1, 0, 0, 0x0000000e},
+				{0x50, 0, 0, 0x0000001b},
+				{0x54, 0, 0, 0x00000012},
+				{0x15, 0, 1, 0x00000010},
+				{0x6, 0, 0, 0x0000ffff},
+				{0x6, 0, 0, 0x00000000},
+			}, false, true},
 
-		// {"udp", false, false},
 		// tcpdump -dd 'udp'
-		{[]BPFInstruction{
-			{0x28, 0, 0, 0x0000000c},
-			{0x15, 0, 5, 0x000086dd},
-			{0x30, 0, 0, 0x00000014},
-			{0x15, 6, 0, 0x00000011},
-			{0x15, 0, 6, 0x0000002c},
-			{0x30, 0, 0, 0x00000036},
-			{0x15, 3, 4, 0x00000011},
-			{0x15, 0, 3, 0x00000800},
-			{0x30, 0, 0, 0x00000017},
-			{0x15, 0, 1, 0x00000011},
-			{0x6, 0, 0, 0x0000ffff},
-			{0x6, 0, 0, 0x00000000},
-		}, false, false},
+		{"udp",
+			[]BPFInstruction{
+				{0x28, 0, 0, 0x0000000c},
+				{0x15, 0, 5, 0x000086dd},
+				{0x30, 0, 0, 0x00000014},
+				{0x15, 6, 0, 0x00000011},
+				{0x15, 0, 6, 0x0000002c},
+				{0x30, 0, 0, 0x00000036},
+				{0x15, 3, 4, 0x00000011},
+				{0x15, 0, 3, 0x00000800},
+				{0x30, 0, 0, 0x00000017},
+				{0x15, 0, 1, 0x00000011},
+				{0x6, 0, 0, 0x0000ffff},
+				{0x6, 0, 0, 0x00000000},
+			}, false, false},
 
-		{oversizedBpfInstructionBuffer[:], true, false},
+		{"", oversizedBpfInstructionBuffer[:], true, false},
 	} {
 		cntr++
 		data, ci, err := handle.ReadPacketData()
 		if err != nil {
 			t.Fatal(err)
 		}
+
 		t.Log("Testing BpfInstruction filter", cntr)
 		if bpf, err := handle.NewBPFInstructionFilter(expected.BpfInstruction); err != nil {
 			if !expected.Error {
@@ -190,6 +192,26 @@ func TestBPFInstruction(t *testing.T) {
 			t.Error("expected error but didn't see one")
 		} else if matches := bpf.Matches(ci, data); matches != expected.Result {
 			t.Error("Filter result was", matches, "but should be", expected.Result)
+		}
+
+		if expected.Filter != "" {
+			t.Log("Testing dead bpf filter", cntr)
+			if bpf, err := CompileBPFFilter(layers.LinkTypeEthernet, 65535, expected.Filter); err != nil {
+				if !expected.Error {
+					t.Error(err, "while compiling filter was unexpected")
+				}
+			} else if expected.Error {
+				t.Error("expected error but didn't see one")
+			} else {
+				if len(bpf) != len(expected.BpfInstruction) {
+					t.Errorf("expected %d instructions, got %d", len(expected.BpfInstruction), len(bpf))
+				}
+				for i := 0; i < len(bpf); i++ {
+					if bpf[i] != expected.BpfInstruction[i] {
+						t.Errorf("expected instruction %d = %d, got %d", i, expected.BpfInstruction[i], bpf[i])
+					}
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
Use pcap_open_dead to create a handle and then compile the filter.
According to the docs this is what pcap_compile_nopcap does internally,
but this method allows extracting an error message which
pcap_compile_nopcap swallows.