### PR TITLE
Utilize some trickiness to reduce init memory usage in enums.

### DIFF
--- a/gc
+++ b/gc
@@ -106,6 +106,7 @@ if [ ! -z "$GEN" ]; then
   popd
   pushd layers
   go run gen.go | gofmt > iana_ports.go
+  go run gen2.go | gofmt > enums_generated.go
   popd
 fi
 

--- a/layers/enums.go
+++ b/layers/enums.go
@@ -272,107 +272,6 @@ const (
 	Dot11TypeDataQOSCFAckPollNoData Dot11Type = 0x3e
 )
 
-var (
-	// Each of the following arrays contains mappings of how to handle enum
-	// values for various enum types in gopacket/layers.
-	//
-	// So, EthernetTypeMetadata[2] contains information on how to handle EthernetType
-	// 2, including which name to give it and which decoder to use to decode
-	// packet data of that type.  These arrays are filled by default with all of the
-	// protocols gopacket/layers knows how to handle, but users of the library can
-	// add new decoders or override existing ones.  For example, if you write a better
-	// TCP decoder, you can override IPProtocolMetadata[IPProtocolTCP].DecodeWith
-	// with your new decoder, and all gopacket/layers decoding will use your new
-	// decoder whenever they encounter that IPProtocol.
-	EthernetTypeMetadata     [65536]EnumMetadata
-	IPProtocolMetadata       [256]EnumMetadata
-	SCTPChunkTypeMetadata    [256]EnumMetadata
-	PPPTypeMetadata          [65536]EnumMetadata
-	PPPoECodeMetadata        [256]EnumMetadata
-	LinkTypeMetadata         [256]EnumMetadata
-	FDDIFrameControlMetadata [256]EnumMetadata
-	EAPOLTypeMetadata        [256]EnumMetadata
-	ProtocolFamilyMetadata   [256]EnumMetadata
-	Dot11TypeMetadata        [256]EnumMetadata
-	USBTypeMetadata          [256]EnumMetadata
-)
-
-func (a EthernetType) Decode(data []byte, p gopacket.PacketBuilder) error {
-	return EthernetTypeMetadata[a].DecodeWith.Decode(data, p)
-}
-func (a EthernetType) String() string {
-	return EthernetTypeMetadata[a].Name
-}
-func (a EthernetType) LayerType() gopacket.LayerType {
-	return EthernetTypeMetadata[a].LayerType
-}
-func (a IPProtocol) Decode(data []byte, p gopacket.PacketBuilder) error {
-	return IPProtocolMetadata[a].DecodeWith.Decode(data, p)
-}
-func (a IPProtocol) String() string {
-	return IPProtocolMetadata[a].Name
-}
-func (a IPProtocol) LayerType() gopacket.LayerType {
-	return IPProtocolMetadata[a].LayerType
-}
-func (a SCTPChunkType) Decode(data []byte, p gopacket.PacketBuilder) error {
-	return SCTPChunkTypeMetadata[a].DecodeWith.Decode(data, p)
-}
-func (a SCTPChunkType) String() string {
-	return SCTPChunkTypeMetadata[a].Name
-}
-func (a PPPType) Decode(data []byte, p gopacket.PacketBuilder) error {
-	return PPPTypeMetadata[a].DecodeWith.Decode(data, p)
-}
-func (a PPPType) String() string {
-	return PPPTypeMetadata[a].Name
-}
-func (a LinkType) Decode(data []byte, p gopacket.PacketBuilder) error {
-	return LinkTypeMetadata[a].DecodeWith.Decode(data, p)
-}
-func (a LinkType) String() string {
-	return LinkTypeMetadata[a].Name
-}
-func (a PPPoECode) Decode(data []byte, p gopacket.PacketBuilder) error {
-	return PPPoECodeMetadata[a].DecodeWith.Decode(data, p)
-}
-func (a PPPoECode) String() string {
-	return PPPoECodeMetadata[a].Name
-}
-func (a FDDIFrameControl) Decode(data []byte, p gopacket.PacketBuilder) error {
-	return FDDIFrameControlMetadata[a].DecodeWith.Decode(data, p)
-}
-func (a FDDIFrameControl) String() string {
-	return FDDIFrameControlMetadata[a].Name
-}
-func (a EAPOLType) Decode(data []byte, p gopacket.PacketBuilder) error {
-	return EAPOLTypeMetadata[a].DecodeWith.Decode(data, p)
-}
-func (a EAPOLType) String() string {
-	return EAPOLTypeMetadata[a].Name
-}
-func (a EAPOLType) LayerType() gopacket.LayerType {
-	return EAPOLTypeMetadata[a].LayerType
-}
-func (a ProtocolFamily) Decode(data []byte, p gopacket.PacketBuilder) error {
-	return ProtocolFamilyMetadata[a].DecodeWith.Decode(data, p)
-}
-func (a ProtocolFamily) String() string {
-	return ProtocolFamilyMetadata[a].Name
-}
-func (a ProtocolFamily) LayerType() gopacket.LayerType {
-	return ProtocolFamilyMetadata[a].LayerType
-}
-func (a Dot11Type) Decode(data []byte, p gopacket.PacketBuilder) error {
-	return Dot11TypeMetadata[a].DecodeWith.Decode(data, p)
-}
-func (a Dot11Type) String() string {
-	return Dot11TypeMetadata[a].Name
-}
-func (a Dot11Type) LayerType() gopacket.LayerType {
-	return Dot11TypeMetadata[a].LayerType
-}
-
 // Decode a raw v4 or v6 IP packet.
 func decodeIPv4or6(data []byte, p gopacket.PacketBuilder) error {
 	version := data[0] >> 4
@@ -385,53 +284,22 @@ func decodeIPv4or6(data []byte, p gopacket.PacketBuilder) error {
 	return fmt.Errorf("Invalid IP packet version %v", version)
 }
 
-func init() {
-	// Here we link up all enumerations with their respective names and decoders.
-	for i := 0; i < 65536; i++ {
-		EthernetTypeMetadata[i] = EnumMetadata{
-			DecodeWith: errorFunc(fmt.Sprintf("Unable to decode ethernet type %d", i)),
-			Name:       fmt.Sprintf("UnknownEthernetType(%d)", i),
-		}
-		PPPTypeMetadata[i] = EnumMetadata{
-			DecodeWith: errorFunc(fmt.Sprintf("Unable to decode PPP type %d", i)),
-			Name:       fmt.Sprintf("UnknownPPPType(%d)", i),
-		}
-	}
-	for i := 0; i < 256; i++ {
-		IPProtocolMetadata[i] = EnumMetadata{
-			DecodeWith: errorFunc(fmt.Sprintf("Unable to decode IP protocol %d", i)),
-			Name:       fmt.Sprintf("UnknownIPProtocol(%d)", i),
-		}
-		SCTPChunkTypeMetadata[i] = EnumMetadata{
-			DecodeWith: errorFunc(fmt.Sprintf("Unable to decode SCTP chunk type %d", i)),
-			Name:       fmt.Sprintf("UnknownSCTPChunkType(%d)", i),
-		}
-		PPPoECodeMetadata[i] = EnumMetadata{
-			DecodeWith: errorFunc(fmt.Sprintf("Unable to decode PPPoE code %d", i)),
-			Name:       fmt.Sprintf("UnknownPPPoECode(%d)", i),
-		}
-		LinkTypeMetadata[i] = EnumMetadata{
-			DecodeWith: errorFunc(fmt.Sprintf("Unable to decode link type %d", i)),
-			Name:       fmt.Sprintf("UnknownLinkType(%d)", i),
-		}
-		FDDIFrameControlMetadata[i] = EnumMetadata{
-			DecodeWith: errorFunc(fmt.Sprintf("Unable to decode FDDI frame control %d", i)),
-			Name:       fmt.Sprintf("UnknownFDDIFrameControl(%d)", i),
-		}
-		EAPOLTypeMetadata[i] = EnumMetadata{
-			DecodeWith: errorFunc(fmt.Sprintf("Unable to decode EAPOL type %d", i)),
-			Name:       fmt.Sprintf("UnknownEAPOLType(%d)", i),
-		}
-		ProtocolFamilyMetadata[i] = EnumMetadata{
-			DecodeWith: errorFunc(fmt.Sprintf("Unable to decode protocol family %d", i)),
-			Name:       fmt.Sprintf("UnknownProtocolFamily(%d)", i),
-		}
-		Dot11TypeMetadata[i] = EnumMetadata{
-			DecodeWith: errorFunc(fmt.Sprintf("Unable to decode Dot11 type %d", i)),
-			Name:       fmt.Sprintf("UnknownDot11Type(%d)", i),
-		}
-	}
+func initActualTypeData() {
+	// Each of the XXXTypeMetadata arrays contains mappings of how to handle enum
+	// values for various enum types in gopacket/layers.
+	// These arrays are actually created by gen2.go and stored in
+	// enums_generated.go.
+	//
+	// So, EthernetTypeMetadata[2] contains information on how to handle EthernetType
+	// 2, including which name to give it and which decoder to use to decode
+	// packet data of that type.  These arrays are filled by default with all of the
+	// protocols gopacket/layers knows how to handle, but users of the library can
+	// add new decoders or override existing ones.  For example, if you write a better
+	// TCP decoder, you can override IPProtocolMetadata[IPProtocolTCP].DecodeWith
+	// with your new decoder, and all gopacket/layers decoding will use your new
+	// decoder whenever they encounter that IPProtocol.
 
+	// Here we link up all enumerations with their respective names and decoders.
 	EthernetTypeMetadata[EthernetTypeLLC] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeLLC), Name: "LLC", LayerType: LayerTypeLLC}
 	EthernetTypeMetadata[EthernetTypeIPv4] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeIPv4), Name: "IPv4", LayerType: LayerTypeIPv4}
 	EthernetTypeMetadata[EthernetTypeIPv6] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeIPv6), Name: "IPv6", LayerType: LayerTypeIPv6}
@@ -558,7 +426,7 @@ func init() {
 	Dot11TypeMetadata[Dot11TypeDataQOSCFPollNoData] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeDot11DataQOSCFPollNoData), Name: "DataQOSCFPollNoData", LayerType: LayerTypeDot11DataQOSCFPollNoData}
 	Dot11TypeMetadata[Dot11TypeDataQOSCFAckPollNoData] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeDot11DataQOSCFAckPollNoData), Name: "DataQOSCFAckPollNoData", LayerType: LayerTypeDot11DataQOSCFAckPollNoData}
 
-	USBTypeMetadata[USBTransportTypeInterrupt] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeUSBInterrupt), Name: "Interrupt", LayerType: LayerTypeUSBInterrupt}
-	USBTypeMetadata[USBTransportTypeControl] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeUSBControl), Name: "Control", LayerType: LayerTypeUSBControl}
-	USBTypeMetadata[USBTransportTypeBulk] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeUSBBulk), Name: "Bulk", LayerType: LayerTypeUSBBulk}
+	USBTransportTypeMetadata[USBTransportTypeInterrupt] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeUSBInterrupt), Name: "Interrupt", LayerType: LayerTypeUSBInterrupt}
+	USBTransportTypeMetadata[USBTransportTypeControl] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeUSBControl), Name: "Control", LayerType: LayerTypeUSBControl}
+	USBTransportTypeMetadata[USBTransportTypeBulk] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeUSBBulk), Name: "Bulk", LayerType: LayerTypeUSBBulk}
 }

--- a/layers/enums_generated.go
+++ b/layers/enums_generated.go
@@ -3,7 +3,7 @@
 package layers
 
 // Created by gen2.go, don't edit manually
-// Generated at 2017-10-23 10:13:41.708259103 -0600 MDT m=+0.001033329
+// Generated at 2017-10-23 10:20:24.458771856 -0600 MDT m=+0.001159033
 
 import (
 	"fmt"
@@ -26,12 +26,17 @@ func init() {
 	initActualTypeData()
 }
 
+// Decoder calls LinkTypeMetadata.DecodeWith's decoder.
 func (a LinkType) Decode(data []byte, p gopacket.PacketBuilder) error {
 	return LinkTypeMetadata[a].DecodeWith.Decode(data, p)
 }
+
+// String returns LinkTypeMetadata.Name.
 func (a LinkType) String() string {
 	return LinkTypeMetadata[a].Name
 }
+
+// LayerType returns LinkTypeMetadata.LayerType.
 func (a LinkType) LayerType() gopacket.LayerType {
 	return LinkTypeMetadata[a].LayerType
 }
@@ -58,12 +63,17 @@ func initUnknownTypesForLinkType() {
 	}
 }
 
+// Decoder calls EthernetTypeMetadata.DecodeWith's decoder.
 func (a EthernetType) Decode(data []byte, p gopacket.PacketBuilder) error {
 	return EthernetTypeMetadata[a].DecodeWith.Decode(data, p)
 }
+
+// String returns EthernetTypeMetadata.Name.
 func (a EthernetType) String() string {
 	return EthernetTypeMetadata[a].Name
 }
+
+// LayerType returns EthernetTypeMetadata.LayerType.
 func (a EthernetType) LayerType() gopacket.LayerType {
 	return EthernetTypeMetadata[a].LayerType
 }
@@ -90,12 +100,17 @@ func initUnknownTypesForEthernetType() {
 	}
 }
 
+// Decoder calls PPPTypeMetadata.DecodeWith's decoder.
 func (a PPPType) Decode(data []byte, p gopacket.PacketBuilder) error {
 	return PPPTypeMetadata[a].DecodeWith.Decode(data, p)
 }
+
+// String returns PPPTypeMetadata.Name.
 func (a PPPType) String() string {
 	return PPPTypeMetadata[a].Name
 }
+
+// LayerType returns PPPTypeMetadata.LayerType.
 func (a PPPType) LayerType() gopacket.LayerType {
 	return PPPTypeMetadata[a].LayerType
 }
@@ -122,12 +137,17 @@ func initUnknownTypesForPPPType() {
 	}
 }
 
+// Decoder calls IPProtocolMetadata.DecodeWith's decoder.
 func (a IPProtocol) Decode(data []byte, p gopacket.PacketBuilder) error {
 	return IPProtocolMetadata[a].DecodeWith.Decode(data, p)
 }
+
+// String returns IPProtocolMetadata.Name.
 func (a IPProtocol) String() string {
 	return IPProtocolMetadata[a].Name
 }
+
+// LayerType returns IPProtocolMetadata.LayerType.
 func (a IPProtocol) LayerType() gopacket.LayerType {
 	return IPProtocolMetadata[a].LayerType
 }
@@ -154,12 +174,17 @@ func initUnknownTypesForIPProtocol() {
 	}
 }
 
+// Decoder calls SCTPChunkTypeMetadata.DecodeWith's decoder.
 func (a SCTPChunkType) Decode(data []byte, p gopacket.PacketBuilder) error {
 	return SCTPChunkTypeMetadata[a].DecodeWith.Decode(data, p)
 }
+
+// String returns SCTPChunkTypeMetadata.Name.
 func (a SCTPChunkType) String() string {
 	return SCTPChunkTypeMetadata[a].Name
 }
+
+// LayerType returns SCTPChunkTypeMetadata.LayerType.
 func (a SCTPChunkType) LayerType() gopacket.LayerType {
 	return SCTPChunkTypeMetadata[a].LayerType
 }
@@ -186,12 +211,17 @@ func initUnknownTypesForSCTPChunkType() {
 	}
 }
 
+// Decoder calls PPPoECodeMetadata.DecodeWith's decoder.
 func (a PPPoECode) Decode(data []byte, p gopacket.PacketBuilder) error {
 	return PPPoECodeMetadata[a].DecodeWith.Decode(data, p)
 }
+
+// String returns PPPoECodeMetadata.Name.
 func (a PPPoECode) String() string {
 	return PPPoECodeMetadata[a].Name
 }
+
+// LayerType returns PPPoECodeMetadata.LayerType.
 func (a PPPoECode) LayerType() gopacket.LayerType {
 	return PPPoECodeMetadata[a].LayerType
 }
@@ -218,12 +248,17 @@ func initUnknownTypesForPPPoECode() {
 	}
 }
 
+// Decoder calls FDDIFrameControlMetadata.DecodeWith's decoder.
 func (a FDDIFrameControl) Decode(data []byte, p gopacket.PacketBuilder) error {
 	return FDDIFrameControlMetadata[a].DecodeWith.Decode(data, p)
 }
+
+// String returns FDDIFrameControlMetadata.Name.
 func (a FDDIFrameControl) String() string {
 	return FDDIFrameControlMetadata[a].Name
 }
+
+// LayerType returns FDDIFrameControlMetadata.LayerType.
 func (a FDDIFrameControl) LayerType() gopacket.LayerType {
 	return FDDIFrameControlMetadata[a].LayerType
 }
@@ -250,12 +285,17 @@ func initUnknownTypesForFDDIFrameControl() {
 	}
 }
 
+// Decoder calls EAPOLTypeMetadata.DecodeWith's decoder.
 func (a EAPOLType) Decode(data []byte, p gopacket.PacketBuilder) error {
 	return EAPOLTypeMetadata[a].DecodeWith.Decode(data, p)
 }
+
+// String returns EAPOLTypeMetadata.Name.
 func (a EAPOLType) String() string {
 	return EAPOLTypeMetadata[a].Name
 }
+
+// LayerType returns EAPOLTypeMetadata.LayerType.
 func (a EAPOLType) LayerType() gopacket.LayerType {
 	return EAPOLTypeMetadata[a].LayerType
 }
@@ -282,12 +322,17 @@ func initUnknownTypesForEAPOLType() {
 	}
 }
 
+// Decoder calls ProtocolFamilyMetadata.DecodeWith's decoder.
 func (a ProtocolFamily) Decode(data []byte, p gopacket.PacketBuilder) error {
 	return ProtocolFamilyMetadata[a].DecodeWith.Decode(data, p)
 }
+
+// String returns ProtocolFamilyMetadata.Name.
 func (a ProtocolFamily) String() string {
 	return ProtocolFamilyMetadata[a].Name
 }
+
+// LayerType returns ProtocolFamilyMetadata.LayerType.
 func (a ProtocolFamily) LayerType() gopacket.LayerType {
 	return ProtocolFamilyMetadata[a].LayerType
 }
@@ -314,12 +359,17 @@ func initUnknownTypesForProtocolFamily() {
 	}
 }
 
+// Decoder calls Dot11TypeMetadata.DecodeWith's decoder.
 func (a Dot11Type) Decode(data []byte, p gopacket.PacketBuilder) error {
 	return Dot11TypeMetadata[a].DecodeWith.Decode(data, p)
 }
+
+// String returns Dot11TypeMetadata.Name.
 func (a Dot11Type) String() string {
 	return Dot11TypeMetadata[a].Name
 }
+
+// LayerType returns Dot11TypeMetadata.LayerType.
 func (a Dot11Type) LayerType() gopacket.LayerType {
 	return Dot11TypeMetadata[a].LayerType
 }
@@ -346,12 +396,17 @@ func initUnknownTypesForDot11Type() {
 	}
 }
 
+// Decoder calls USBTransportTypeMetadata.DecodeWith's decoder.
 func (a USBTransportType) Decode(data []byte, p gopacket.PacketBuilder) error {
 	return USBTransportTypeMetadata[a].DecodeWith.Decode(data, p)
 }
+
+// String returns USBTransportTypeMetadata.Name.
 func (a USBTransportType) String() string {
 	return USBTransportTypeMetadata[a].Name
 }
+
+// LayerType returns USBTransportTypeMetadata.LayerType.
 func (a USBTransportType) LayerType() gopacket.LayerType {
 	return USBTransportTypeMetadata[a].LayerType
 }

--- a/layers/enums_generated.go
+++ b/layers/enums_generated.go
@@ -1,0 +1,379 @@
+// Copyright 2012 Google, Inc. All rights reserved.
+
+package layers
+
+// Created by gen2.go, don't edit manually
+// Generated at 2017-10-23 10:13:41.708259103 -0600 MDT m=+0.001033329
+
+import (
+	"fmt"
+
+	"github.com/google/gopacket"
+)
+
+func init() {
+	initUnknownTypesForLinkType()
+	initUnknownTypesForEthernetType()
+	initUnknownTypesForPPPType()
+	initUnknownTypesForIPProtocol()
+	initUnknownTypesForSCTPChunkType()
+	initUnknownTypesForPPPoECode()
+	initUnknownTypesForFDDIFrameControl()
+	initUnknownTypesForEAPOLType()
+	initUnknownTypesForProtocolFamily()
+	initUnknownTypesForDot11Type()
+	initUnknownTypesForUSBTransportType()
+	initActualTypeData()
+}
+
+func (a LinkType) Decode(data []byte, p gopacket.PacketBuilder) error {
+	return LinkTypeMetadata[a].DecodeWith.Decode(data, p)
+}
+func (a LinkType) String() string {
+	return LinkTypeMetadata[a].Name
+}
+func (a LinkType) LayerType() gopacket.LayerType {
+	return LinkTypeMetadata[a].LayerType
+}
+
+type errorDecoderForLinkType int
+
+func (a *errorDecoderForLinkType) Decode(data []byte, p gopacket.PacketBuilder) error {
+	return a
+}
+func (a *errorDecoderForLinkType) Error() string {
+	return fmt.Sprintf("Unable to decode LinkType %d", int(*a))
+}
+
+var errorDecodersForLinkType [256]errorDecoderForLinkType
+var LinkTypeMetadata [256]EnumMetadata
+
+func initUnknownTypesForLinkType() {
+	for i := 0; i < 256; i++ {
+		errorDecodersForLinkType[i] = errorDecoderForLinkType(i)
+		LinkTypeMetadata[i] = EnumMetadata{
+			DecodeWith: &errorDecodersForLinkType[i],
+			Name:       "UnknownLinkType",
+		}
+	}
+}
+
+func (a EthernetType) Decode(data []byte, p gopacket.PacketBuilder) error {
+	return EthernetTypeMetadata[a].DecodeWith.Decode(data, p)
+}
+func (a EthernetType) String() string {
+	return EthernetTypeMetadata[a].Name
+}
+func (a EthernetType) LayerType() gopacket.LayerType {
+	return EthernetTypeMetadata[a].LayerType
+}
+
+type errorDecoderForEthernetType int
+
+func (a *errorDecoderForEthernetType) Decode(data []byte, p gopacket.PacketBuilder) error {
+	return a
+}
+func (a *errorDecoderForEthernetType) Error() string {
+	return fmt.Sprintf("Unable to decode EthernetType %d", int(*a))
+}
+
+var errorDecodersForEthernetType [65536]errorDecoderForEthernetType
+var EthernetTypeMetadata [65536]EnumMetadata
+
+func initUnknownTypesForEthernetType() {
+	for i := 0; i < 65536; i++ {
+		errorDecodersForEthernetType[i] = errorDecoderForEthernetType(i)
+		EthernetTypeMetadata[i] = EnumMetadata{
+			DecodeWith: &errorDecodersForEthernetType[i],
+			Name:       "UnknownEthernetType",
+		}
+	}
+}
+
+func (a PPPType) Decode(data []byte, p gopacket.PacketBuilder) error {
+	return PPPTypeMetadata[a].DecodeWith.Decode(data, p)
+}
+func (a PPPType) String() string {
+	return PPPTypeMetadata[a].Name
+}
+func (a PPPType) LayerType() gopacket.LayerType {
+	return PPPTypeMetadata[a].LayerType
+}
+
+type errorDecoderForPPPType int
+
+func (a *errorDecoderForPPPType) Decode(data []byte, p gopacket.PacketBuilder) error {
+	return a
+}
+func (a *errorDecoderForPPPType) Error() string {
+	return fmt.Sprintf("Unable to decode PPPType %d", int(*a))
+}
+
+var errorDecodersForPPPType [65536]errorDecoderForPPPType
+var PPPTypeMetadata [65536]EnumMetadata
+
+func initUnknownTypesForPPPType() {
+	for i := 0; i < 65536; i++ {
+		errorDecodersForPPPType[i] = errorDecoderForPPPType(i)
+		PPPTypeMetadata[i] = EnumMetadata{
+			DecodeWith: &errorDecodersForPPPType[i],
+			Name:       "UnknownPPPType",
+		}
+	}
+}
+
+func (a IPProtocol) Decode(data []byte, p gopacket.PacketBuilder) error {
+	return IPProtocolMetadata[a].DecodeWith.Decode(data, p)
+}
+func (a IPProtocol) String() string {
+	return IPProtocolMetadata[a].Name
+}
+func (a IPProtocol) LayerType() gopacket.LayerType {
+	return IPProtocolMetadata[a].LayerType
+}
+
+type errorDecoderForIPProtocol int
+
+func (a *errorDecoderForIPProtocol) Decode(data []byte, p gopacket.PacketBuilder) error {
+	return a
+}
+func (a *errorDecoderForIPProtocol) Error() string {
+	return fmt.Sprintf("Unable to decode IPProtocol %d", int(*a))
+}
+
+var errorDecodersForIPProtocol [256]errorDecoderForIPProtocol
+var IPProtocolMetadata [256]EnumMetadata
+
+func initUnknownTypesForIPProtocol() {
+	for i := 0; i < 256; i++ {
+		errorDecodersForIPProtocol[i] = errorDecoderForIPProtocol(i)
+		IPProtocolMetadata[i] = EnumMetadata{
+			DecodeWith: &errorDecodersForIPProtocol[i],
+			Name:       "UnknownIPProtocol",
+		}
+	}
+}
+
+func (a SCTPChunkType) Decode(data []byte, p gopacket.PacketBuilder) error {
+	return SCTPChunkTypeMetadata[a].DecodeWith.Decode(data, p)
+}
+func (a SCTPChunkType) String() string {
+	return SCTPChunkTypeMetadata[a].Name
+}
+func (a SCTPChunkType) LayerType() gopacket.LayerType {
+	return SCTPChunkTypeMetadata[a].LayerType
+}
+
+type errorDecoderForSCTPChunkType int
+
+func (a *errorDecoderForSCTPChunkType) Decode(data []byte, p gopacket.PacketBuilder) error {
+	return a
+}
+func (a *errorDecoderForSCTPChunkType) Error() string {
+	return fmt.Sprintf("Unable to decode SCTPChunkType %d", int(*a))
+}
+
+var errorDecodersForSCTPChunkType [256]errorDecoderForSCTPChunkType
+var SCTPChunkTypeMetadata [256]EnumMetadata
+
+func initUnknownTypesForSCTPChunkType() {
+	for i := 0; i < 256; i++ {
+		errorDecodersForSCTPChunkType[i] = errorDecoderForSCTPChunkType(i)
+		SCTPChunkTypeMetadata[i] = EnumMetadata{
+			DecodeWith: &errorDecodersForSCTPChunkType[i],
+			Name:       "UnknownSCTPChunkType",
+		}
+	}
+}
+
+func (a PPPoECode) Decode(data []byte, p gopacket.PacketBuilder) error {
+	return PPPoECodeMetadata[a].DecodeWith.Decode(data, p)
+}
+func (a PPPoECode) String() string {
+	return PPPoECodeMetadata[a].Name
+}
+func (a PPPoECode) LayerType() gopacket.LayerType {
+	return PPPoECodeMetadata[a].LayerType
+}
+
+type errorDecoderForPPPoECode int
+
+func (a *errorDecoderForPPPoECode) Decode(data []byte, p gopacket.PacketBuilder) error {
+	return a
+}
+func (a *errorDecoderForPPPoECode) Error() string {
+	return fmt.Sprintf("Unable to decode PPPoECode %d", int(*a))
+}
+
+var errorDecodersForPPPoECode [256]errorDecoderForPPPoECode
+var PPPoECodeMetadata [256]EnumMetadata
+
+func initUnknownTypesForPPPoECode() {
+	for i := 0; i < 256; i++ {
+		errorDecodersForPPPoECode[i] = errorDecoderForPPPoECode(i)
+		PPPoECodeMetadata[i] = EnumMetadata{
+			DecodeWith: &errorDecodersForPPPoECode[i],
+			Name:       "UnknownPPPoECode",
+		}
+	}
+}
+
+func (a FDDIFrameControl) Decode(data []byte, p gopacket.PacketBuilder) error {
+	return FDDIFrameControlMetadata[a].DecodeWith.Decode(data, p)
+}
+func (a FDDIFrameControl) String() string {
+	return FDDIFrameControlMetadata[a].Name
+}
+func (a FDDIFrameControl) LayerType() gopacket.LayerType {
+	return FDDIFrameControlMetadata[a].LayerType
+}
+
+type errorDecoderForFDDIFrameControl int
+
+func (a *errorDecoderForFDDIFrameControl) Decode(data []byte, p gopacket.PacketBuilder) error {
+	return a
+}
+func (a *errorDecoderForFDDIFrameControl) Error() string {
+	return fmt.Sprintf("Unable to decode FDDIFrameControl %d", int(*a))
+}
+
+var errorDecodersForFDDIFrameControl [256]errorDecoderForFDDIFrameControl
+var FDDIFrameControlMetadata [256]EnumMetadata
+
+func initUnknownTypesForFDDIFrameControl() {
+	for i := 0; i < 256; i++ {
+		errorDecodersForFDDIFrameControl[i] = errorDecoderForFDDIFrameControl(i)
+		FDDIFrameControlMetadata[i] = EnumMetadata{
+			DecodeWith: &errorDecodersForFDDIFrameControl[i],
+			Name:       "UnknownFDDIFrameControl",
+		}
+	}
+}
+
+func (a EAPOLType) Decode(data []byte, p gopacket.PacketBuilder) error {
+	return EAPOLTypeMetadata[a].DecodeWith.Decode(data, p)
+}
+func (a EAPOLType) String() string {
+	return EAPOLTypeMetadata[a].Name
+}
+func (a EAPOLType) LayerType() gopacket.LayerType {
+	return EAPOLTypeMetadata[a].LayerType
+}
+
+type errorDecoderForEAPOLType int
+
+func (a *errorDecoderForEAPOLType) Decode(data []byte, p gopacket.PacketBuilder) error {
+	return a
+}
+func (a *errorDecoderForEAPOLType) Error() string {
+	return fmt.Sprintf("Unable to decode EAPOLType %d", int(*a))
+}
+
+var errorDecodersForEAPOLType [256]errorDecoderForEAPOLType
+var EAPOLTypeMetadata [256]EnumMetadata
+
+func initUnknownTypesForEAPOLType() {
+	for i := 0; i < 256; i++ {
+		errorDecodersForEAPOLType[i] = errorDecoderForEAPOLType(i)
+		EAPOLTypeMetadata[i] = EnumMetadata{
+			DecodeWith: &errorDecodersForEAPOLType[i],
+			Name:       "UnknownEAPOLType",
+		}
+	}
+}
+
+func (a ProtocolFamily) Decode(data []byte, p gopacket.PacketBuilder) error {
+	return ProtocolFamilyMetadata[a].DecodeWith.Decode(data, p)
+}
+func (a ProtocolFamily) String() string {
+	return ProtocolFamilyMetadata[a].Name
+}
+func (a ProtocolFamily) LayerType() gopacket.LayerType {
+	return ProtocolFamilyMetadata[a].LayerType
+}
+
+type errorDecoderForProtocolFamily int
+
+func (a *errorDecoderForProtocolFamily) Decode(data []byte, p gopacket.PacketBuilder) error {
+	return a
+}
+func (a *errorDecoderForProtocolFamily) Error() string {
+	return fmt.Sprintf("Unable to decode ProtocolFamily %d", int(*a))
+}
+
+var errorDecodersForProtocolFamily [256]errorDecoderForProtocolFamily
+var ProtocolFamilyMetadata [256]EnumMetadata
+
+func initUnknownTypesForProtocolFamily() {
+	for i := 0; i < 256; i++ {
+		errorDecodersForProtocolFamily[i] = errorDecoderForProtocolFamily(i)
+		ProtocolFamilyMetadata[i] = EnumMetadata{
+			DecodeWith: &errorDecodersForProtocolFamily[i],
+			Name:       "UnknownProtocolFamily",
+		}
+	}
+}
+
+func (a Dot11Type) Decode(data []byte, p gopacket.PacketBuilder) error {
+	return Dot11TypeMetadata[a].DecodeWith.Decode(data, p)
+}
+func (a Dot11Type) String() string {
+	return Dot11TypeMetadata[a].Name
+}
+func (a Dot11Type) LayerType() gopacket.LayerType {
+	return Dot11TypeMetadata[a].LayerType
+}
+
+type errorDecoderForDot11Type int
+
+func (a *errorDecoderForDot11Type) Decode(data []byte, p gopacket.PacketBuilder) error {
+	return a
+}
+func (a *errorDecoderForDot11Type) Error() string {
+	return fmt.Sprintf("Unable to decode Dot11Type %d", int(*a))
+}
+
+var errorDecodersForDot11Type [256]errorDecoderForDot11Type
+var Dot11TypeMetadata [256]EnumMetadata
+
+func initUnknownTypesForDot11Type() {
+	for i := 0; i < 256; i++ {
+		errorDecodersForDot11Type[i] = errorDecoderForDot11Type(i)
+		Dot11TypeMetadata[i] = EnumMetadata{
+			DecodeWith: &errorDecodersForDot11Type[i],
+			Name:       "UnknownDot11Type",
+		}
+	}
+}
+
+func (a USBTransportType) Decode(data []byte, p gopacket.PacketBuilder) error {
+	return USBTransportTypeMetadata[a].DecodeWith.Decode(data, p)
+}
+func (a USBTransportType) String() string {
+	return USBTransportTypeMetadata[a].Name
+}
+func (a USBTransportType) LayerType() gopacket.LayerType {
+	return USBTransportTypeMetadata[a].LayerType
+}
+
+type errorDecoderForUSBTransportType int
+
+func (a *errorDecoderForUSBTransportType) Decode(data []byte, p gopacket.PacketBuilder) error {
+	return a
+}
+func (a *errorDecoderForUSBTransportType) Error() string {
+	return fmt.Sprintf("Unable to decode USBTransportType %d", int(*a))
+}
+
+var errorDecodersForUSBTransportType [256]errorDecoderForUSBTransportType
+var USBTransportTypeMetadata [256]EnumMetadata
+
+func initUnknownTypesForUSBTransportType() {
+	for i := 0; i < 256; i++ {
+		errorDecodersForUSBTransportType[i] = errorDecoderForUSBTransportType(i)
+		USBTransportTypeMetadata[i] = EnumMetadata{
+			DecodeWith: &errorDecodersForUSBTransportType[i],
+			Name:       "UnknownUSBTransportType",
+		}
+	}
+}

--- a/layers/gen2.go
+++ b/layers/gen2.go
@@ -35,15 +35,19 @@ import (
 `
 
 var funcsTmpl = template.Must(template.New("foo").Parse(`
+// Decoder calls {{.Name}}Metadata.DecodeWith's decoder.
 func (a {{.Name}}) Decode(data []byte, p gopacket.PacketBuilder) error {
 	return {{.Name}}Metadata[a].DecodeWith.Decode(data, p)
 }
+// String returns {{.Name}}Metadata.Name.
 func (a {{.Name}}) String() string {
 	return {{.Name}}Metadata[a].Name
 }
+// LayerType returns {{.Name}}Metadata.LayerType.
 func (a {{.Name}}) LayerType() gopacket.LayerType {
 	return {{.Name}}Metadata[a].LayerType
 }
+
 type errorDecoderFor{{.Name}} int
 func (a *errorDecoderFor{{.Name}}) Decode(data []byte, p gopacket.PacketBuilder) error {
   return a

--- a/layers/gen2.go
+++ b/layers/gen2.go
@@ -1,0 +1,100 @@
+// Copyright 2012 Google, Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file in the root of the source
+// tree.
+
+// +build ignore
+
+// This binary handles creating string constants and function templates for enums.
+//
+//  go run gen.go | gofmt > enums_generated.go
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"text/template"
+	"time"
+)
+
+const fmtString = `// Copyright 2012 Google, Inc. All rights reserved.
+
+package layers
+
+// Created by gen2.go, don't edit manually
+// Generated at %s
+
+import (
+  "fmt"
+
+  "github.com/google/gopacket"
+)
+
+`
+
+var funcsTmpl = template.Must(template.New("foo").Parse(`
+func (a {{.Name}}) Decode(data []byte, p gopacket.PacketBuilder) error {
+	return {{.Name}}Metadata[a].DecodeWith.Decode(data, p)
+}
+func (a {{.Name}}) String() string {
+	return {{.Name}}Metadata[a].Name
+}
+func (a {{.Name}}) LayerType() gopacket.LayerType {
+	return {{.Name}}Metadata[a].LayerType
+}
+type errorDecoderFor{{.Name}} int
+func (a *errorDecoderFor{{.Name}}) Decode(data []byte, p gopacket.PacketBuilder) error {
+  return a
+}
+func (a *errorDecoderFor{{.Name}}) Error() string {
+  return fmt.Sprintf("Unable to decode {{.Name}} %d", int(*a))
+}
+
+var errorDecodersFor{{.Name}} [{{.Num}}]errorDecoderFor{{.Name}}
+var {{.Name}}Metadata [{{.Num}}]EnumMetadata
+
+func initUnknownTypesFor{{.Name}}() {
+  for i := 0; i < {{.Num}}; i++ {
+    errorDecodersFor{{.Name}}[i] = errorDecoderFor{{.Name}}(i)
+    {{.Name}}Metadata[i] = EnumMetadata{
+      DecodeWith: &errorDecodersFor{{.Name}}[i],
+      Name: "Unknown{{.Name}}",
+    }
+  }
+}
+`))
+
+func main() {
+	fmt.Fprintf(os.Stderr, "Writing results to stdout\n")
+	fmt.Printf(fmtString, time.Now())
+	types := []struct {
+		Name string
+		Num  int
+	}{
+		{"LinkType", 256},
+		{"EthernetType", 65536},
+		{"PPPType", 65536},
+		{"IPProtocol", 256},
+		{"SCTPChunkType", 256},
+		{"PPPoECode", 256},
+		{"FDDIFrameControl", 256},
+		{"EAPOLType", 256},
+		{"ProtocolFamily", 256},
+		{"Dot11Type", 256},
+		{"USBTransportType", 256},
+	}
+
+	fmt.Println("func init() {")
+	for _, t := range types {
+		fmt.Printf("initUnknownTypesFor%s()\n", t.Name)
+	}
+	fmt.Println("initActualTypeData()")
+	fmt.Println("}")
+	for _, t := range types {
+		if err := funcsTmpl.Execute(os.Stdout, t); err != nil {
+			log.Fatalf("Failed to execute template %s: %v", t.Name, err)
+		}
+	}
+}

--- a/layers/iana_ports.go
+++ b/layers/iana_ports.go
@@ -3,7 +3,7 @@
 package layers
 
 // Created by gen.go, don't edit manually
-// Generated at 2017-09-19 13:08:22.987239325 -0600 MDT
+// Generated at 2017-10-23 09:57:28.214859163 -0600 MDT m=+1.011679290
 // Fetched from "http://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xml"
 
 // TCPPortNames contains the port names for all TCP ports.
@@ -3753,6 +3753,7 @@ var tcpPortNames = map[TCPPort]string{
 	4117:  "hillrserv",
 	4118:  "netscript",
 	4119:  "assuria-slm",
+	4120:  "minirem",
 	4121:  "e-builder",
 	4122:  "fprams",
 	4123:  "z-wave",

--- a/layers/usb.go
+++ b/layers/usb.go
@@ -81,27 +81,6 @@ const (
 	USBTransportTypeBulk        USBTransportType = 0x03 // Bulk transfers can be used for large bursty data, using all remaining available bandwidth, no guarantees on bandwidth or latency, such as file transfers.
 )
 
-func (a USBTransportType) LayerType() gopacket.LayerType {
-	return USBTypeMetadata[a].LayerType
-}
-
-func (a USBTransportType) String() string {
-	switch a {
-	case USBTransportTypeTransferIn:
-		return "Transfer In"
-	case USBTransportTypeIsochronous:
-		return "Isochronous"
-	case USBTransportTypeInterrupt:
-		return "Interrupt"
-	case USBTransportTypeControl:
-		return "Control"
-	case USBTransportTypeBulk:
-		return "Bulk"
-	default:
-		return "Unknown transport type"
-	}
-}
-
 type USBDirectionType uint8
 
 const (


### PR DESCRIPTION
Using some prebuilt arrays that don't require heap creation and some lazy string creation for errors, avoid doing a ton of fmt.Sprintf in enums.go's init function, which should speed up initiation and reduce heap mem usage.