### PR TITLE
pcapgo: read.go - SetSnaplen to better control read parameters

### DIFF
--- a/pcapgo/read.go
+++ b/pcapgo/read.go
@@ -149,6 +149,11 @@ func (r *Reader) Snaplen() uint32 {
 	return r.snaplen
 }
 
+// SetSnaplen sets the snapshot length of the capture file.
+func (r *Reader) SetSnaplen(newSnaplen uint32) {
+	r.snaplen = newSnaplen
+}
+
 // Reader formater
 func (r *Reader) String() string {
 	return fmt.Sprintf("PcapFile  maj: %x min: %x snaplen: %d linktype: %s", r.versionMajor, r.versionMinor, r.snaplen, r.linkType)

--- a/pcapgo/read.go
+++ b/pcapgo/read.go
@@ -150,6 +150,32 @@ func (r *Reader) Snaplen() uint32 {
 }
 
 // SetSnaplen sets the snapshot length of the capture file.
+//
+// This is useful when a pcap file contains packets bigger than then snaplen.
+// Pcapgo will error when reading packets bigger than snaplen, then it dumps those
+// packets and reads the next 16 bytes, which are part of the "faulty" packet's payload, but pcapgo
+// thinks it's the next header, which is probably also faulty because it's not really a packet header.
+// This can lead to a lot of faulty reads.
+//
+// The SetSnaplen function can be used to set a bigger snaplen to prevent those read errors.
+//
+// This snaplen situation can happen when a pcap writer doesn't truncate packets to the snaplen size while writing packets to file.
+// E.g. In Python, dpkt.pcap.Writer sets snaplen by default to 1500 (https://dpkt.readthedocs.io/en/latest/api/api_auto.html#dpkt.pcap.Writer)
+// but doesn't enforce this when writing packets (https://dpkt.readthedocs.io/en/latest/_modules/dpkt/pcap.html#Writer.writepkt).
+// When reading, tools like tcpdump, tcpslice, mergecap and wireshark ignore the snaplen and use
+// their own defined snaplen.
+// E.g. When reading packets, tcpdump defines MAXIMUM_SNAPLEN (https://github.com/the-tcpdump-group/tcpdump/blob/6e80fcdbe9c41366df3fa244ffe4ac8cce2ab597/netdissect.h#L290)
+// and uses it (https://github.com/the-tcpdump-group/tcpdump/blob/66384fa15b04b47ad08c063d4728df3b9c1c0677/print.c#L343-L358).
+//
+// For further reading:
+// - https://github.com/the-tcpdump-group/tcpdump/issues/389
+// - https://bugs.wireshark.org/bugzilla/show_bug.cgi?id=8808
+// - https://www.wireshark.org/lists/wireshark-dev/201307/msg00061.html
+// - https://github.com/wireshark/wireshark/blob/bfd51199e707c1d5c28732be34b44a9ee8a91cd8/wiretap/pcap-common.c#L723-L742
+//   - https://github.com/wireshark/wireshark/blob/f07fb6cdfc0904905627707b88450054e921f092/wiretap/libpcap.c#L592-L598
+//   - https://github.com/wireshark/wireshark/blob/f07fb6cdfc0904905627707b88450054e921f092/wiretap/libpcap.c#L714-L727
+// - https://github.com/the-tcpdump-group/tcpdump/commit/d033c1bc381c76d13e4aface97a4f4ec8c3beca2
+// - https://github.com/the-tcpdump-group/tcpdump/blob/88e87cb2cb74c5f939792171379acd9e0efd8b9a/netdissect.h#L263-L290
 func (r *Reader) SetSnaplen(newSnaplen uint32) {
 	r.snaplen = newSnaplen
 }


### PR DESCRIPTION
This helps to better control what packet size to allow to read and what packet size to dump.

E.g. if a pcap has snaplen of 1500 but has packets of sizes bigger than 1500, [wireshark allows that](https://www.wireshark.org/lists/wireshark-dev/201307/msg00061.html), but pcapgo dumps the packet and reads the next 16 bytes (which are part of the faulty packet payload but pcapgo thinks it's the next header, which will probably also be faulty because it's not really a packet header).  
This can lead to a lot of faulty reads.

Tools like tcpslice, mergecap, tcpdump. pcapfix, etc usually ignore the pcap's snaplen and define their own read snaplen of 262144 or 131072 (e.g. tcpdump [defines max snaplen](https://github.com/the-tcpdump-group/tcpdump/blob/6e80fcdbe9c41366df3fa244ffe4ac8cce2ab597/netdissect.h#L290) and [uses it](https://github.com/the-tcpdump-group/tcpdump/blob/66384fa15b04b47ad08c063d4728df3b9c1c0677/print.c#L343-L358) when it reads a packet).