### PR TITLE
Reset Length field in Ethernet.DecodeFromBytes

### DIFF
--- a/layers/ethernet.go
+++ b/layers/ethernet.go
@@ -46,6 +46,7 @@ func (eth *Ethernet) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) er
 	eth.SrcMAC = net.HardwareAddr(data[6:12])
 	eth.EthernetType = EthernetType(binary.BigEndian.Uint16(data[12:14]))
 	eth.BaseLayer = BaseLayer{data[:14], data[14:]}
+	eth.Length = 0
 	if eth.EthernetType < 0x0600 {
 		eth.Length = uint16(eth.EthernetType)
 		eth.EthernetType = EthernetTypeLLC


### PR DESCRIPTION
This is necessary since the DecodingLayer interface states that the whole layer must be reset.

Without this fix, if one uses in-place decoding (e.g. DecodingLayerParser), a IEEE 802.3-style ethernet frame followed by an Ethernet II frame leaks the Length from the first packet to the second one.