### PR TITLE
Current af_packet code does not have SetBPFFilter similar to pf_ring/…

### DIFF
--- a/pcap/pcap.go
+++ b/pcap/pcap.go
@@ -288,6 +288,14 @@ func OpenOffline(file string) (handle *Handle, err error) {
 	return h, nil
 }
 
+func OpenDead(linktype layers.LinkType, snaplen int32) (handle *Handle, _ error) {
+	cptr := C.pcap_open_dead(C.int(linktype), C.int(snaplen))
+	if cptr == nil {
+		return nil, errors.New("pcap_open_dead failed")
+	}
+	return &Handle{cptr: cptr}, nil
+}
+
 // NextError is the return code from a call to Next.
 type NextError int32
 
@@ -714,6 +722,10 @@ func destroyBPF(bpf *BPF) {
 // String returns the original string this BPF filter was compiled from.
 func (b *BPF) String() string {
 	return b.orig
+}
+
+func (b *BPF) BPF() _Ctype_struct_bpf_program {
+	return b.bpf
 }
 
 // Matches returns true if the given packet data matches this filter.


### PR DESCRIPTION
Current af_packet does not have SetBPFFilter similar to pf_ring/pcap. SetBPF in af_packet needs us to pass compiled BPF program. SetBPFFilter uses pcap's compile functions to do the compilation for us. This code is originally commited to packetbeat as part of this commit. https://github.com/packetb-old/gopacket/commit/44554145590f42204f5f78cb2aeb45ba08cd2c2f