### PR TITLE
Fix: stopped dhcpv4 option length increasing indefinitely 

### DIFF
--- a/layers/dhcpv4.go
+++ b/layers/dhcpv4.go
@@ -150,6 +150,7 @@ func (d *DHCPv4) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error 
 	}
 
 	options := data[240:]
+	d.Options = d.Options[:0]
 
 	stop := len(options)
 	start := 0


### PR DESCRIPTION
While decoding dhcp4 using  DecodingLayerParser, as same object is reused, the `Options` field got appended with options of packets indefinitely. The `Options` field is cleared, initialized to zero length, to avoid this problem