### PR TITLE
Add raw layertype for google

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -26,6 +26,7 @@ Satoshi Matsumoto <kaorimatz@gmail.com>
 David Stainton <dstainton415@gmail.com>
 Jesse Ward <jesse@jesseward.com>
 Kane Mathers <kane@kanemathers.name>
+Holger Hans Peter Freyther <automatic@freyther.de>
 
 -----------------------------------------------
 FORKED FROM github.com/akrennmair/gopcap

--- a/layers/enums.go
+++ b/layers/enums.go
@@ -374,18 +374,6 @@ func (a Dot11Type) LayerType() gopacket.LayerType {
 	return Dot11TypeMetadata[a].LayerType
 }
 
-// Decode a raw v4 or v6 IP packet.
-func decodeIPv4or6(data []byte, p gopacket.PacketBuilder) error {
-	version := data[0] >> 4
-	switch version {
-	case 4:
-		return decodeIPv4(data, p)
-	case 6:
-		return decodeIPv6(data, p)
-	}
-	return fmt.Errorf("Invalid IP packet version %v", version)
-}
-
 func init() {
 	// Here we link up all enumerations with their respective names and decoders.
 	for i := 0; i < 65536; i++ {
@@ -501,9 +489,9 @@ func init() {
 	LinkTypeMetadata[LinkTypeIEEE802_11] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeDot11), Name: "Dot11"}
 	LinkTypeMetadata[LinkTypeLoop] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeLoopback), Name: "Loop"}
 	LinkTypeMetadata[LinkTypeIEEE802_11] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeDot11), Name: "802.11"}
-	LinkTypeMetadata[LinkTypeRaw] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeIPv4or6), Name: "Raw"}
-	LinkTypeMetadata[LinkTypeRawLinux] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeIPv4or6), Name: "Raw"}
-	LinkTypeMetadata[LinkTypeRawOpenBSD] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeIPv4or6), Name: "Raw"}
+	LinkTypeMetadata[LinkTypeRaw] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeRawIP), Name: "Raw"}
+	LinkTypeMetadata[LinkTypeRawLinux] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeRawIP), Name: "Raw"}
+	LinkTypeMetadata[LinkTypeRawOpenBSD] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeRawIP), Name: "Raw"}
 	LinkTypeMetadata[LinkTypePFLog] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodePFLog), Name: "PFLog"}
 	LinkTypeMetadata[LinkTypeIEEE80211Radio] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeRadioTap), Name: "RadioTap"}
 	LinkTypeMetadata[LinkTypeLinuxUSB] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeUSB), Name: "USB"}

--- a/layers/enums.go
+++ b/layers/enums.go
@@ -93,7 +93,7 @@ const (
 type LinkType uint8
 
 const (
-	// According to pcap-linktype(7) and http://www.tcpdump.org/linktypes.html
+	// According to pcap-linktype(7) and http://www.tcpdump.org/linktypes.html with fixes from pcap/bpf.h
 	LinkTypeNull           LinkType = 0
 	LinkTypeEthernet       LinkType = 1
 	LinkTypeAX25           LinkType = 3
@@ -102,10 +102,12 @@ const (
 	LinkTypeSLIP           LinkType = 8
 	LinkTypePPP            LinkType = 9
 	LinkTypeFDDI           LinkType = 10
+	LinkTypeRawLinux       LinkType = 12
+	LinkTypeRawOpenBSD     LinkType = 14
 	LinkTypePPP_HDLC       LinkType = 50
 	LinkTypePPPEthernet    LinkType = 51
 	LinkTypeATM_RFC1483    LinkType = 100
-	LinkTypeRaw            LinkType = 101
+	LinkTypeRaw            LinkType = 102
 	LinkTypeC_HDLC         LinkType = 104
 	LinkTypeIEEE802_11     LinkType = 105
 	LinkTypeFRelay         LinkType = 107
@@ -500,6 +502,8 @@ func init() {
 	LinkTypeMetadata[LinkTypeLoop] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeLoopback), Name: "Loop"}
 	LinkTypeMetadata[LinkTypeIEEE802_11] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeDot11), Name: "802.11"}
 	LinkTypeMetadata[LinkTypeRaw] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeIPv4or6), Name: "Raw"}
+	LinkTypeMetadata[LinkTypeRawLinux] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeIPv4or6), Name: "Raw"}
+	LinkTypeMetadata[LinkTypeRawOpenBSD] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeIPv4or6), Name: "Raw"}
 	LinkTypeMetadata[LinkTypePFLog] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodePFLog), Name: "PFLog"}
 	LinkTypeMetadata[LinkTypeIEEE80211Radio] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeRadioTap), Name: "RadioTap"}
 	LinkTypeMetadata[LinkTypeLinuxUSB] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeUSB), Name: "USB"}

--- a/layers/ip6_test.go
+++ b/layers/ip6_test.go
@@ -176,7 +176,7 @@ func TestPacketIPv6HopByHop0Decode(t *testing.T) {
 	if p.ErrorLayer() != nil {
 		t.Error("Failed to decode packet:", p.ErrorLayer().Error())
 	}
-	checkLayers(p, []gopacket.LayerType{LayerTypeIPv6, LayerTypeIPv6HopByHop}, t)
+	checkLayers(p, []gopacket.LayerType{LayerTypeRaw, LayerTypeIPv6, LayerTypeIPv6HopByHop}, t)
 	if got, ok := p.Layer(LayerTypeIPv6).(*IPv6); ok {
 		want := ip6
 		want.HopByHop = got.HopByHop // avoid comparing pointers
@@ -282,7 +282,7 @@ func TestPacketIPv6Destination0Decode(t *testing.T) {
 	if p.ErrorLayer() != nil {
 		t.Error("Failed to decode packet:", p.ErrorLayer().Error())
 	}
-	checkLayers(p, []gopacket.LayerType{LayerTypeIPv6, LayerTypeIPv6Destination}, t)
+	checkLayers(p, []gopacket.LayerType{LayerTypeRaw, LayerTypeIPv6, LayerTypeIPv6Destination}, t)
 	if got, ok := p.Layer(LayerTypeIPv6).(*IPv6); ok {
 		want := ip6
 		if !reflect.DeepEqual(got, want) {
@@ -395,7 +395,7 @@ func TestIPv6JumbogramDecode(t *testing.T) {
 	if p.ErrorLayer() != nil {
 		t.Error("Failed to decode packet:", p.ErrorLayer().Error())
 	}
-	checkLayers(p, []gopacket.LayerType{LayerTypeIPv6, LayerTypeIPv6HopByHop, gopacket.LayerTypePayload}, t)
+	checkLayers(p, []gopacket.LayerType{LayerTypeRaw, LayerTypeIPv6, LayerTypeIPv6HopByHop, gopacket.LayerTypePayload}, t)
 
 	if got, ok := p.Layer(LayerTypeIPv6).(*IPv6); ok {
 		want := ip6

--- a/layers/layertypes.go
+++ b/layers/layertypes.go
@@ -122,6 +122,7 @@ var (
 	LayerTypeDHCPv4                      = gopacket.RegisterLayerType(118, gopacket.LayerTypeMetadata{Name: "DHCPv4", Decoder: gopacket.DecodeFunc(decodeDHCPv4)})
 	LayerTypeVRRP                        = gopacket.RegisterLayerType(119, gopacket.LayerTypeMetadata{Name: "VRRP", Decoder: gopacket.DecodeFunc(decodeVRRP)})
 	LayerTypeGeneve                      = gopacket.RegisterLayerType(120, gopacket.LayerTypeMetadata{Name: "Geneve", Decoder: gopacket.DecodeFunc(decodeGeneve)})
+	LayerTypeRaw                         = gopacket.RegisterLayerType(121, gopacket.LayerTypeMetadata{Name: "RAW", Decoder: gopacket.DecodeFunc(decodeRawIP)})
 )
 
 var (

--- a/layers/raw.go
+++ b/layers/raw.go
@@ -1,0 +1,67 @@
+// Copyright 2012 The GoPacket Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file in the root of the source
+// tree.
+
+package layers
+
+import (
+	"fmt"
+	"github.com/google/gopacket"
+)
+
+// RawIP (DLT_RAW) contains no header and we start with the IP header
+type Raw struct {
+	BaseLayer
+	Family ProtocolFamily
+}
+
+func (r *Raw) LayerType() gopacket.LayerType { return LayerTypeRaw }
+
+func (r *Raw) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
+	if len(data) < 1 {
+		return fmt.Errorf("Raw packet too small")
+	}
+
+	family, err := versionToFamily(data[0] >> 4)
+	if err != nil {
+		return err
+	}
+	r.Family = family
+	r.BaseLayer = BaseLayer{make([]byte, 0), data}
+	return nil
+}
+
+func (r *Raw) CanDecode() gopacket.LayerClass {
+	return LayerTypeRaw
+}
+
+func (r *Raw) NextLayerType() gopacket.LayerType {
+	return r.Family.LayerType()
+}
+
+func versionToFamily(version uint8) (ProtocolFamily, error) {
+	switch version {
+	case 4:
+		return ProtocolFamilyIPv4, nil
+	case 6:
+		return ProtocolFamilyIPv6Linux, nil
+	default:
+		return 0, fmt.Errorf("Unknown protocol version %d", version)
+	}
+}
+
+// Decode a raw v4 or v6 IP packet.
+func decodeRawIP(data []byte, p gopacket.PacketBuilder) error {
+	family, err := versionToFamily(data[0] >> 4)
+	if err != nil {
+		return err
+	}
+	r := &Raw{
+		BaseLayer: BaseLayer{make([]byte, 0), data},
+		Family:    family,
+	}
+	p.AddLayer(r)
+	return p.NextDecoder(r.Family)
+}

--- a/layers/raw_test.go
+++ b/layers/raw_test.go
@@ -1,0 +1,52 @@
+// Copyright 2017 The GoPacket Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file in the root of the source
+// tree.
+
+package layers
+
+import (
+	"testing"
+
+	"github.com/google/gopacket"
+)
+
+// testPacketRawICMP4 is the packet:
+//   12:13:21.217957 IP 10.8.254.8 > 8.8.8.8: ICMP echo request, id 20348, seq 1, length 64
+//   	0x0000:  4500 0054 1530 4000 4001 0d59 0a08 fe08  E..T.0@.@..Y....
+//   	0x0010:  0808 0808 0800 d81d 4f7c 0001 e1e5 3059  ........O|....0Y
+//   	0x0020:  0000 0000 fc52 0300 0000 0000 1011 1213  .....R..........
+//   	0x0030:  1415 1617 1819 1a1b 1c1d 1e1f 2021 2223  .............!"#
+//   	0x0040:  2425 2627 2829 2a2b 2c2d 2e2f 3031 3233  $%&'()*+,-./0123
+//   	0x0050:  3435 3637                                4567
+var testPacketRawICMP4 = []byte{
+	0x45, 0x00, 0x00, 0x54, 0x15, 0x30, 0x40, 0x00, 0x40, 0x01, 0x0d, 0x59, 0x0a, 0x08, 0xfe, 0x08,
+	0x08, 0x08, 0x08, 0x08, 0x08, 0x00, 0xd8, 0x1d, 0x4f, 0x7c, 0x00, 0x01, 0xe1, 0xe5, 0x30, 0x59,
+	0x00, 0x00, 0x00, 0x00, 0xfc, 0x52, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x11, 0x12, 0x13,
+	0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20, 0x21, 0x22, 0x23,
+	0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f, 0x30, 0x31, 0x32, 0x33,
+	0x34, 0x35, 0x36, 0x37,
+}
+
+func TestPacketRawIPICMPv4(t *testing.T) {
+	p := gopacket.NewPacket(testPacketRawICMP4, LinkTypeRaw, gopacket.Default)
+	if p.ErrorLayer() != nil {
+		t.Error("Failed to decode packet:", p.ErrorLayer().Error())
+	}
+	checkLayers(p, []gopacket.LayerType{LayerTypeRaw, LayerTypeIPv4, LayerTypeICMPv4, gopacket.LayerTypePayload}, t)
+	// If ICMPv4 is found we most likely parse at the right offset. Skip detailed tests. Just verify
+	// that the Contents of the BaseLayer is an empty array
+	if got, ok := p.Layer(LayerTypeRaw).(*Raw); ok {
+		if len(got.BaseLayer.Contents) != 0 {
+			t.Error("RAW layer not empty", len(got.BaseLayer.Contents))
+		}
+	} else {
+		t.Error("RAW packet processing failed to get right layer")
+	}
+}
+func BenchmarkDecodePacketRawIPICMPv4(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		gopacket.NewPacket(testPacketRawICMP4, LinkTypeRaw, gopacket.NoCopy)
+	}
+}

--- a/layers/tcpip_test.go
+++ b/layers/tcpip_test.go
@@ -78,7 +78,7 @@ func TestIPv4UDPChecksum(t *testing.T) {
 	if p.ErrorLayer() != nil {
 		t.Fatal("Failed to decode packet:", p.ErrorLayer().Error())
 	}
-	checkLayers(p, []gopacket.LayerType{LayerTypeIPv4, LayerTypeUDP}, t)
+	checkLayers(p, []gopacket.LayerType{LayerTypeRaw, LayerTypeIPv4, LayerTypeUDP}, t)
 
 	if l, ok := p.Layer(LayerTypeUDP).(*UDP); !ok {
 		t.Fatal("No UDP layer type found in packet")
@@ -120,7 +120,7 @@ func TestIPv6UDPChecksumWithIPv6DstOpts(t *testing.T) {
 	if p.ErrorLayer() != nil {
 		t.Fatal("Failed to decode packet:", p.ErrorLayer().Error())
 	}
-	checkLayers(p, []gopacket.LayerType{LayerTypeIPv6, LayerTypeIPv6Destination, LayerTypeUDP}, t)
+	checkLayers(p, []gopacket.LayerType{LayerTypeRaw, LayerTypeIPv6, LayerTypeIPv6Destination, LayerTypeUDP}, t)
 
 	if l, ok := p.Layer(LayerTypeUDP).(*UDP); !ok {
 		t.Fatal("No UDP layer type found in packet")
@@ -170,7 +170,7 @@ func TestIPv6JumbogramUDPChecksum(t *testing.T) {
 	if p.ErrorLayer() != nil {
 		t.Fatal("Failed to decode packet:", p.ErrorLayer().Error())
 	}
-	checkLayers(p, []gopacket.LayerType{LayerTypeIPv6, LayerTypeIPv6HopByHop, LayerTypeUDP, gopacket.LayerTypePayload}, t)
+	checkLayers(p, []gopacket.LayerType{LayerTypeRaw, LayerTypeIPv6, LayerTypeIPv6HopByHop, LayerTypeUDP, gopacket.LayerTypePayload}, t)
 
 	if l, ok := p.Layer(LayerTypeUDP).(*UDP); !ok {
 		t.Fatal("No UDP layer type found in packet")


### PR DESCRIPTION
For Elasticsearch's packetbeat it is necessary to expose a LayerTypeRaw. Correct the LinkTypeRaw for mainstream platforms and add a LayerTpeRaw. Update the tests that use LinkTypeRaw right now.