### PR TITLE
Register decodeDot11 for LinkTypeMetadata

### DIFF
--- a/layers/enums.go
+++ b/layers/enums.go
@@ -489,6 +489,7 @@ func init() {
 	LinkTypeMetadata[LinkTypePPP] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodePPP), Name: "PPP"}
 	LinkTypeMetadata[LinkTypeFDDI] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeFDDI), Name: "FDDI"}
 	LinkTypeMetadata[LinkTypeNull] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeLoopback), Name: "Null"}
+	LinkTypeMetadata[LinkTypeIEEE802_11] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeDot11), Name: "Dot11"}
 	LinkTypeMetadata[LinkTypeLoop] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeLoopback), Name: "Loop"}
 	LinkTypeMetadata[LinkTypeRaw] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeIPv4or6), Name: "Raw"}
 	LinkTypeMetadata[LinkTypePFLog] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodePFLog), Name: "PFLog"}


### PR DESCRIPTION
In a (private) project of mine I have this code:

```go
	dot11Layer := packet.Layer(layers.LayerTypeDot11)
	if dot11Layer == nil {
		return
	}

	dot11 := &layers.Dot11{}
	data := dot11Layer.LayerPayload()
	dot11.DecodeFromBytes(data, gopacket.NilDecodeFeedback)
```

which failed to decode properly: `Packet decoding error: Unable to decode link type 105`. This change fixes that issue.

If the issue is a result of a mistake on my side and this commit is the wrong way around it, please do tell me.