### PR TITLE
Post-check whether requested offset is in range of available bytes.

### DIFF
--- a/reassembly/tcpassembly.go
+++ b/reassembly/tcpassembly.go
@@ -157,11 +157,15 @@ func (rl *reassemblyObject) KeepFrom(offset int) {
 
 func (rl *reassemblyObject) CaptureInfo(offset int) gopacket.CaptureInfo {
 	current := 0
-	for _, r := range rl.all {
+	var r byteContainer
+	for _, r = range rl.all {
 		if current >= offset {
 			return r.captureInfo()
 		}
 		current += r.length()
+	}
+	if r != nil && current >= offset {
+		return r.captureInfo()
 	}
 	// Invalid offset
 	return gopacket.CaptureInfo{}


### PR DESCRIPTION
Without this, it seems a request for the CaptureInfo at, for example, byte 1, will return the empty CaptureInfo struct in the common case where `len(rl.all) == 1`, even though there's of course a byte 1 and available CaptureInfo that corresponds to it.