### PR TITLE
Activate(): handle PCAP_WARNING, provide proper error message

### DIFF
--- a/pcap/pcap.go
+++ b/pcap/pcap.go
@@ -923,7 +923,7 @@ var activateErrMsg error
 
 // Error returns the current error associated with a pcap handle (pcap_geterr).
 func (p *InactiveHandle) Error() error {
-        return errors.New(C.GoString(C.pcap_geterr(p.cptr)))
+	return errors.New(C.GoString(C.pcap_geterr(p.cptr)))
 }
 
 // Activate activates the handle.  The current InactiveHandle becomes invalid


### PR DESCRIPTION
When activating an InactiveHandle on Linux with a buffer size that is too small, the returned error is '1' but this case is not handled in the code (probably there are more situations where this can occur, the above happened to me). The man page says

> **PCAP_WARNING**
              Another warning condition occurred; pcap_geterr() or pcap_perror() may be called with p as an  argument  to  fetch  or  display  a  message describing the warning condition.

Didn't have this issue on my Mac and had to modify the gopacket code to figure out what was actually going on behind the scenes (in my case `can't mmap rx ring: Invalid argument` which was caused by the inappropriate buffer size). Thought it would be nice if gopacket could tell this apart and report it properly out-of-the-box.

There's some code replication for the `(*InactiveHandle) Error()` which is identical to `(*Handle) Error()` and also the variable which holds the content... Since I'm relatively new to Golang there probably is a better way... works for me, however.