### PR TITLE
make pcapgo compilable on non linux machine

### DIFF
--- a/pcapgo/capture.go
+++ b/pcapgo/capture.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file in the root of the source
 // tree.
+// +build linux
 
 package pcapgo
 


### PR DESCRIPTION
syscall.ETH_P_ALL is only defined for linux