### PR TITLE
-Adding missing parsing in ospf.go

### DIFF
--- a/layers/ospf.go
+++ b/layers/ospf.go
@@ -131,10 +131,11 @@ type NetworkLSA struct {
 
 // RouterV2 extends RouterLSAV2
 type RouterV2 struct {
-	Type     uint8
-	LinkID   uint32
-	LinkData uint32
-	Metric   uint16
+	Type      uint8
+	LinkID    uint32
+	LinkData  uint32
+	NumMetric uint8
+	Metric    uint16
 }
 
 // RouterLSAV2 is the struct from RFC 2328  A.4.2.
@@ -282,6 +283,19 @@ func extractLSAInformation(lstype, lsalength uint16, data []byte) (interface{}, 
 	switch lstype {
 	case RouterLSAtypeV2:
 		var routers []RouterV2
+
+		var j uint32
+		for j = 24; j < uint32(lsalength); j += 12 {
+			router := RouterV2{
+				LinkID:    binary.BigEndian.Uint32(data[j : j+4]),
+				LinkData:  binary.BigEndian.Uint32(data[j+4 : j+8]),
+				Type:      uint8(data[j+8]),
+				NumMetric: uint8(data[j+9]),
+				Metric:    binary.BigEndian.Uint16(data[j+10 : j+12]),
+			}
+			routers = append(routers, router)
+		}
+
 		links := binary.BigEndian.Uint16(data[22:24])
 		content = RouterLSAV2{
 			Flags:   data[20],


### PR DESCRIPTION
-Added missing parsing within extractLSAInformation for RouterV2 structs.
-Added field, Number of Metric, for RouterV2 struct