### PR TITLE
Fix eap packet parsing

### DIFF
--- a/layers/eapol.go
+++ b/layers/eapol.go
@@ -7,6 +7,7 @@
 package layers
 
 import (
+	"encoding/binary"
 	"github.com/google/gopacket"
 )
 

--- a/layers/eapol.go
+++ b/layers/eapol.go
@@ -16,7 +16,7 @@ type EAPOL struct {
 	BaseLayer
 	Version uint8
 	Type    EAPOLType
-    Length  uint16
+	Length  uint16
 }
 
 // LayerType returns LayerTypeEAPOL.
@@ -26,7 +26,7 @@ func (e *EAPOL) LayerType() gopacket.LayerType { return LayerTypeEAPOL }
 func (e *EAPOL) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 	e.Version = data[0]
 	e.Type = EAPOLType(data[1])
-    e.Length = binary.BigEndian.Uint16(data[2:4])
+	e.Length = binary.BigEndian.Uint16(data[2:4])
 	e.BaseLayer = BaseLayer{data[:4], data[4:]}
 	return nil
 }
@@ -34,11 +34,11 @@ func (e *EAPOL) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 // SerializeTo writes the serialized form of this layer into the
 // SerializationBuffer, implementing gopacket.SerializableLayer
 func (e *EAPOL) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeOptions) error {
-    bytes, _ := b.PrependBytes(4)
-    bytes[0] = e.Version
-    bytes[1] = byte(e.Type)
-    binary.BigEndian.PutUint16(bytes[2:], e.Length)
-    return nil
+	bytes, _ := b.PrependBytes(4)
+	bytes[0] = e.Version
+	bytes[1] = byte(e.Type)
+	binary.BigEndian.PutUint16(bytes[2:], e.Length)
+	return nil
 }
 
 // CanDecode returns the set of layer types that this DecodingLayer can decode.

--- a/layers/eapol.go
+++ b/layers/eapol.go
@@ -15,6 +15,7 @@ type EAPOL struct {
 	BaseLayer
 	Version uint8
 	Type    EAPOLType
+    Length  uint16
 }
 
 // LayerType returns LayerTypeEAPOL.
@@ -24,8 +25,19 @@ func (e *EAPOL) LayerType() gopacket.LayerType { return LayerTypeEAPOL }
 func (e *EAPOL) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 	e.Version = data[0]
 	e.Type = EAPOLType(data[1])
-	e.BaseLayer = BaseLayer{data[:2], data[2:]}
+    e.Length = binary.BigEndian.Uint16(data[2:4])
+	e.BaseLayer = BaseLayer{data[:4], data[4:]}
 	return nil
+}
+
+// SerializeTo writes the serialized form of this layer into the
+// SerializationBuffer, implementing gopacket.SerializableLayer
+func (e *EAPOL) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeOptions) error {
+    bytes, _ := b.PrependBytes(4)
+    bytes[0] = e.Version
+    bytes[1] = byte(e.Type)
+    binary.BigEndian.PutUint16(bytes[2:], e.Length)
+    return nil
 }
 
 // CanDecode returns the set of layer types that this DecodingLayer can decode.


### PR DESCRIPTION
The current version of the EAPOL layer does not parse EAPOL packets with length properly. It ignores the Length parameter and attempts to parse the data starting at the Length parameter. This change found in issue #249 fixes the issue and parses EAPOL/EAP packets properly.