### PR TITLE
Cap memory usage for bidi example.

### DIFF
--- a/examples/bidirectional/main.go
+++ b/examples/bidirectional/main.go
@@ -163,6 +163,10 @@ func main() {
 	streamFactory := &myFactory{bidiMap: make(map[key]*bidi)}
 	streamPool := tcpassembly.NewStreamPool(streamFactory)
 	assembler := tcpassembly.NewAssembler(streamPool)
+	// Limit memory usage by auto-flushing connection state if we get over 100K
+	// packets in memory, or over 1000 for a single stream.
+	assembler.MaxBufferedPagesTotal = 100000
+	assembler.MaxBufferedPagesPerConnection = 1000
 
 	log.Println("reading in packets")
 	// Read in packets, pass to assembler.


### PR DESCRIPTION
Should fix #405.