### PR TITLE
Convert LLC and SNAP to DecodingLayer interface

### DIFF
--- a/layers/llc.go
+++ b/layers/llc.go
@@ -132,7 +132,7 @@ func decodeSNAP(data []byte, p gopacket.PacketBuilder) error {
 // SerializationBuffer, implementing gopacket.SerializableLayer.
 // See the docs for gopacket.SerializableLayer for more info.
 func (l *LLC) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeOptions) error {
-	var ig_flag, cr_flag byte
+	var igFlag, crFlag byte
 	var length int
 
 	if l.Control&0xFF00 != 0 {
@@ -152,18 +152,18 @@ func (l *LLC) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeOpt
 	if buf, err := b.PrependBytes(length); err != nil {
 		return err
 	} else {
-		ig_flag = 0
+		igFlag = 0
 		if l.IG {
-			ig_flag = 0x1
+			igFlag = 0x1
 		}
 
-		cr_flag = 0
+		crFlag = 0
 		if l.CR {
-			cr_flag = 0x1
+			crFlag = 0x1
 		}
 
-		buf[0] = l.DSAP + ig_flag
-		buf[1] = l.SSAP + cr_flag
+		buf[0] = l.DSAP + igFlag
+		buf[1] = l.SSAP + crFlag
 
 		if length == 4 {
 			buf[2] = uint8(l.Control >> 8)

--- a/layers/llc.go
+++ b/layers/llc.go
@@ -27,6 +27,47 @@ type LLC struct {
 // LayerType returns gopacket.LayerTypeLLC.
 func (l *LLC) LayerType() gopacket.LayerType { return LayerTypeLLC }
 
+// DecodeFromBytes decodes the given bytes into this layer.
+func (l *LLC) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
+	if len(data) < 3 {
+		return errors.New("LLC header too small")
+	}
+	l.DSAP = data[0] & 0xFE
+	l.IG = data[0]&0x1 != 0
+	l.SSAP = data[1] & 0xFE
+	l.CR = data[1]&0x1 != 0
+	l.Control = uint16(data[2])
+
+	if l.Control&0x1 == 0 || l.Control&0x3 == 0x1 {
+		if len(data) < 4 {
+			return errors.New("LLC header too small")
+		}
+		l.Control = l.Control<<8 | uint16(data[3])
+		l.Contents = data[:4]
+		l.Payload = data[4:]
+	} else {
+		l.Contents = data[:3]
+		l.Payload = data[3:]
+	}
+	return nil
+}
+
+// CanDecode returns the set of layer types that this DecodingLayer can decode.
+func (l *LLC) CanDecode() gopacket.LayerClass {
+	return LayerTypeLLC
+}
+
+// NextLayerType returns the layer type contained by this DecodingLayer.
+func (l *LLC) NextLayerType() gopacket.LayerType {
+	switch {
+	case l.DSAP == 0xAA && l.SSAP == 0xAA:
+		return LayerTypeSNAP
+	case l.DSAP == 0x42 && l.SSAP == 0x42:
+		return LayerTypeSTP
+	}
+	return gopacket.LayerTypeZero // Not implemented
+}
+
 // SNAP is used inside LLC.  See
 // http://standards.ieee.org/getieee802/download/802-2001.pdf.
 // From http://en.wikipedia.org/wiki/Subnetwork_Access_Protocol:
@@ -42,37 +83,43 @@ type SNAP struct {
 // LayerType returns gopacket.LayerTypeSNAP.
 func (s *SNAP) LayerType() gopacket.LayerType { return LayerTypeSNAP }
 
-func decodeLLC(data []byte, p gopacket.PacketBuilder) error {
-	l := &LLC{
-		DSAP:    data[0] & 0xFE,
-		IG:      data[0]&0x1 != 0,
-		SSAP:    data[1] & 0xFE,
-		CR:      data[1]&0x1 != 0,
-		Control: uint16(data[2]),
+// DecodeFromBytes decodes the given bytes into this layer.
+func (s *SNAP) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
+	if len(data) < 5 {
+		return errors.New("SNAP header too small")
 	}
-	if l.Control&0x1 == 0 || l.Control&0x3 == 0x1 {
-		l.Control = l.Control<<8 | uint16(data[3])
-		l.Contents = data[:4]
-		l.Payload = data[4:]
-	} else {
-		l.Contents = data[:3]
-		l.Payload = data[3:]
+	s.OrganizationalCode = data[:3]
+	s.Type = EthernetType(binary.BigEndian.Uint16(data[3:5]))
+	s.BaseLayer = BaseLayer{data[:5], data[5:]}
+	return nil
+}
+
+// CanDecode returns the set of layer types that this DecodingLayer can decode.
+func (s *SNAP) CanDecode() gopacket.LayerClass {
+	return LayerTypeLLC
+}
+
+// NextLayerType returns the layer type contained by this DecodingLayer.
+func (s *SNAP) NextLayerType() gopacket.LayerType {
+	// See BUG(gconnel) in decodeSNAP
+	return s.Type.LayerType()
+}
+
+func decodeLLC(data []byte, p gopacket.PacketBuilder) error {
+	l := &LLC{}
+	err := l.DecodeFromBytes(data, p)
+	if err != nil {
+		return err
 	}
 	p.AddLayer(l)
-	switch {
-	case l.DSAP == 0xAA && l.SSAP == 0xAA:
-		return p.NextDecoder(LayerTypeSNAP)
-	case l.DSAP == 0x42 && l.SSAP == 0x42:
-		return p.NextDecoder(LayerTypeSTP)
-	}
-	return p.NextDecoder(gopacket.DecodeUnknown)
+	return p.NextDecoder(l.NextLayerType())
 }
 
 func decodeSNAP(data []byte, p gopacket.PacketBuilder) error {
-	s := &SNAP{
-		OrganizationalCode: data[:3],
-		Type:               EthernetType(binary.BigEndian.Uint16(data[3:5])),
-		BaseLayer:          BaseLayer{data[:5], data[5:]},
+	s := &SNAP{}
+	err := s.DecodeFromBytes(data, p)
+	if err != nil {
+		return err
 	}
 	p.AddLayer(s)
 	// BUG(gconnell):  When decoding SNAP, we treat the SNAP type as an Ethernet


### PR DESCRIPTION
This moves code from the decodeX functions to DecodeFromBytes for both LLC and SNAP and changes decodeX to use DecodeFromBytes. The only behavioral change I introduced is error handling in case the passed byte-slice is too short.

Since I touched the file, I also added a second commit that removes the underscores in LLC.SerializeTo from the variable names to make the linter happy - I can make a separate pull request for this if you like.