### PR TITLE
Dhcp pad

### DIFF
--- a/layers/dhcp_test.go
+++ b/layers/dhcp_test.go
@@ -22,6 +22,7 @@ func TestDHCPv4EncodeRequest(t *testing.T) {
 
 	dhcp.Options = append(dhcp.Options, NewDHCPOption(DHCPOptMessageType, []byte{byte(DHCPMsgTypeDiscover)}))
 	dhcp.Options = append(dhcp.Options, NewDHCPOption(DHCPOptHostname, []byte{'e', 'x', 'a', 'm', 'p', 'l', 'e', '.', 'c', 'o', 'm'}))
+	dhcp.Options = append(dhcp.Options, NewDHCPOption(DHCPOptPad, nil))
 	dhcp.Options = append(dhcp.Options, NewDHCPOption(DHCPOptParamsRequest,
 		[]byte{byte(DHCPOptSubnetMask), byte(DHCPOptBroadcastAddr), byte(DHCPOptTimeOffset),
 			byte(DHCPOptRouter), byte(DHCPOptDomainName), byte(DHCPOptDNS), byte(DHCPOptDomainSearch),
@@ -48,6 +49,7 @@ func TestDHCPv4EncodeResponse(t *testing.T) {
 
 	dhcp.Options = append(dhcp.Options, NewDHCPOption(DHCPOptMessageType, []byte{byte(DHCPMsgTypeOffer)}))
 	dhcp.Options = append(dhcp.Options, NewDHCPOption(DHCPOptSubnetMask, []byte{255, 255, 255, 0}))
+	dhcp.Options = append(dhcp.Options, NewDHCPOption(DHCPOptPad, nil))
 	dhcp.Options = append(dhcp.Options, NewDHCPOption(DHCPOptT1, []byte{0x00, 0x00, 0x0e, 0x10}))
 	dhcp.Options = append(dhcp.Options, NewDHCPOption(DHCPOptT2, []byte{0x00, 0x00, 0x0e, 0x10}))
 	dhcp.Options = append(dhcp.Options, NewDHCPOption(DHCPOptLeaseTime, []byte{0x00, 0x00, 0x0e, 0x10}))

--- a/layers/dhcpv4.go
+++ b/layers/dhcpv4.go
@@ -161,7 +161,12 @@ func (d *DHCPv4) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error 
 			break
 		}
 		d.Options = append(d.Options, o)
-		start += int(o.Length) + 2
+		// Check if the option is a single byte pad
+		if o.Type == DHCPOptPad {
+			start++
+		} else {
+			start += int(o.Length) + 2
+		}
 	}
 	return nil
 }
@@ -215,7 +220,12 @@ func (d *DHCPv4) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.Serialize
 			if err := o.encode(data[offset:]); err != nil {
 				return err
 			}
-			offset += 2 + len(o.Data)
+			// A pad option is only a single byte
+			if o.Type == DHCPOptPad {
+				offset++
+			} else {
+				offset += 2 + len(o.Data)
+			}
 		}
 		optend := NewDHCPOption(DHCPOptEnd, nil)
 		if err := optend.encode(data[offset:]); err != nil {

--- a/layers/dhcpv4.go
+++ b/layers/dhcpv4.go
@@ -175,7 +175,11 @@ func (d *DHCPv4) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error 
 func (d *DHCPv4) Len() uint16 {
 	n := uint16(240)
 	for _, o := range d.Options {
-		n += uint16(o.Length) + 2
+		if o.Type == DHCPOptPad {
+			n++
+		} else {
+			n += uint16(o.Length) + 2
+		}
 	}
 	n++ // for opt end
 	return n
@@ -186,9 +190,6 @@ func (d *DHCPv4) Len() uint16 {
 // See the docs for gopacket.SerializableLayer for more info.
 func (d *DHCPv4) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeOptions) error {
 	plen := int(d.Len())
-	if plen < 300 {
-		plen = 300
-	}
 
 	data, err := b.PrependBytes(plen)
 	if err != nil {


### PR DESCRIPTION
Ensure the Pad option is treated as a single byte as according to https://tools.ietf.org/html/rfc2132

