### PR TITLE
fix nfds error in select statement

### DIFF
--- a/pcap/pcap_unix.go
+++ b/pcap/pcap_unix.go
@@ -32,11 +32,11 @@ int pcap_wait(pcap_t *p, int usec) {
 	tv.tv_usec = usec;
 
 	if(usec != 0) {
-		return select(1, &fds, NULL, NULL, &tv);
+		return select(fd+1, &fds, NULL, NULL, &tv);
 	}
 
 	// block indefinitely if no timeout provided
-	return select(1, &fds, NULL, NULL, NULL);
+	return select(fd+1, &fds, NULL, NULL, NULL);
 }
 */
 import "C"


### PR DESCRIPTION
From man page for select "nfds should be set to the highest-numbered
file descriptor in any of the three sets, plus 1". This was causing
one of our apps to never capture packets as the fd returned by
pcap_get_selectable_fd was 8 and then never checked.