### PR TITLE
Add internal testing function for ports to udp (copied from tcp)

### DIFF
--- a/layers/udp.go
+++ b/layers/udp.go
@@ -118,3 +118,11 @@ func decodeUDP(data []byte, p gopacket.PacketBuilder) error {
 func (u *UDP) TransportFlow() gopacket.Flow {
 	return gopacket.NewFlow(EndpointUDPPort, u.sPort, u.dPort)
 }
+
+// For testing only
+func (u *UDP) SetInternalPortsForTesting() {
+	u.sPort = make([]byte, 2)
+	u.dPort = make([]byte, 2)
+	binary.BigEndian.PutUint16(u.sPort, uint16(u.SrcPort))
+	binary.BigEndian.PutUint16(u.dPort, uint16(u.DstPort))
+}


### PR DESCRIPTION
This is needed to provide a way for setting sPort and dPort.
Without this function one cannot create a UDP-Layer as suggested by https://godoc.org/github.com/google/gopacket#hdr-Creating_Packet_Data and then use TransportFlow() on it (well actually one can - but the endpoints are zero as a result).