### PR TITLE
AF_PACKET:  Adding back VLAN header optional.

### DIFF
--- a/afpacket/afpacket.go
+++ b/afpacket/afpacket.go
@@ -283,7 +283,7 @@ retry:
 			goto retry
 		}
 	}
-	data = h.current.getData()
+	data = h.current.getData(&h.opts)
 	ci.Timestamp = h.current.getTime()
 	ci.CaptureLength = len(data)
 	ci.Length = h.current.getLength()

--- a/afpacket/options.go
+++ b/afpacket/options.go
@@ -92,6 +92,16 @@ type OptBlockTimeout time.Duration
 // descriptor to become ready. Specifying a negative value in  time‐out means an infinite timeout.
 type OptPollTimeout time.Duration
 
+// OptAddVLANHeader modifies the packet data that comes back from the
+// kernel by adding in the VLAN header that the NIC stripped.  AF_PACKET by
+// default uses VLAN offloading, in which the NIC strips the VLAN header off of
+// the packet before handing it to the kernel.  This means that, even if a
+// packet has an 802.1q header on the wire, it'll show up without one by the
+// time it goes through AF_PACKET.  If this option is true, the VLAN header is
+// added back in before the packet is returned.  Note that this potentially has
+// a large performance hit, especially in otherwise zero-copy operation.
+type OptAddVLANHeader bool
+
 // Default constants used by options.
 const (
 	DefaultFrameSize    = 4096                   // Default value for OptFrameSize.
@@ -106,6 +116,7 @@ type options struct {
 	framesPerBlock int
 	blockSize      int
 	numBlocks      int
+	addVLANHeader  bool
 	blockTimeout   time.Duration
 	pollTimeout    time.Duration
 	version        OptTPacketVersion
@@ -143,6 +154,8 @@ func parseOptions(opts ...interface{}) (ret options, err error) {
 			ret.iface = string(v)
 		case OptSocketType:
 			ret.socktype = v
+		case OptAddVLANHeader:
+			ret.addVLANHeader = bool(v)
 		default:
 			err = errors.New("unknown type in options")
 			return

--- a/examples/afpacket/afpacket.go
+++ b/examples/afpacket/afpacket.go
@@ -1,0 +1,65 @@
+// Copyright 2018 Google, Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file in the root of the source
+// tree.
+
+// afpacket provides a simple example of using afpacket with zero-copy to read
+// packet data.
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+	"runtime/pprof"
+
+	"github.com/google/gopacket/afpacket"
+
+	_ "github.com/google/gopacket/layers"
+)
+
+var (
+	iface      = flag.String("i", "eth0", "Interface to read from")
+	cpuprofile = flag.String("cpuprofile", "", "If non-empty, write CPU profile here")
+	count      = flag.Int64("c", -1, "If >= 0, # of packets to capture before returning")
+	verbose    = flag.Int64("log_every", 1, "Write a log every X packets")
+	addVLAN    = flag.Bool("add_vlan", false, "If true, add VLAN header")
+)
+
+func main() {
+	flag.Parse()
+	if *cpuprofile != "" {
+		log.Printf("Writing CPU profile to %q", *cpuprofile)
+		f, err := os.Create(*cpuprofile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if err := pprof.StartCPUProfile(f); err != nil {
+			log.Fatal(err)
+		}
+		defer pprof.StopCPUProfile()
+	}
+	log.Printf("Starting on interface %q", *iface)
+	source, err := afpacket.NewTPacket(
+		afpacket.OptInterface(*iface),
+		afpacket.OptBlockSize(1<<20 /*1MB*/),
+		afpacket.OptAddVLANHeader(*addVLAN))
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer source.Close()
+	bytes := uint64(0)
+	packets := uint64(0)
+	for ; *count != 0; *count-- {
+		data, _, err := source.ZeroCopyReadPacketData()
+		if err != nil {
+			log.Fatal(err)
+		}
+		bytes += uint64(len(data))
+		packets++
+		if *count%*verbose == 0 {
+			log.Printf("Read in %d bytes in %d packets", bytes, packets)
+		}
+	}
+}

--- a/gc
+++ b/gc
@@ -127,6 +127,9 @@ if [ -f /usr/include/pcap.h ]; then
   Root pcap_tester --mode=filtered
   Root pcap_tester --mode=timestamp || echo "You might not support timestamp sources"
   popd
+  pushd examples/afpacket
+  go build
+  popd
   pushd examples/pcapdump
   go build
   popd


### PR DESCRIPTION
Makes the adding back of the VLAN header for AF_PACKET packet data
optional and defaulted to off.  Especially for ZeroCopy, the addition of
VLAN headers is a performance hit (I clocked a 10x slowdown on a fast,
VLAN'd network).  While unfortunately it's counter-intuitive that the
kernel (or NIC, or whatever) removes the VLAN header, it's also
counter-intuitive that we return something to the user that the kernel
didn't return to us.  So, let's go for the thing that's at least fast,
while allowing for users to request the VLAN header if they'd like.