### PR TITLE
Extend pcap API

### DIFF
--- a/pcap/pcap.go
+++ b/pcap/pcap.go
@@ -125,6 +125,9 @@ import (
 
 const errorBufferSize = 256
 
+// ErrNotActive is returned if handle is not activated
+const ErrNotActive = int(C.PCAP_ERROR_NOT_ACTIVATED)
+
 // MaxBpfInstructions is the maximum number of BPF instructions supported (BPF_MAXINSNS),
 // taken from Linux kernel: include/uapi/linux/bpf_common.h
 //
@@ -840,6 +843,12 @@ func (p *Handle) SetDirection(direction Direction) error {
 		return statusError(status)
 	}
 	return nil
+}
+
+// SnapLen returns the snapshot length
+func (p *Handle) SnapLen() int {
+	len := C.pcap_snapshot(p.cptr)
+	return int(len)
 }
 
 // TimestampSource tells PCAP which type of timestamp to use for packets.


### PR DESCRIPTION
Signed-off-by: Lehner Florian <dev@der-flo.net>

This patch extends the API by `SnapLen()` and `pcap.ErrNotActive`.

Here is a little coding example:

```
package main

import (
	"fmt"
	"github.com/google/gopacket/pcap"
)

func main() {
	inh, err := pcap.NewInactiveHandle("wlp3s0")
	if err != nil {
		fmt.Printf("Could not create a new inactive Handle: %v\n", err)
		return
	}
	defer inh.CleanUp()

	if err := inh.SetSnapLen(4096); err != nil {
		fmt.Printf("Could not set snapshotlength to 4096: %v\n", err)
		return
	}
	handle, err := inh.Activate()
	if err != nil {
		fmt.Printf("Could not activate Handle: %v\n", err)
		return
	}
	defer handle.Close()

	fmt.Println("Snapshotlength: ", handle.SnapLen())
	fmt.Println("Error: ", pcap.ErrNotActive)
}

```