### PR TITLE
More elegant solution for decodeExtendedRouterFlowRecord

### DIFF
--- a/layers/sflow.go
+++ b/layers/sflow.go
@@ -1047,21 +1047,13 @@ type SFlowExtendedRouterFlowRecord struct {
 func decodeExtendedRouterFlowRecord(data *[]byte) (SFlowExtendedRouterFlowRecord, error) {
 	er := SFlowExtendedRouterFlowRecord{}
 	var fdf SFlowFlowDataFormat
-	var ipType uint32
+	var extendedRouterAddressType SFlowIPType
 
 	*data, fdf = (*data)[4:], SFlowFlowDataFormat(binary.BigEndian.Uint32((*data)[:4]))
 	er.EnterpriseID, er.Format = fdf.decode()
 	*data, er.FlowDataLength = (*data)[4:], binary.BigEndian.Uint32((*data)[:4])
-	*data, ipType = (*data)[4:], binary.BigEndian.Uint32((*data)[:4])
-
-	if ipType == 1 {
-		*data, er.NextHop = (*data)[4:], (*data)[:4]
-	} else if ipType == 2 {
-		*data, er.NextHop = (*data)[16:], (*data)[:16]
-	} else {
-		return er, fmt.Errorf("Unknown Next Hop IP type: %d", ipType)
-	}
-
+	*data, extendedRouterAddressType = (*data)[4:], SFlowIPType(binary.BigEndian.Uint32((*data)[:4]))
+	*data, er.NextHop = (*data)[extendedRouterAddressType.Length():], (*data)[:extendedRouterAddressType.Length()]
 	*data, er.NextHopSourceMask = (*data)[4:], binary.BigEndian.Uint32((*data)[:4])
 	*data, er.NextHopDestinationMask = (*data)[4:], binary.BigEndian.Uint32((*data)[:4])
 	return er, nil
@@ -1073,7 +1065,7 @@ func decodeExtendedRouterFlowRecord(data *[]byte) (SFlowExtendedRouterFlowRecord
 // This information is vital because it gives a picture of how much
 // traffic is being sent from / received by various BGP peers.
 
-// Extended gatway records have the following structure:
+// Extended gateway records have the following structure:
 
 //  0                      15                      31
 //  +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
@@ -1081,7 +1073,10 @@ func decodeExtendedRouterFlowRecord(data *[]byte) (SFlowExtendedRouterFlowRecord
 //  +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
 //  |                  record length                |
 //  +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
-//  |                    Next Hop                   |
+//  |   IP version of next hop router (1=v4|2=v6)   |
+//  +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+//  /     Next Hop address (v4=4byte|v6=16byte)     /
+//  /                                               /
 //  +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
 //  |                       AS                      |
 //  +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+


### PR DESCRIPTION
PR #342 fixed a bug in layers/sflow.go `decodeExtendedRouterFlowRecord` that missed decoding the address.  The initial patch was accepted, but was not very elegant.  In that PR, @safchain requested that I also fix the issue in for decoding `SFlowExtendedGatewayFlowRecord`.  Upon examination, the in-code documentation did not show the field, but the actual decode block did the correct thing.  That is also where the more elegant solution below came from (Thanks @actaeon).

This PR:
* Changes the address type detection to follow existing methods (using `SFlowIPType`)
* Updates the documented Extended gateway records structure to match the implementation