### PR TITLE
Allow pcap_next_ex return value to be greater than 1

### DIFF
--- a/pcap/pcap.go
+++ b/pcap/pcap.go
@@ -105,7 +105,7 @@ int pcap_set_rfmon(pcap_t *p, int rfmon) {
 int pcap_next_ex_escaping(pcap_t *p, uintptr_t pkt_hdr, uintptr_t pkt_data) {
   int ex = pcap_next_ex(p, (struct pcap_pkthdr**)(pkt_hdr), (const u_char**)(pkt_data));
   if (ex > 1) {
-	ex = 1;
+    ex = 1;
   }
   return ex;
 }

--- a/pcap/pcap.go
+++ b/pcap/pcap.go
@@ -102,6 +102,9 @@ int pcap_set_rfmon(pcap_t *p, int rfmon) {
 #endif
 
 // The things we do to avoid pointers escaping to the heap...
+// According to https://github.com/the-tcpdump-group/libpcap/blob/1131a7c26c6f4d4772e4a2beeaf7212f4dea74ac/pcap.c#L398-L406 ,
+// the return value of pcap_next_ex could be greater than 1 for success.
+// Let's just make it 1 if it comes bigger than 1.
 int pcap_next_ex_escaping(pcap_t *p, uintptr_t pkt_hdr, uintptr_t pkt_data) {
   int ex = pcap_next_ex(p, (struct pcap_pkthdr**)(pkt_hdr), (const u_char**)(pkt_data));
   if (ex > 1) {

--- a/pcap/pcap.go
+++ b/pcap/pcap.go
@@ -103,7 +103,11 @@ int pcap_set_rfmon(pcap_t *p, int rfmon) {
 
 // The things we do to avoid pointers escaping to the heap...
 int pcap_next_ex_escaping(pcap_t *p, uintptr_t pkt_hdr, uintptr_t pkt_data) {
-  return pcap_next_ex(p, (struct pcap_pkthdr**)(pkt_hdr), (const u_char**)(pkt_data));
+  int ex = pcap_next_ex(p, (struct pcap_pkthdr**)(pkt_hdr), (const u_char**)(pkt_data));
+  if (ex > 1) {
+	ex = 1;
+  }
+  return ex;
 }
 */
 import "C"


### PR DESCRIPTION
According to [man pcap_next_ex](https://linux.die.net/man/3/pcap_next_ex), return value of pcap_next_ex should be 1 if OK, but actually it could be greater than 1 according to [the comment in the source code](https://github.com/the-tcpdump-group/libpcap/blob/1131a7c26c6f4d4772e4a2beeaf7212f4dea74ac/pcap.c#L398-L406).

If more than 1 package captured during 1sec, the original implementation will cause malfunction in `ReadPacketData` and `ZeroCopyReadPacketData`. It should be OK if we allow all return value that greater than 1 to be `NextErrorOK`.