### PR TITLE
Reset all parts of Reassembly for new page.

### DIFF
--- a/tcpassembly/assembly.go
+++ b/tcpassembly/assembly.go
@@ -148,8 +148,7 @@ func (c *pageCache) next(ts time.Time) (p *page) {
 	p, c.free = c.free[i], c.free[:i]
 	p.prev = nil
 	p.next = nil
-	p.Seen = ts
-	p.Bytes = p.buf[:0]
+	p.Reassembly = Reassembly{Bytes: p.buf[:0], Seen: ts}
 	c.used++
 	return p
 }


### PR DESCRIPTION
Before this, the Skip part of the Reassembly was sometimes not correctly
reset for new pages.  Fixes #389