### PR TITLE
Add support for 802.11-2016

### DIFF
--- a/layers/dot11.go
+++ b/layers/dot11.go
@@ -317,6 +317,88 @@ type Dot11 struct {
 	SequenceNumber uint16
 	FragmentNumber uint16
 	Checksum       uint32
+	QOS            *Dot11QOS
+	HTControl      *Dot11HTControl
+}
+
+type Dot11QOS struct {
+	TID       uint8 /* Traffic IDentifier */
+	EOSP      bool  /* End of service period */
+	AckPolicy Dot11AckPolicy
+	TXOP      uint8
+}
+
+type Dot11HTControl struct {
+	ACConstraint bool
+	RDGMorePPDU  bool
+
+	VHT *Dot11HTControlVHT
+	HT  *Dot11HTControlHT
+}
+
+type Dot11HTControlHT struct {
+	LinkAdapationControl *Dot11LinkAdapationControl
+	CalibrationPosition  uint8
+	CalibrationSequence  uint8
+	CSISteering          uint8
+	NDPAnnouncement      bool
+	DEI                  bool
+}
+
+type Dot11HTControlVHT struct {
+	MRQ            bool
+	UnsolicitedMFB bool
+	MSI            *uint8
+	MFB            Dot11HTControlMFB
+	CompressedMSI  *uint8
+	STBCIndication bool
+	MFSI           *uint8
+	GID            *uint8
+	CodingType     *Dot11CodingType
+	FbTXBeamformed bool
+}
+
+type Dot11HTControlMFB struct {
+	NumSTS uint8
+	VHTMCS uint8
+	BW     uint8
+	SNR    int8
+}
+
+type Dot11LinkAdapationControl struct {
+	TRQ  bool
+	MRQ  bool
+	MSI  uint8
+	MFSI uint8
+	ASEL *Dot11ASEL
+	MFB  *uint8
+}
+
+type Dot11ASEL struct {
+	Command uint8
+	Data    uint8
+}
+
+type Dot11CodingType uint8
+
+const (
+	Dot11CodingTypeBCC  = 0
+	Dot11CodingTypeLDPC = 1
+)
+
+func (a Dot11CodingType) String() string {
+	switch a {
+	case Dot11CodingTypeBCC:
+		return "BCC"
+	case Dot11CodingTypeLDPC:
+		return "LDPC"
+	default:
+		return "Unknown coding type"
+	}
+}
+
+func (m *Dot11HTControlMFB) NoFeedBackPresent() bool {
+	return m.VHTMCS == 15 && m.NumSTS == 7
 }
 
 func decodeDot11(data []byte, p gopacket.PacketBuilder) error {
@@ -327,11 +409,15 @@ func decodeDot11(data []byte, p gopacket.PacketBuilder) error {
 func (m *Dot11) LayerType() gopacket.LayerType  { return LayerTypeDot11 }
 func (m *Dot11) CanDecode() gopacket.LayerClass { return LayerTypeDot11 }
 func (m *Dot11) NextLayerType() gopacket.LayerType {
-	if m.Flags.WEP() {
-		return (LayerTypeDot11WEP)
-	}
+	// if m.Flags.WEP() {
+	// 	return (LayerTypeDot11WEP)
+	// }
 
 	return m.Type.LayerType()
+}
+
+func createU8(x uint8) *uint8 {
+	return &x
 }
 
 func (m *Dot11) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
@@ -385,7 +471,102 @@ func (m *Dot11) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 		offset += 6
 	}
 
-	m.BaseLayer = BaseLayer{Contents: data[0:offset], Payload: data[offset : len(data)-4]}
+	if m.Type.QOS() {
+		if len(data) < offset+2 {
+			df.SetTruncated()
+			return fmt.Errorf("Dot11 length %v too short, %v required", len(data), offset+6)
+		}
+		m.QOS = &Dot11QOS{
+			TID:       (uint8(data[offset]) & 0x0F),
+			EOSP:      (uint8(data[offset]) & 0x10) == 0x10,
+			AckPolicy: Dot11AckPolicy((uint8(data[offset]) & 0x60) >> 5),
+			TXOP:      uint8(data[offset+1]),
+		}
+		offset += 2
+	}
+	if m.Flags.Order() && (m.Type.QOS() || mainType == Dot11TypeMgmt) {
+		if len(data) < offset+4 {
+			df.SetTruncated()
+			return fmt.Errorf("Dot11 length %v too short, %v required", len(data), offset+6)
+		}
+
+		htc := &Dot11HTControl{
+			ACConstraint: data[offset+3]&0x40 != 0,
+			RDGMorePPDU:  data[offset+3]&0x80 != 0,
+		}
+		m.HTControl = htc
+
+		if data[offset]&0x1 != 0 { // VHT Variant
+			vht := &Dot11HTControlVHT{}
+			htc.VHT = vht
+			vht.MRQ = data[offset]&0x4 != 0
+			vht.UnsolicitedMFB = data[offset+3]&0x20 != 0
+			vht.MFB = Dot11HTControlMFB{
+				NumSTS: uint8(data[offset+1] >> 1 & 0x7),
+				VHTMCS: uint8(data[offset+1] >> 4 & 0xF),
+				BW:     uint8(data[offset+2] & 0x3),
+				SNR:    int8((-(data[offset+2] >> 2 & 0x20))+data[offset+2]>>2&0x1F) + 22,
+			}
+
+			if vht.UnsolicitedMFB {
+				if !vht.MFB.NoFeedBackPresent() {
+					vht.CompressedMSI = createU8(data[offset] >> 3 & 0x3)
+					vht.STBCIndication = data[offset]&0x20 != 0
+					vht.CodingType = (*Dot11CodingType)(createU8(data[offset+3] >> 3 & 0x1))
+					vht.FbTXBeamformed = data[offset+3]&0x10 != 0
+					vht.GID = createU8(
+						data[offset]>>6 +
+							(data[offset+1] & 0x1 << 2) +
+							data[offset+3]&0x7<<3)
+				}
+			} else {
+				if vht.MRQ {
+					vht.MSI = createU8((data[offset] >> 3) & 0x07)
+				}
+				vht.MFSI = createU8(data[offset]>>6 + (data[offset+1] & 0x1 << 2))
+			}
+
+		} else { // HT Variant
+			ht := &Dot11HTControlHT{}
+			htc.HT = ht
+
+			lac := &Dot11LinkAdapationControl{}
+			ht.LinkAdapationControl = lac
+			lac.TRQ = data[offset]&0x2 != 0
+			lac.MFSI = data[offset]>>6&0x3 + data[offset+1]&0x1<<3
+			if data[offset]&0x3C == 0x38 { // ASEL
+				lac.ASEL = &Dot11ASEL{
+					Command: data[offset+1] >> 1 & 0x7,
+					Data:    data[offset+1] >> 4 & 0xF,
+				}
+			} else {
+				lac.MRQ = data[offset]&0x4 != 0
+				if lac.MRQ {
+					lac.MSI = data[offset] >> 3 & 0x7
+				}
+				lac.MFB = createU8(data[offset+1] >> 1)
+			}
+			ht.CalibrationPosition = data[offset+2] & 0x3
+			ht.CalibrationSequence = data[offset+2] >> 2 & 0x3
+			ht.CSISteering = data[offset+2] >> 6 & 0x3
+			ht.NDPAnnouncement = data[offset+3]&0x1 != 0
+			if mainType != Dot11TypeMgmt {
+				ht.DEI = data[offset+3]&0x20 != 0
+			}
+		}
+
+		offset += 4
+	}
+
+	if len(data) < offset+4 {
+		df.SetTruncated()
+		return fmt.Errorf("Dot11 length %v too short, %v required", len(data), offset+4)
+	}
+
+	m.BaseLayer = BaseLayer{
+		Contents: data[0:offset],
+		Payload:  data[offset : len(data)-4],
+	}
 	m.Checksum = binary.LittleEndian.Uint32(data[len(data)-4 : len(data)])
 	return nil
 }
@@ -618,24 +799,10 @@ func (m *Dot11DataCFAckPollNoData) DecodeFromBytes(data []byte, df gopacket.Deco
 
 type Dot11DataQOS struct {
 	Dot11Ctrl
-	TID       uint8 /* Traffic IDentifier */
-	EOSP      bool  /* End of service period */
-	AckPolicy Dot11AckPolicy
-	TXOP      uint8
 }
 
 func (m *Dot11DataQOS) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
-	if len(data) < 4 {
-		df.SetTruncated()
-		return fmt.Errorf("Dot11DataQOS length %v too short, %v required", len(data), 4)
-	}
-	m.TID = (uint8(data[0]) & 0x0F)
-	m.EOSP = (uint8(data[0]) & 0x10) == 0x10
-	m.AckPolicy = Dot11AckPolicy((uint8(data[0]) & 0x60) >> 5)
-	m.TXOP = uint8(data[1])
-	// TODO: Mesh Control bytes 2:4
-	m.BaseLayer = BaseLayer{Contents: data[0:4], Payload: data[4:]}
-	return nil
+	return m.Dot11Ctrl.DecodeFromBytes(data, df)
 }
 
 type Dot11DataQOSData struct {

--- a/layers/dot11_test.go
+++ b/layers/dot11_test.go
@@ -464,7 +464,7 @@ func TestPacketP6196(t *testing.T) {
 		t.Error("Failed to decode packet:", p.ErrorLayer().Error())
 	}
 
-	checkLayers(p, []gopacket.LayerType{LayerTypeRadioTap, LayerTypeDot11, LayerTypeDot11WEP}, t)
+	checkLayers(p, []gopacket.LayerType{LayerTypeRadioTap, LayerTypeDot11, LayerTypeDot11DataQOSData, LayerTypeDot11WEP}, t)
 }
 
 func BenchmarkDecodePacketP6196(b *testing.B) {

--- a/layers/dot11_test.go
+++ b/layers/dot11_test.go
@@ -473,6 +473,69 @@ func BenchmarkDecodePacketP6196(b *testing.B) {
 	}
 }
 
+// testPacketDot11HTControl is the packet:
+// 0000   00 00 26 00 2b 48 20 00 bf 70 06 02 00 00 00 00   ..&.+H .¿p......
+// 0010   40 00 78 14 40 01 b8 00 00 00 44 00 00 01 73 00   @.x.@.¸...D...s.
+// 0020   00 00 00 00 00 00 88 c9 30 14 01 02 03 04 05 06   .......É0.ò.Jòs}
+// 0030   11 12 13 14 15 16 21 22 23 24 25 26 c0 bd 00 14   .öP.6:M 2.Á7À½..
+// 0040   0e 28 00 a8 06 01 00 04 e6 73 b3 4a 24 3e 19 ea   .(.¨....æs³J$>.ê
+// 0050   2a b7 1f 3c c7 89 2b 22 e2 2b 28 6c 69 aa 0a ee   *·.<Ç.+"â+(liª.î
+// 0060   1e bc 2d 2a 00 35 68 39 ad 6f 29 52 38 07 ae cf   .¼-*.5h9.o)R8.®Ï
+// 0070   03 e7 0d 53 8b 3c 12 28 52 05 cc 70 be c7 68 5e   .ç.S.<.(R.Ìp¾Çh^
+// 0080   5f b1 06 f4 73 22 63 ef 77 41 7b 86               _±.ôs"cïwA{.
+var testPacketDot11HTControl = []byte{
+	0x00, 0x00, 0x26, 0x00, 0x2b, 0x48, 0x20, 0x00, 0xbf, 0x70, 0x06, 0x02, 0x00, 0x00, 0x00, 0x00,
+	0x40, 0x00, 0x78, 0x14, 0x40, 0x01, 0xb8, 0x00, 0x00, 0x00, 0x44, 0x00, 0x00, 0x01, 0x73, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x88, 0xc9, 0x30, 0x14, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
+	0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0xc0, 0xbd, 0x00, 0x14,
+	0x0e, 0x28, 0x00, 0xa8, 0x06, 0x01, 0x00, 0x04, 0xe6, 0x73, 0xb3, 0x4a, 0x24, 0x3e, 0x19, 0xea,
+	0x2a, 0xb7, 0x1f, 0x3c, 0xc7, 0x89, 0x2b, 0x22, 0xe2, 0x2b, 0x28, 0x6c, 0x69, 0xaa, 0x0a, 0xee,
+	0x1e, 0xbc, 0x2d, 0x2a, 0x00, 0x35, 0x68, 0x39, 0xad, 0x6f, 0x29, 0x52, 0x38, 0x07, 0xae, 0xcf,
+	0x03, 0xe7, 0x0d, 0x53, 0x8b, 0x3c, 0x12, 0x28, 0x52, 0x05, 0xcc, 0x70, 0xbe, 0xc7, 0x68, 0x5e,
+	0x5f, 0xb1, 0x06, 0xf4, 0x73, 0x22, 0x63, 0xef, 0x77, 0x41, 0x7b, 0x86,
+}
+
+var mfb = uint8(20)
+
+var wantHTControl = Dot11HTControl{
+	ACConstraint: false,
+	RDGMorePPDU:  true,
+	HT: &Dot11HTControlHT{
+		LinkAdapationControl: &Dot11LinkAdapationControl{
+			TRQ:  true,
+			MRQ:  true,
+			MSI:  1,
+			MFSI: 0,
+			ASEL: nil,
+			MFB:  &mfb,
+		},
+		CalibrationPosition: 0,
+		CalibrationSequence: 0,
+		CSISteering:         0,
+		NDPAnnouncement:     false,
+		DEI:                 true,
+	},
+}
+
+func TestPacketDot11HTControl(t *testing.T) {
+	p := gopacket.NewPacket(testPacketDot11HTControl, LinkTypeIEEE80211Radio, gopacket.Default)
+	if p.ErrorLayer() != nil {
+		t.Error("Failed to decode packet:", p.ErrorLayer().Error())
+	}
+
+	checkLayers(p, []gopacket.LayerType{LayerTypeRadioTap, LayerTypeDot11, LayerTypeDot11DataQOSData, LayerTypeDot11WEP}, t)
+
+	ld11 := p.Layer(LayerTypeDot11)
+	if dot11, ok := ld11.(*Dot11); ok {
+		if dot11.HTControl == nil {
+			t.Fatal("Packet didn't contain HTControl")
+		}
+		if !reflect.DeepEqual(*dot11.HTControl, wantHTControl) {
+			t.Errorf("Dot11 packet processing failed:\ngot  :\n%#v\n\nwant :\n%#v\n\n", dot11.HTControl, wantHTControl)
+		}
+	}
+}
+
 func TestInformationElement(t *testing.T) {
 	bin := []byte{
 		0, 0,

--- a/layers/enums.go
+++ b/layers/enums.go
@@ -219,12 +219,17 @@ func (d Dot11Type) MainType() Dot11Type {
 	return d & dot11TypeMask
 }
 
+func (d Dot11Type) QOS() bool {
+	return d&dot11QOSMask == Dot11TypeDataQOSData
+}
+
 const (
 	Dot11TypeMgmt     Dot11Type = 0x00
 	Dot11TypeCtrl     Dot11Type = 0x01
 	Dot11TypeData     Dot11Type = 0x02
 	Dot11TypeReserved Dot11Type = 0x03
 	dot11TypeMask               = 0x03
+	dot11QOSMask                = 0x23
 
 	// The following are type/subtype conglomerations.
 


### PR DESCRIPTION
Add support for 802.11-206 HTControl fields. I've also fixed a problem where the QoS field was 4 bytes instead of 2 bytes long because the ath5k driver adds padding if the 802.11 header isn't 32 bit aligned. To fix this I've updated the radiotap layer to remove this padding where present.