### PR TITLE
fixing memory leak in reassembly

### DIFF
--- a/reassembly/memory.go
+++ b/reassembly/memory.go
@@ -170,8 +170,10 @@ func (p *StreamPool) Dump() {
 
 func (p *StreamPool) remove(conn *connection) {
 	p.mu.Lock()
-	delete(p.conns, conn.key)
-	p.free = append(p.free, conn)
+	if _, ok := p.conns[conn.key]; ok {
+		delete(p.conns, conn.key)
+		p.free = append(p.free, conn)
+	}
 	p.mu.Unlock()
 }
 


### PR DESCRIPTION
Using reassmbly to reassemble tcp connections in large pcap files I noticed an increasing usage of memory. I'm not sure why, but it seems that `(p *StreamPool) remove()` is executed multiple times for the same connection, when `ReassemblyComplete()` returns `true`.

In this case deleting the connection from `p.conns` does nothing, but the connection is added multiple times to `p.free`.

This pull request provides functionality to avoid this duplicates in `p.free` by checking if the given connection is available in `p.conns`.