### PR TITLE
Avoid the double free of the bpf object

### DIFF
--- a/pcap/pcap.go
+++ b/pcap/pcap.go
@@ -529,7 +529,6 @@ func (p *Handle) SetBPFFilter(expr string) (err error) {
 	}
 
 	if -1 == C.pcap_setfilter(p.cptr, &bpf) {
-		C.pcap_freecode(&bpf)
 		return p.Error()
 	}
 


### PR DESCRIPTION
SetBPFFilter C.pcap_freecode may be called twice sometimes.