### PR TITLE
Fix handling of SCTP type data

### DIFF
--- a/layers/decode_test.go
+++ b/layers/decode_test.go
@@ -594,9 +594,9 @@ func TestDecodeSCTPPackets(t *testing.T) {
 	wantLayers := [][]gopacket.LayerType{
 		[]gopacket.LayerType{LayerTypeSCTPInit},
 		[]gopacket.LayerType{LayerTypeSCTPInitAck},
-		[]gopacket.LayerType{LayerTypeSCTPCookieEcho, LayerTypeSCTPData, gopacket.LayerTypePayload},
+		[]gopacket.LayerType{LayerTypeSCTPCookieEcho, LayerTypeSCTPData},
 		[]gopacket.LayerType{LayerTypeSCTPCookieAck, LayerTypeSCTPSack},
-		[]gopacket.LayerType{LayerTypeSCTPData, gopacket.LayerTypePayload},
+		[]gopacket.LayerType{LayerTypeSCTPData},
 		[]gopacket.LayerType{LayerTypeSCTPSack},
 		[]gopacket.LayerType{LayerTypeSCTPShutdown},
 		[]gopacket.LayerType{LayerTypeSCTPShutdownAck},

--- a/layers/sctp.go
+++ b/layers/sctp.go
@@ -300,14 +300,11 @@ func decodeSCTPData(data []byte, p gopacket.PacketBuilder) error {
 	}
 
 	if sc.PayloadProtocol == 0 {
-		sc.Payload = make([]byte, sc.SCTPChunk.Length-16)
-		copy(sc.Payload, data[16:sc.SCTPChunk.Length+1])
-		// Length is the length in bytes of the data, INCLUDING the 16-byte header.
+		sc.Payload = data[16 : sc.SCTPChunk.Length+1]
 		p.AddLayer(sc)
 		return p.NextDecoder(gopacket.DecodeFunc(decodeWithSCTPChunkTypePrefix))
 	}
 
-	// Length is the length in bytes of the data, INCLUDING the 16-byte header.
 	p.AddLayer(sc)
 	return p.NextDecoder(gopacket.LayerTypePayload)
 


### PR DESCRIPTION
Signed-off-by: Lehner Florian <dev@der-flo.net>

This patch fixes the design issue mentioned in https://github.com/google/gopacket/issues/347. It allows the nesting of SCTP data chunks. The payload of a data chunk is stored inside a []byte within the SCTPData struct.
