### PR TITLE
Add support for out-of-band VLAN IDs on afpacket sources.

### DIFF
--- a/afpacket/afpacket.go
+++ b/afpacket/afpacket.go
@@ -288,6 +288,7 @@ retry:
 	ci.CaptureLength = len(data)
 	ci.Length = h.current.getLength()
 	ci.InterfaceIndex = h.current.getIfaceIndex()
+	ci.VLAN = h.current.getVLAN()
 	atomic.AddInt64(&h.stats.Packets, 1)
 	h.headerNextNeeded = true
 	h.mu.Unlock()

--- a/afpacket/afpacket.go
+++ b/afpacket/afpacket.go
@@ -53,6 +53,13 @@ func tpacketAlign(v int) int {
 	return int((uint(v) + tpacketAlignment - 1) & ((^tpacketAlignment) - 1))
 }
 
+// AncillaryVLAN structures are used to pass the captured VLAN
+// as ancillary data via CaptureInfo.
+type AncillaryVLAN struct {
+	// The VLAN VID provided by the kernel.
+	VLAN int
+}
+
 // Stats is a set of counters detailing the work TPacket has done so far.
 type Stats struct {
 	// Packets is the total number of packets returned to the caller.
@@ -288,7 +295,10 @@ retry:
 	ci.CaptureLength = len(data)
 	ci.Length = h.current.getLength()
 	ci.InterfaceIndex = h.current.getIfaceIndex()
-	ci.VLAN = h.current.getVLAN()
+	vlan := h.current.getVLAN()
+	if vlan >= 0 {
+		ci.AncillaryData = append(ci.AncillaryData, AncillaryVLAN{vlan})
+	}
 	atomic.AddInt64(&h.stats.Packets, 1)
 	h.headerNextNeeded = true
 	h.mu.Unlock()

--- a/afpacket/options.go
+++ b/afpacket/options.go
@@ -100,6 +100,10 @@ type OptPollTimeout time.Duration
 // time it goes through AF_PACKET.  If this option is true, the VLAN header is
 // added back in before the packet is returned.  Note that this potentially has
 // a large performance hit, especially in otherwise zero-copy operation.
+//
+// Note that if you do not need to have a "real" VLAN layer, it may be
+// preferable to use the VLAN ID provided in gopacket.CaptureInfo.VLAN,
+// which is populated out-of-band and has negligible performance impact.
 type OptAddVLANHeader bool
 
 // Default constants used by options.

--- a/afpacket/options.go
+++ b/afpacket/options.go
@@ -102,8 +102,10 @@ type OptPollTimeout time.Duration
 // a large performance hit, especially in otherwise zero-copy operation.
 //
 // Note that if you do not need to have a "real" VLAN layer, it may be
-// preferable to use the VLAN ID provided in gopacket.CaptureInfo.VLAN,
-// which is populated out-of-band and has negligible performance impact.
+// preferable to use the VLAN ID provided by the AncillaryVLAN struct
+// in CaptureInfo.AncillaryData, which is populated out-of-band and has
+// negligible performance impact. Such ancillary data will automatically
+// be provided if available.
 type OptAddVLANHeader bool
 
 // Default constants used by options.

--- a/packet.go
+++ b/packet.go
@@ -31,6 +31,12 @@ type CaptureInfo struct {
 	Length int
 	// InterfaceIndex
 	InterfaceIndex int
+	// VLAN is the VLAN ID if one was provided out-of-band by the
+	// capture mechanism. If no ID was provided, this will be -1.
+	// Note that this can be -1 and a VLAN header still present
+	// if the capture mechanism does not support out-of-band reporting
+	// of VLAN IDs.
+	VLAN int
 }
 
 // PacketMetadata contains metadata for a packet.

--- a/packet.go
+++ b/packet.go
@@ -31,12 +31,10 @@ type CaptureInfo struct {
 	Length int
 	// InterfaceIndex
 	InterfaceIndex int
-	// VLAN is the VLAN ID if one was provided out-of-band by the
-	// capture mechanism. If no ID was provided, this will be -1.
-	// Note that this can be -1 and a VLAN header still present
-	// if the capture mechanism does not support out-of-band reporting
-	// of VLAN IDs.
-	VLAN int
+	// The packet source can place ancillary data of various types here.
+	// For example, the afpacket source can report the VLAN of captured
+	// packets this way.
+	AncillaryData []interface{}
 }
 
 // PacketMetadata contains metadata for a packet.


### PR DESCRIPTION
The Linux kernel supports VLAN offloading, which will strip off VLAN headers before passing the packet data up to the capture layer. This results in the odd situation where the data presented to the capture layer is not what was actually visible on the wire.

For those who needed visibility into the VLAN layer, the `afpacket.OptAddVLANHeader` option was provided. When set, a synthetic VLAN header is created and copied over. While this works and provides a more accurate view of the data on the wire, it is slow (as noted in the documentation of the option, sometimes by an order of magnitude).

This commit augments the `gopacket.CaptureInfo` structure by adding a `VLAN` field that stores the VID (VLAN ID) of the packet if it was provided out-of-band by the capture mechanism. If it was not provided, this field defaults to -1 (it should not default to zero, as it is possible to have a zero VID, which is used for priority tagging).

This provides a fast mechanism to access VLAN information for those who need it while retaining the `afpacket.OptAddVLANHeader` mechanism for those who need it.