### PR TITLE
Remove costly allocation from writePacketHeader by moving buffer into struct

### DIFF
--- a/pcapgo/write_test.go
+++ b/pcapgo/write_test.go
@@ -8,9 +8,10 @@ package pcapgo
 
 import (
 	"bytes"
-	"github.com/google/gopacket"
 	"testing"
 	"time"
+
+	"github.com/google/gopacket"
 )
 
 func TestWriteHeader(t *testing.T) {
@@ -44,6 +45,23 @@ func TestWritePacket(t *testing.T) {
 	}
 	if got := buf.Bytes(); !bytes.Equal(got, want) {
 		t.Errorf("buf mismatch:\nwant: %+v\ngot:  %+v", want, got)
+	}
+}
+
+func BenchmarkWritePacket(b *testing.B) {
+	b.StopTimer()
+	ci := gopacket.CaptureInfo{
+		Timestamp:     time.Unix(0x01020304, 0xAA*1000),
+		Length:        0xABCD,
+		CaptureLength: 10,
+	}
+	data := []byte{9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		w.WritePacket(ci, data)
 	}
 }
 


### PR DESCRIPTION
My production code uses pcapgo.WritePacket to write header and packet data to a byte slice in the real time capture tight loop. While profiling this code, I discovered pcapgo.writePacketHeader's byte array seems to get allocated on the heap. I found by moving this into the Writer struct this allocation is not made saving approx. 30-40ns per call on my machine. While this won't matter much for post-capture processing, it does make a large impact during the capture itself. Moving this will make these write routines safe to call only from a single goroutine, but I can't see what use case could be had by calling from multiple anyway.

Before:
---------
    scott@saruman:~/go/src/github.com/google/gopacket/pcapgo$ go test -v ./... -run=^$ -bench=.
    goos: linux
    goarch: amd64
    pkg: github.com/google/gopacket/pcapgo
    BenchmarkWritePacket-8   	20000000	       116 ns/op
    PASS
    ok  	github.com/google/gopacket/pcapgo	2.510s

After:
-------
    scott@saruman:~/go/src/github.com/google/gopacket/pcapgo$ go test -v ./... -run=^$ -bench=.
    goos: linux
    goarch: amd64
    pkg: github.com/google/gopacket/pcapgo
    BenchmarkWritePacket-8   	20000000	        73.6 ns/op
    PASS
    ok  	github.com/google/gopacket/pcapgo	2.726s
