### PR TITLE
gopacket: fix vet errors

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -129,7 +129,7 @@ func BenchmarkUnbufferedChannel(b *testing.B) {
 	defer close(ca)
 	go func() {
 		defer close(cb)
-		for _ = range ca {
+		for range ca {
 			cb <- true
 		}
 	}()
@@ -144,7 +144,7 @@ func BenchmarkSmallBufferedChannel(b *testing.B) {
 	defer close(ca)
 	go func() {
 		defer close(cb)
-		for _ = range ca {
+		for range ca {
 			cb <- true
 		}
 	}()
@@ -159,7 +159,7 @@ func BenchmarkLargeBufferedChannel(b *testing.B) {
 	defer close(ca)
 	go func() {
 		defer close(cb)
-		for _ = range ca {
+		for range ca {
 			cb <- true
 		}
 	}()


### PR DESCRIPTION
Omit values from range.

@gconnell: not sure why Travis worked before the merge and not after:

https://travis-ci.org/google/gopacket/builds/356013620
https://travis-ci.org/google/gopacket/builds/347579113