### PR TITLE
Lack of support for data frames

### DIFF
--- a/layers/dot11.go
+++ b/layers/dot11.go
@@ -516,13 +516,11 @@ func decodeDot11DataData(data []byte, p gopacket.PacketBuilder) error {
 	return decodingLayerDecoder(d, data, p)
 }
 
-func (m *Dot11DataData) LayerType() gopacket.LayerType {return LayerTypeDot11DataData}
-func (m *Dot11DataData) CanDecode() gopacket.LayerClass {return LayerTypeDot11DataData}
+func (m *Dot11DataData) LayerType() gopacket.LayerType  { return LayerTypeDot11DataData }
+func (m *Dot11DataData) CanDecode() gopacket.LayerClass { return LayerTypeDot11DataData }
 func (m *Dot11DataData) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 	return m.Dot11Data.DecodeFromBytes(data, df)
 }
-
-
 
 type Dot11DataCFAck struct {
 	Dot11Data

--- a/layers/dot11.go
+++ b/layers/dot11.go
@@ -507,6 +507,23 @@ func decodeDot11Data(data []byte, p gopacket.PacketBuilder) error {
 	return decodingLayerDecoder(d, data, p)
 }
 
+type Dot11DataData struct {
+	Dot11Data
+}
+
+func decodeDot11DataData(data []byte, p gopacket.PacketBuilder) error {
+	d := &Dot11DataData{}
+	return decodingLayerDecoder(d, data, p)
+}
+
+func (m *Dot11DataData) LayerType() gopacket.LayerType {return LayerTypeDot11DataData}
+func (m *Dot11DataData) CanDecode() gopacket.LayerClass {return LayerTypeDot11DataData}
+func (m *Dot11DataData) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
+	return m.Dot11Data.DecodeFromBytes(data, df)
+}
+
+
+
 type Dot11DataCFAck struct {
 	Dot11Data
 }

--- a/layers/enums.go
+++ b/layers/enums.go
@@ -256,7 +256,7 @@ const (
 	Dot11TypeCtrlCFEndAck      Dot11Type = 0x3d
 
 	// Data
-	Dot11TypeDataData				Dot11Type = 0x02
+	Dot11TypeDataData               Dot11Type = 0x02
 	Dot11TypeDataCFAck              Dot11Type = 0x06
 	Dot11TypeDataCFPoll             Dot11Type = 0x0a
 	Dot11TypeDataCFAckPoll          Dot11Type = 0x0e

--- a/layers/enums.go
+++ b/layers/enums.go
@@ -256,6 +256,7 @@ const (
 	Dot11TypeCtrlCFEndAck      Dot11Type = 0x3d
 
 	// Data
+	Dot11TypeDataData				Dot11Type = 0x02
 	Dot11TypeDataCFAck              Dot11Type = 0x06
 	Dot11TypeDataCFPoll             Dot11Type = 0x0a
 	Dot11TypeDataCFAckPoll          Dot11Type = 0x0e

--- a/layers/layertypes.go
+++ b/layers/layertypes.go
@@ -69,7 +69,7 @@ var (
 	LayerTypeDot11                       = gopacket.RegisterLayerType(65, gopacket.LayerTypeMetadata{Name: "Dot11", Decoder: gopacket.DecodeFunc(decodeDot11)})
 	LayerTypeDot11Ctrl                   = gopacket.RegisterLayerType(66, gopacket.LayerTypeMetadata{Name: "Dot11Ctrl", Decoder: gopacket.DecodeFunc(decodeDot11Ctrl)})
 	LayerTypeDot11Data                   = gopacket.RegisterLayerType(67, gopacket.LayerTypeMetadata{Name: "Dot11Data", Decoder: gopacket.DecodeFunc(decodeDot11Data)})
-	LayerTypeDot11DataData				 = gopacket.RegisterLayerType(129, gopacket.LayerTypeMetadata{Name: "Dot11DataData", Decoder: gopacket.DecodeFunc(decodeDot11DataData)})
+	LayerTypeDot11DataData               = gopacket.RegisterLayerType(129, gopacket.LayerTypeMetadata{Name: "Dot11DataData", Decoder: gopacket.DecodeFunc(decodeDot11DataData)})
 	LayerTypeDot11DataCFAck              = gopacket.RegisterLayerType(68, gopacket.LayerTypeMetadata{Name: "Dot11DataCFAck", Decoder: gopacket.DecodeFunc(decodeDot11DataCFAck)})
 	LayerTypeDot11DataCFPoll             = gopacket.RegisterLayerType(69, gopacket.LayerTypeMetadata{Name: "Dot11DataCFPoll", Decoder: gopacket.DecodeFunc(decodeDot11DataCFPoll)})
 	LayerTypeDot11DataCFAckPoll          = gopacket.RegisterLayerType(70, gopacket.LayerTypeMetadata{Name: "Dot11DataCFAckPoll", Decoder: gopacket.DecodeFunc(decodeDot11DataCFAckPoll)})

--- a/layers/layertypes.go
+++ b/layers/layertypes.go
@@ -69,6 +69,7 @@ var (
 	LayerTypeDot11                       = gopacket.RegisterLayerType(65, gopacket.LayerTypeMetadata{Name: "Dot11", Decoder: gopacket.DecodeFunc(decodeDot11)})
 	LayerTypeDot11Ctrl                   = gopacket.RegisterLayerType(66, gopacket.LayerTypeMetadata{Name: "Dot11Ctrl", Decoder: gopacket.DecodeFunc(decodeDot11Ctrl)})
 	LayerTypeDot11Data                   = gopacket.RegisterLayerType(67, gopacket.LayerTypeMetadata{Name: "Dot11Data", Decoder: gopacket.DecodeFunc(decodeDot11Data)})
+	LayerTypeDot11DataData				 = gopacket.RegisterLayerType(129, gopacket.LayerTypeMetadata{Name: "Dot11DataData", Decoder: gopacket.DecodeFunc(decodeDot11DataData)})
 	LayerTypeDot11DataCFAck              = gopacket.RegisterLayerType(68, gopacket.LayerTypeMetadata{Name: "Dot11DataCFAck", Decoder: gopacket.DecodeFunc(decodeDot11DataCFAck)})
 	LayerTypeDot11DataCFPoll             = gopacket.RegisterLayerType(69, gopacket.LayerTypeMetadata{Name: "Dot11DataCFPoll", Decoder: gopacket.DecodeFunc(decodeDot11DataCFPoll)})
 	LayerTypeDot11DataCFAckPoll          = gopacket.RegisterLayerType(70, gopacket.LayerTypeMetadata{Name: "Dot11DataCFAckPoll", Decoder: gopacket.DecodeFunc(decodeDot11DataCFAckPoll)})


### PR DESCRIPTION
As far as I can tell, gopacket doesn't support processing the frames with subtype "Data" (That is, frames with type 10 and subtype 0000).  I've added support to process said frames symmetrical to how other data frames are processed.

Frankly, I suspect I may have missed or misunderstood something- it doesn't make sense to me that something which seems very obvious to me would simply lack support in gopacket.  Have I made some mistaken assumptions?