### PR TITLE
Reset IPv4 Options slice during new data decoding

### DIFF
--- a/layers/ip4.go
+++ b/layers/ip4.go
@@ -200,6 +200,7 @@ func (ip *IPv4) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 	ip.Checksum = binary.BigEndian.Uint16(data[10:12])
 	ip.SrcIP = data[12:16]
 	ip.DstIP = data[16:20]
+	ip.Options = ip.Options[:0]
 	// Set up an initial guess for contents/payload... we'll reset these soon.
 	ip.BaseLayer = BaseLayer{Contents: data}
 


### PR DESCRIPTION
Existing IPv4 slice might be reused to avoid new allocations (with DecodingLayerParser or standalone), therefore Options slice should be reset during DecodeFromBytes, otherwise previous ip options will remain in Options slice.