### PR TITLE
pcap: potential fix for performance regression

### DIFF
--- a/pcap/pcap_unix.go
+++ b/pcap/pcap_unix.go
@@ -46,7 +46,7 @@ import (
 	"unsafe"
 )
 
-func (p *Handle) openLive() error {
+func (p *Handle) setNonBlocking() error {
 	buf := (*C.char)(C.calloc(errorBufferSize, 1))
 	defer C.free(unsafe.Pointer(buf))
 

--- a/pcap/pcap_windows.go
+++ b/pcap/pcap_windows.go
@@ -11,7 +11,7 @@ import (
 	"runtime"
 )
 
-func (p *Handle) openLive() error {
+func (p *Handle) setNonBlocking() error {
 	// do nothing
 	return nil
 }


### PR DESCRIPTION
Rely on libpcap's blocking when the timeout is set to `BlockForever` and
make sure to `waitForPacket` at least once before trying to read again
when the timeout is greater than 0.

Updates #339, #372.

My CPU usage for a capture with a timeout greater than 0 dropped from
100% to <1%. Didn't test with `BlockForever`.