### PR TITLE
Determine endpoint IPv4/IPv6 type based on structure rather than byte-length

### DIFF
--- a/layers/endpoints.go
+++ b/layers/endpoints.go
@@ -50,12 +50,16 @@ var (
 // NewIPEndpoint creates a new IP (v4 or v6) endpoint from a net.IP address.
 // It returns gopacket.InvalidEndpoint if the IP address is invalid.
 func NewIPEndpoint(a net.IP) gopacket.Endpoint {
-	switch len(a) {
-	case 4:
-		return gopacket.NewEndpoint(EndpointIPv4, []byte(a))
-	case 16:
-		return gopacket.NewEndpoint(EndpointIPv6, []byte(a))
+	ipv4 := a.To4()
+	if ipv4 != nil {
+		return gopacket.NewEndpoint(EndpointIPv4, []byte(ipv4))
 	}
+
+	ipv6 := a.To16()
+	if ipv6 != nil {
+		return gopacket.NewEndpoint(EndpointIPv6, []byte(ipv6))
+	}
+
 	return gopacket.InvalidEndpoint
 }
 

--- a/layers/endpoints_test.go
+++ b/layers/endpoints_test.go
@@ -1,0 +1,37 @@
+// Copyright 2017, Google, Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file in the root of the source
+// tree.
+
+package layers
+
+import (
+	"net"
+	"testing"
+
+	"github.com/google/gopacket"
+)
+
+func TestNewIPEndpoint(t *testing.T) {
+	cases := []struct {
+		ip           net.IP
+		endpointType gopacket.EndpointType
+	}{
+		{net.ParseIP("192.168.0.1").To4(), EndpointIPv4},
+		{net.ParseIP("192.168.0.1").To16(), EndpointIPv4},
+		{net.ParseIP("2001:0db8:85a3:0000:0000:8a2e:0370:7334"), EndpointIPv6},
+	}
+
+	for _, c := range cases {
+		endpoint := NewIPEndpoint(c.ip)
+		if endpoint == gopacket.InvalidEndpoint {
+			t.Errorf("Failed to create an IP endpoint for %s (%d-bytes)",
+				c.ip, len(c.ip))
+		}
+		if endpoint.EndpointType() != c.endpointType {
+			t.Errorf("Wrong endpoint type created for %s (%d-bytes): expected %s, got %s",
+				c.ip, len(c.ip), c.endpointType, endpoint.EndpointType())
+		}
+	}
+}


### PR DESCRIPTION
This PR modifies `layers.NewIPEndpoint(net.IP)` to properly inspect whether the input IP is an IPv4 or an IPv6, based on its structure/content, rather than by its `[]byte` slice length.
Prior to this PR, passing a 16-bytes IPv4 (e.g., `net.IPv4(192,168,0,1)`) created a `gopacket.Endpoint` of type IPv6.

According to the [`net.IP` documentation](https://golang.org/pkg/net/#IP), IPv4 addresses may be represented using 16-bytes:
> Note that in this documentation, referring to an IP address as an IPv4 address or an IPv6 address is a semantic property of the address, not just the length of the byte slice: a 16-byte slice can still be an IPv4 address.

The fix currently utilizes `net.IP`'s `.To4()`/`.To16()` methods to determine the type of the IP address. This can be micro-optimized by using `bytes.Compare(a[0:12], 0x0000000000ff)`, which is how 16-bytes IPv4 is represented by the `net` package. This is an internal and undocumented property, but is probably unlikely to change...