### PR TITLE
802.11-related fixes

### DIFF
--- a/layers/dot11.go
+++ b/layers/dot11.go
@@ -625,16 +625,15 @@ type Dot11DataQOS struct {
 }
 
 func (m *Dot11DataQOS) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
-	if len(data) < 4 {
+	if len(data) < 2 {
 		df.SetTruncated()
-		return fmt.Errorf("Dot11DataQOS length %v too short, %v required", len(data), 4)
+		return fmt.Errorf("Dot11DataQOS length %v too short, %v required", len(data), 2)
 	}
 	m.TID = (uint8(data[0]) & 0x0F)
 	m.EOSP = (uint8(data[0]) & 0x10) == 0x10
 	m.AckPolicy = Dot11AckPolicy((uint8(data[0]) & 0x60) >> 5)
 	m.TXOP = uint8(data[1])
-	// TODO: Mesh Control bytes 2:4
-	m.BaseLayer = BaseLayer{Contents: data[0:4], Payload: data[4:]}
+	m.BaseLayer = BaseLayer{Contents: data[0:2], Payload: data[2:]}
 	return nil
 }
 

--- a/layers/dot11.go
+++ b/layers/dot11.go
@@ -327,10 +327,6 @@ func decodeDot11(data []byte, p gopacket.PacketBuilder) error {
 func (m *Dot11) LayerType() gopacket.LayerType  { return LayerTypeDot11 }
 func (m *Dot11) CanDecode() gopacket.LayerClass { return LayerTypeDot11 }
 func (m *Dot11) NextLayerType() gopacket.LayerType {
-	if m.Flags.WEP() {
-		return (LayerTypeDot11WEP)
-	}
-
 	return m.Type.LayerType()
 }
 


### PR DESCRIPTION
I had to make these changes to be able to use gopacket to strip data payload from packets while retaining all 802.11 headers.

It looks like originally gopacket was suitable for my task until this commit: https://github.com/google/gopacket/commit/d23ebfbfc434b2f371699e7d59a30d096de2cde1

It would be good to know what goal that commit was trying to solve. Probably it is OK to use Dot11WEP instead of Dot11Data, but so far I do not understand how to propagate context from Dot11 to Dot11Data via Dot11DataQoSData.

I tested my changes on sniffed Wi-Fi packets - both encrypted (not only data, but and also management - see 802.11w) or not. Everything is OK if to stop iterating over layers at Dot11Data or at Radiotap if bad FCS encountered.