### PR TITLE
(layers) Added support for LCM protocol

### DIFF
--- a/layers/layertypes.go
+++ b/layers/layertypes.go
@@ -132,6 +132,7 @@ var (
 	LayerTypeICMPv6Redirect              = gopacket.RegisterLayerType(128, gopacket.LayerTypeMetadata{Name: "ICMPv6Redirect", Decoder: gopacket.DecodeFunc(decodeICMPv6Redirect)})
 	LayerTypeGTPv1U                      = gopacket.RegisterLayerType(129, gopacket.LayerTypeMetadata{Name: "GTPv1U", Decoder: gopacket.DecodeFunc(decodeGTPv1u)})
 	LayerTypeEAPOLKey                    = gopacket.RegisterLayerType(130, gopacket.LayerTypeMetadata{Name: "EAPOLKey", Decoder: gopacket.DecodeFunc(decodeEAPOLKey)})
+	LayerTypeLCM                         = gopacket.RegisterLayerType(131, gopacket.LayerTypeMetadata{Name: "LCM", Decoder: gopacket.DecodeFunc(decodeLCM)})
 )
 
 var (

--- a/layers/lcm.go
+++ b/layers/lcm.go
@@ -1,0 +1,193 @@
+// Copyright 2018 Google, Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file in the root of the source
+// tree.
+
+package layers
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/google/gopacket"
+)
+
+const (
+	// LCMShortHeaderMagic is the LCM small message header magic number
+	LCMShortHeaderMagic uint32 = 0x4c433032
+	// LCMFragmentedHeaderMagic is the LCM fragmented message header magic number
+	LCMFragmentedHeaderMagic uint32 = 0x4c433033
+)
+
+// LCM (Lightweight Communications and Marshalling) is a set of libraries and
+// tools for message passing and data marshalling, targeted at real-time systems
+// where high-bandwidth and low latency are critical. It provides a
+// publish/subscribe message passing model and automatic
+// marshalling/unmarshalling code generation with bindings for applications in a
+// variety of programming languages.
+//
+// References
+//   https://lcm-proj.github.io/
+//   https://github.com/lcm-proj/lcm
+type LCM struct {
+	// Common (short & fragmented header) fields
+	Magic          uint32
+	SequenceNumber uint32
+	// Fragmented header only fields
+	PayloadSize    uint32
+	FragmentOffset uint32
+	FragmentNumber uint16
+	TotalFragments uint16
+	// Common field
+	ChannelName string
+	// Gopacket helper fields
+	Fragmented  bool
+	fingerprint uint64
+	contents    []byte
+	payload     []byte
+}
+
+var (
+	lcmLayerTypes  = map[uint64]gopacket.LayerType{}
+	layerTypeIndex = 1001
+)
+
+// RegisterLCMLayerType allows users to register decoders for the underlying
+// LCM payload. This is done based on the fingerprint that every LCM message
+// contains and which identifies it uniquely. If num is not the zero value it
+// will be used when registering with RegisterLayerType towards gopacket,
+// otherwise an incremental value starting from 1001 will be used.
+func RegisterLCMLayerType(num int, fingerprint uint64,
+	decoder gopacket.Decoder) gopacket.LayerType {
+	name := fmt.Sprintf("%v", fingerprint)
+	metadata := gopacket.LayerTypeMetadata{Name: name, Decoder: decoder}
+
+	if num == 0 {
+		num = layerTypeIndex
+		layerTypeIndex++
+	}
+
+	lcmLayerTypes[fingerprint] = gopacket.RegisterLayerType(num, metadata)
+
+	return lcmLayerTypes[fingerprint]
+}
+
+// GetLCMLayerType returns the underlying LCM message's LayerType.
+// This LayerType has to be registered by using RegisterLCMLayerType.
+func GetLCMLayerType(fingerprint uint64) gopacket.LayerType {
+	layerType, ok := lcmLayerTypes[fingerprint]
+	if !ok {
+		return gopacket.LayerTypePayload
+	}
+
+	return layerType
+}
+
+func decodeLCM(data []byte, p gopacket.PacketBuilder) error {
+	lcm := &LCM{}
+
+	err := lcm.DecodeFromBytes(data, p)
+	if err != nil {
+		return err
+	}
+
+	p.AddLayer(lcm)
+	p.SetApplicationLayer(lcm)
+
+	return p.NextDecoder(lcm.NextLayerType())
+}
+
+// DecodeFromBytes decodes the given bytes into this layer.
+func (lcm *LCM) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
+	offset := 0
+
+	lcm.Magic = binary.BigEndian.Uint32(data[offset:4])
+	offset += 4
+
+	if lcm.Magic != LCMShortHeaderMagic && lcm.Magic != LCMFragmentedHeaderMagic {
+		return fmt.Errorf("Received LCM header magic %v does not match know "+
+			"LCM magic numbers. Dropping packet.", lcm.Magic)
+	}
+
+	lcm.SequenceNumber = binary.BigEndian.Uint32(data[offset:8])
+	offset += 4
+
+	if lcm.Magic == LCMFragmentedHeaderMagic {
+		lcm.Fragmented = true
+
+		lcm.PayloadSize = binary.BigEndian.Uint32(data[offset : offset+4])
+		offset += 4
+
+		lcm.FragmentOffset = binary.BigEndian.Uint32(data[offset : offset+4])
+		offset += 4
+
+		lcm.FragmentNumber = binary.BigEndian.Uint16(data[offset : offset+2])
+		offset += 2
+
+		lcm.TotalFragments = binary.BigEndian.Uint16(data[offset : offset+2])
+		offset += 2
+	} else {
+		lcm.Fragmented = false
+	}
+
+	if !lcm.Fragmented || (lcm.Fragmented && lcm.FragmentNumber == 0) {
+		buffer := make([]byte, 0)
+		for _, b := range data[offset:] {
+			offset++
+
+			if b == 0 {
+				break
+			}
+
+			buffer = append(buffer, b)
+		}
+
+		lcm.ChannelName = string(buffer)
+	}
+
+	lcm.fingerprint = binary.BigEndian.Uint64(data[offset : offset+8])
+
+	lcm.contents = data[:offset]
+	lcm.payload = data[offset:]
+
+	return nil
+}
+
+// CanDecode returns a set of layers that LCM objects can decode.
+// As LCM objects can only decode the LCM layer, we just return that layer.
+func (lcm LCM) CanDecode() gopacket.LayerClass {
+	return LayerTypeLCM
+}
+
+// NextLayerType specifies the LCM payload layer type following this header.
+// As LCM packets are serialized structs with uniq fingerprints for each uniq
+// combination of data types, lookup of correct layer type is based on that
+// fingerprint.
+func (lcm LCM) NextLayerType() gopacket.LayerType {
+	if lcm.Fragmented {
+		return gopacket.LayerTypeFragment
+	}
+
+	return GetLCMLayerType(lcm.fingerprint)
+}
+
+// LayerType returns LayerTypeLCM
+func (lcm LCM) LayerType() gopacket.LayerType {
+	return LayerTypeLCM
+}
+
+// LayerContents returns the contents of the LCM header.
+func (lcm LCM) LayerContents() []byte {
+	return lcm.contents
+}
+
+// LayerPayload returns the payload following this LCM header.
+func (lcm LCM) LayerPayload() []byte {
+	return lcm.payload
+}
+
+// Payload returns the payload following this LCM header.
+func (lcm LCM) Payload() []byte {
+	return lcm.LayerPayload()
+}

--- a/layers/lcm_test.go
+++ b/layers/lcm_test.go
@@ -1,0 +1,156 @@
+// Copyright 2018 Google, Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file in the root of the source
+// tree.
+
+package layers
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/google/gopacket"
+)
+
+var (
+	fingerprint uint64 = 0x6c636d2073656c66
+
+	shortPacket = []byte{
+		0x4c, 0x43, 0x30, 0x32, 0x00, 0x00, 0x00, 0x00, 0x4c, 0x43, 0x4d, 0x5f,
+		0x53, 0x45, 0x4c, 0x46, 0x5f, 0x54, 0x45, 0x53, 0x54, 0x00, 0x6c, 0x63,
+		0x6d, 0x20, 0x73, 0x65, 0x6c, 0x66, 0x20, 0x74, 0x65, 0x73, 0x74,
+	}
+
+	fragmentedPacket = []byte{
+		0x4c, 0x43, 0x30, 0x33, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x0d,
+		0x00, 0x00, 0x00, 0x2d, 0x00, 0x00, 0x00, 0x02, 0x4c, 0x43, 0x4d, 0x5f,
+		0x53, 0x45, 0x4c, 0x46, 0x5f, 0x54, 0x45, 0x53, 0x54, 0x00, 0x6c, 0x63,
+		0x6d, 0x20, 0x73, 0x65, 0x6c, 0x66, 0x20, 0x74, 0x65, 0x73, 0x74,
+	}
+
+	invalidPacket = []byte{
+		0x4c, 0x43, 0x30, 0x34, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	}
+
+	expectedChannel = "LCM_SELF_TEST"
+)
+
+func TestLCMDecode(t *testing.T) {
+	testShortLCM(t)
+	testFragmentedLCM(t)
+	testInvalidLCM(t)
+}
+
+func testShortLCM(t *testing.T) {
+	lcm := &LCM{}
+
+	err := lcm.DecodeFromBytes(shortPacket, gopacket.NilDecodeFeedback)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if lcm.Magic != LCMShortHeaderMagic {
+		t.Errorf("Expected LCM Magic %x, but decoded %x.\n",
+			LCMShortHeaderMagic, lcm.Magic)
+	}
+
+	if lcm.SequenceNumber != 0x00 {
+		t.Errorf("Expected an LCM Sequence Number of %x, but decoded %x.\n",
+			0x00, lcm.SequenceNumber)
+	}
+
+	if lcm.ChannelName != expectedChannel {
+		t.Errorf("Expected channel name %s but received %s\n",
+			expectedChannel, lcm.ChannelName)
+	}
+
+	if lcm.Fragmented {
+		t.Errorf("Misinterpreted non-fragmented packet as fragmented.")
+	}
+
+	for i, val := range lcm.LayerContents() {
+		if val != shortPacket[i] {
+			t.Errorf("\nLCM Payload: expected\n%sbut received\n%s",
+				hex.Dump(shortPacket[:22]), hex.Dump(lcm.Payload()))
+		}
+	}
+
+	for i, val := range lcm.Payload() {
+		if val != shortPacket[i+22] {
+			t.Errorf("\nLCM Payload: expected\n%sbut received\n%s",
+				hex.Dump(shortPacket[22:]), hex.Dump(lcm.Payload()))
+		}
+	}
+}
+
+func testFragmentedLCM(t *testing.T) {
+	lcm := LCM{}
+
+	err := lcm.DecodeFromBytes(fragmentedPacket, gopacket.NilDecodeFeedback)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if lcm.Magic != LCMFragmentedHeaderMagic {
+		t.Errorf("Expected LCM Magic %x, but decoded %x.\n",
+			LCMFragmentedHeaderMagic, lcm.Magic)
+	}
+
+	if lcm.SequenceNumber != 0x01 {
+		t.Errorf("Expected an LCM Sequence Number of %x, but decoded %x.\n",
+			0x01, lcm.SequenceNumber)
+	}
+
+	if lcm.PayloadSize != 0x0d {
+		t.Errorf("Expected an LCM Payload Size of %x, but decoded %x.\n", 0x0d,
+			lcm.PayloadSize)
+	}
+
+	if lcm.FragmentOffset != 0x2d {
+		t.Errorf("Expected an LCM Fragment Offset of %x, but decoded %x.\n",
+			0x2d, lcm.FragmentOffset)
+	}
+
+	if lcm.FragmentNumber != 0x00 {
+		t.Errorf("Expected the first LCM fragment (%x), but decoded %x.\n",
+			0x00, lcm.FragmentNumber)
+	}
+
+	if lcm.TotalFragments != 0x02 {
+		t.Errorf("Expected two LCM fragments (%x), but decoded %x.\n", 0x02,
+			lcm.TotalFragments)
+	}
+
+	if lcm.ChannelName != expectedChannel {
+		t.Errorf("Expected LCM Channel Name %s but decoded %s\n",
+			expectedChannel, lcm.ChannelName)
+	}
+
+	if !lcm.Fragmented {
+		t.Errorf("Misinterpreted fragmented packet as non-fragmented.")
+	}
+
+	for i, val := range lcm.LayerContents() {
+		if val != fragmentedPacket[i] {
+			t.Errorf("\nLCM Payload: expected\n%sbut received\n%s",
+				hex.Dump(fragmentedPacket[:22]), hex.Dump(lcm.Payload()))
+		}
+	}
+
+	for i, val := range lcm.Payload() {
+		if val != fragmentedPacket[i+34] {
+			t.Errorf("\nLCM Payload: expected\n%sbut received\n%s",
+				hex.Dump(fragmentedPacket[34:]), hex.Dump(lcm.Payload()))
+		}
+	}
+}
+
+func testInvalidLCM(t *testing.T) {
+	lcm := LCM{}
+
+	err := lcm.DecodeFromBytes(invalidPacket, gopacket.NilDecodeFeedback)
+	if err == nil {
+		t.Fatal("Did not detect LCM decode error.")
+	}
+}


### PR DESCRIPTION
This patch features support for LCM layers. The code is based on the LCM
protocol definition (https://lcm-proj.github.io/).
LCM is a lightweight communications protocol that is used e.g. in the
automotive industry for testing and developing purposes.

The submitted patch allows for decoding LCM headers plus the registration
of underlying decoders (which should be used in combination with an
incoming patch towards the LCM GitHub repository that will emit gopacket
code based on LCM defintions).