### PR TITLE
New APIs for setting pfring's poll_watermark and poll_duration parameters

### DIFF
--- a/pfring/pfring.go
+++ b/pfring/pfring.go
@@ -222,7 +222,7 @@ func (r *Ring) SetSamplingRate(rate int) error {
 	}
 	return nil
 }
-
+// SetPollWatermark sets the pfring's poll watermark packet count
 func (r *Ring) SetPollWatermark(count uint16) error {
 	if rv := C.pfring_set_poll_watermark(r.cptr, C.u_int16_t(count)); rv != 0 {
 		return fmt.Errorf("Unable to set poll watermark, got error code %d", rv)
@@ -230,10 +230,12 @@ func (r *Ring) SetPollWatermark(count uint16) error {
 	return nil
 }
 
+// SetPriority sets the pfring poll threads CPU usage limit
 func (r *Ring) SetPriority(cpu uint16) {
 	C.pfring_config(C.u_short(cpu))
 }
 
+// SetPollDuration sets the pfring's poll duration before it yields/returns
 func (r *Ring) SetPollDuration(duration uint) error {
 	if rv := C.pfring_set_poll_duration(r.cptr, C.u_int(duration)); rv != 0 {
 		return fmt.Errorf("Unable to set poll duration, got error code %d", rv)

--- a/pfring/pfring.go
+++ b/pfring/pfring.go
@@ -223,6 +223,24 @@ func (r *Ring) SetSamplingRate(rate int) error {
 	return nil
 }
 
+func (r *Ring) SetPollWatermark(count uint16) error {
+	if rv := C.pfring_set_poll_watermark(r.cptr, C.u_int16_t(count)); rv != 0 {
+		return fmt.Errorf("Unable to set poll watermark, got error code %d", rv)
+	}
+	return nil
+}
+
+func (r *Ring) SetPriority(cpu uint16) {
+	C.pfring_config(C.u_short(cpu))
+}
+
+func (r *Ring) SetPollDuration(duration uint) error {
+	if rv := C.pfring_set_poll_duration(r.cptr, C.u_int(duration)); rv != 0 {
+		return fmt.Errorf("Unable to set poll duration, got error code %d", rv)
+	}
+	return nil
+}
+
 // SetBPFFilter sets the BPF filter for the ring.
 func (r *Ring) SetBPFFilter(bpfFilter string) error {
 	filter := C.CString(bpfFilter)

--- a/pfring/pfring.go
+++ b/pfring/pfring.go
@@ -237,8 +237,8 @@ func (r *Ring) SetPriority(cpu uint16) {
 }
 
 // SetPollDuration sets the pfring's poll duration before it yields/returns
-func (r *Ring) SetPollDuration(duration uint) error {
-	if rv := C.pfring_set_poll_duration(r.cptr, C.u_int(duration)); rv != 0 {
+func (r *Ring) SetPollDuration(durationMillis time.Duration) error {
+	if rv := C.pfring_set_poll_duration(r.cptr, C.u_int(durationMillis)); rv != 0 {
 		return fmt.Errorf("Unable to set poll duration, got error code %d", rv)
 	}
 	return nil

--- a/pfring/pfring.go
+++ b/pfring/pfring.go
@@ -222,6 +222,7 @@ func (r *Ring) SetSamplingRate(rate int) error {
 	}
 	return nil
 }
+
 // SetPollWatermark sets the pfring's poll watermark packet count
 func (r *Ring) SetPollWatermark(count uint16) error {
 	if rv := C.pfring_set_poll_watermark(r.cptr, C.u_int16_t(count)); rv != 0 {

--- a/pfring/pfring.go
+++ b/pfring/pfring.go
@@ -237,7 +237,7 @@ func (r *Ring) SetPriority(cpu uint16) {
 }
 
 // SetPollDuration sets the pfring's poll duration before it yields/returns
-func (r *Ring) SetPollDuration(durationMillis time.Duration) error {
+func (r *Ring) SetPollDuration(durationMillis uint) error {
 	if rv := C.pfring_set_poll_duration(r.cptr, C.u_int(durationMillis)); rv != 0 {
 		return fmt.Errorf("Unable to set poll duration, got error code %d", rv)
 	}


### PR DESCRIPTION
PF_RING has default values of 128 packets and 500ms for poll_watermark and poll_duration respectively. It means the pf_ring's packet poll call would return only when either there are 128 packets queued in it's ring buffer or 500ms time has elapsed since the call to pfring_poll. This is affecting the performance in our use case. I have added these APIs to make these parameters flexible for change to programmers needs.