### PR TITLE
fix icmpv6 option decode crash issue

### DIFF
--- a/layers/icmp6msg.go
+++ b/layers/icmp6msg.go
@@ -485,6 +485,11 @@ func (i *ICMPv6Options) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback)
 		// unit is 8 octets, convert to bytes
 		length := int(data[1]) * 8
 
+		if length == 0 {
+			df.SetTruncated()
+			return errors.New("ICMPv6 message option with length 0")
+		}
+
 		if len(data) < length {
 			df.SetTruncated()
 			return fmt.Errorf("ICMP layer only %v bytes for ICMPv6 message option with length %v", len(data), length)


### PR DESCRIPTION
Decoding ICMPv6 packet with zero length of ICMPv6 option length will cause panic. 
Security hole. 
=======
panic: runtime error: slice bounds out of range [recovered]
	panic: runtime error: slice bounds out of range

goroutine 50 [running]:
testing.tRunner.func1(0xc4204262d0)
	/usr/local/go/src/testing/testing.go:711 +0x2d2
panic(0xcbc8e0, 0x1627cf0)
	/usr/local/go/src/runtime/panic.go:491 +0x283
bitbucket-eng-sjc1.cisco.com/bitbucket/cloudcmts/cmts-l3-dhcprelay/vendor/github.com/google/gopacket/layers.(*ICMPv6Options).DecodeFromBytes(0xc4204d3b38, 0x1652b26, 0x7, 0x7, 0x1642b60, 0x1bdb2e0, 0x164e460, 0xc42006eea0)
	/go/src/bitbucket-eng-sjc1.cisco.com/bitbucket/cloudcmts/cmts-l3-dhcprelay/vendor/github.com/google/gopacket/layers/icmp6msg.go:470 +0x426
bitbucket-eng-sjc1.cisco.com/bitbucket/cloudcmts/cmts-l3-dhcprelay/vendor/github.com/google/gopacket/layers.(*ICMPv6RouterSolicitation).DecodeFromBytes(0xc4204d3b08, 0x1652b22, 0xb, 0xb, 0x1642b60, 0x1bdb2e0, 0x0, 0x4e504b)
	/go/src/bitbucket-eng-sjc1.cisco.com/bitbucket/cloudcmts/cmts-l3-dhcprelay/vendor/github.com/google/gopacket/layers/icmp6msg.go:175 +0x11d