### PR TITLE
Serialized Layer Introspection [Fixes #517]

### DIFF
--- a/layers/icmp6hopbyhop_test.go
+++ b/layers/icmp6hopbyhop_test.go
@@ -74,4 +74,11 @@ func TestPacketICMPv6WithHopByHop(t *testing.T) {
 	if expectedType != actualType {
 		t.Errorf("expected ICMP layer's TypeCode to be %d but was %d", expectedType, actualType)
 	}
+
+	p := gopacket.NewPacket(icmp6HopByHopData, LinkTypeEthernet, gopacket.Default)
+	if p.ErrorLayer() != nil {
+		t.Error("Failed to decode packet:", p.ErrorLayer().Error())
+	}
+	checkLayers(p, []gopacket.LayerType{LayerTypeEthernet, LayerTypeIPv6, LayerTypeIPv6HopByHop, LayerTypeICMPv6}, t)
+	checkSerialization(p, t)
 }

--- a/layers/ip6.go
+++ b/layers/ip6.go
@@ -17,7 +17,8 @@ import (
 )
 
 const (
-	IPv6HopByHopOptionJumbogram = 0xC2 // RFC 2675
+	// IPv6HopByHopOptionJumbogram code as defined in RFC 2675
+	IPv6HopByHopOptionJumbogram = 0xC2
 )
 
 const (
@@ -42,10 +43,11 @@ type IPv6 struct {
 }
 
 // LayerType returns LayerTypeIPv6
-func (i *IPv6) LayerType() gopacket.LayerType { return LayerTypeIPv6 }
+func (ipv6 *IPv6) LayerType() gopacket.LayerType { return LayerTypeIPv6 }
 
-func (i *IPv6) NetworkFlow() gopacket.Flow {
-	return gopacket.NewFlow(EndpointIPv6, i.SrcIP, i.DstIP)
+// NetworkFlow returns this new Flow (EndpointIPv6, SrcIP, DstIP)
+func (ipv6 *IPv6) NetworkFlow() gopacket.Flow {
+	return gopacket.NewFlow(EndpointIPv6, ipv6.SrcIP, ipv6.DstIP)
 }
 
 // Search for Jumbo Payload TLV in IPv6HopByHop and return (length, true) if found
@@ -115,7 +117,7 @@ func setIPv6PayloadJumboLength(hbh []byte) error {
 		opt := hbh[offset]
 		if opt == 0 {
 			//Pad1
-			offset += 1
+			offset++
 			continue
 		}
 		optLen := int(hbh[offset+1])
@@ -134,7 +136,7 @@ func setIPv6PayloadJumboLength(hbh []byte) error {
 // SerializeTo writes the serialized form of this layer into the
 // SerializationBuffer, implementing gopacket.SerializableLayer.
 // See the docs for gopacket.SerializableLayer for more info.
-func (ip6 *IPv6) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeOptions) error {
+func (ipv6 *IPv6) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeOptions) error {
 	var jumbo bool
 	var err error
 
@@ -145,11 +147,11 @@ func (ip6 *IPv6) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.Serialize
 		if opts.FixLengths {
 			// We need to set the length later because the hop-by-hop header may
 			// not exist or else need padding, so pLen may yet change
-			addIPv6JumboOption(ip6)
-		} else if ip6.HopByHop == nil {
+			addIPv6JumboOption(ipv6)
+		} else if ipv6.HopByHop == nil {
 			return fmt.Errorf("Cannot fit payload length of %d into IPv6 packet", pLen)
 		} else {
-			_, ok, err := getIPv6HopByHopJumboLength(ip6.HopByHop)
+			_, ok, err := getIPv6HopByHopJumboLength(ipv6.HopByHop)
 			if err != nil {
 				return err
 			}
@@ -160,7 +162,7 @@ func (ip6 *IPv6) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.Serialize
 	}
 
 	hbhAlreadySerialized := false
-	if ip6.HopByHop != nil {
+	if ipv6.HopByHop != nil {
 		for _, l := range b.Layers() {
 			if l == LayerTypeIPv6HopByHop {
 				hbhAlreadySerialized = true
@@ -168,12 +170,12 @@ func (ip6 *IPv6) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.Serialize
 			}
 		}
 	}
-	if ip6.HopByHop != nil && !hbhAlreadySerialized {
-		if ip6.NextHeader != IPProtocolIPv6HopByHop {
+	if ipv6.HopByHop != nil && !hbhAlreadySerialized {
+		if ipv6.NextHeader != IPProtocolIPv6HopByHop {
 			// Just fix it instead of throwing an error
-			ip6.NextHeader = IPProtocolIPv6HopByHop
+			ipv6.NextHeader = IPProtocolIPv6HopByHop
 		}
-		err = ip6.HopByHop.SerializeTo(b, opts)
+		err = ipv6.HopByHop.SerializeTo(b, opts)
 		if err != nil {
 			return err
 		}
@@ -194,90 +196,94 @@ func (ip6 *IPv6) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.Serialize
 	if err != nil {
 		return err
 	}
-	bytes[0] = (ip6.Version << 4) | (ip6.TrafficClass >> 4)
-	bytes[1] = (ip6.TrafficClass << 4) | uint8(ip6.FlowLabel>>16)
-	binary.BigEndian.PutUint16(bytes[2:], uint16(ip6.FlowLabel))
+	bytes[0] = (ipv6.Version << 4) | (ipv6.TrafficClass >> 4)
+	bytes[1] = (ipv6.TrafficClass << 4) | uint8(ipv6.FlowLabel>>16)
+	binary.BigEndian.PutUint16(bytes[2:], uint16(ipv6.FlowLabel))
 	if opts.FixLengths {
 		if jumbo {
-			ip6.Length = 0
+			ipv6.Length = 0
 		} else {
-			ip6.Length = uint16(pLen)
+			ipv6.Length = uint16(pLen)
 		}
 	}
-	binary.BigEndian.PutUint16(bytes[4:], ip6.Length)
-	bytes[6] = byte(ip6.NextHeader)
-	bytes[7] = byte(ip6.HopLimit)
-	if err := ip6.AddressTo16(); err != nil {
+	binary.BigEndian.PutUint16(bytes[4:], ipv6.Length)
+	bytes[6] = byte(ipv6.NextHeader)
+	bytes[7] = byte(ipv6.HopLimit)
+	if err := ipv6.AddressTo16(); err != nil {
 		return err
 	}
-	copy(bytes[8:], ip6.SrcIP)
-	copy(bytes[24:], ip6.DstIP)
+	copy(bytes[8:], ipv6.SrcIP)
+	copy(bytes[24:], ipv6.DstIP)
 	return nil
 }
 
-func (ip6 *IPv6) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
-	ip6.Version = uint8(data[0]) >> 4
-	ip6.TrafficClass = uint8((binary.BigEndian.Uint16(data[0:2]) >> 4) & 0x00FF)
-	ip6.FlowLabel = binary.BigEndian.Uint32(data[0:4]) & 0x000FFFFF
-	ip6.Length = binary.BigEndian.Uint16(data[4:6])
-	ip6.NextHeader = IPProtocol(data[6])
-	ip6.HopLimit = data[7]
-	ip6.SrcIP = data[8:24]
-	ip6.DstIP = data[24:40]
-	ip6.HopByHop = nil
-	ip6.BaseLayer = BaseLayer{data[:40], data[40:]}
+// DecodeFromBytes implementation according to gopacket.DecodingLayer
+func (ipv6 *IPv6) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
+	ipv6.Version = uint8(data[0]) >> 4
+	ipv6.TrafficClass = uint8((binary.BigEndian.Uint16(data[0:2]) >> 4) & 0x00FF)
+	ipv6.FlowLabel = binary.BigEndian.Uint32(data[0:4]) & 0x000FFFFF
+	ipv6.Length = binary.BigEndian.Uint16(data[4:6])
+	ipv6.NextHeader = IPProtocol(data[6])
+	ipv6.HopLimit = data[7]
+	ipv6.SrcIP = data[8:24]
+	ipv6.DstIP = data[24:40]
+	ipv6.HopByHop = nil
+	ipv6.BaseLayer = BaseLayer{data[:40], data[40:]}
 
 	// We treat a HopByHop IPv6 option as part of the IPv6 packet, since its
 	// options are crucial for understanding what's actually happening per packet.
-	if ip6.NextHeader == IPProtocolIPv6HopByHop {
-		err := ip6.hbh.DecodeFromBytes(ip6.Payload, df)
+	if ipv6.NextHeader == IPProtocolIPv6HopByHop {
+		err := ipv6.hbh.DecodeFromBytes(ipv6.Payload, df)
 		if err != nil {
 			return err
 		}
-		ip6.HopByHop = &ip6.hbh
-		pEnd, jumbo, err := getIPv6HopByHopJumboLength(ip6.HopByHop)
+		ipv6.HopByHop = &ipv6.hbh
+		pEnd, jumbo, err := getIPv6HopByHopJumboLength(ipv6.HopByHop)
 		if err != nil {
 			return err
 		}
-		if jumbo && ip6.Length == 0 {
+		if jumbo && ipv6.Length == 0 {
 			pEnd := int(pEnd)
-			if pEnd > len(ip6.Payload) {
+			if pEnd > len(ipv6.Payload) {
 				df.SetTruncated()
-				pEnd = len(ip6.Payload)
+				pEnd = len(ipv6.Payload)
 			}
-			ip6.Payload = ip6.Payload[:pEnd]
+			ipv6.Payload = ipv6.Payload[:pEnd]
 			return nil
-		} else if jumbo && ip6.Length != 0 {
+		} else if jumbo && ipv6.Length != 0 {
 			return errors.New("IPv6 has jumbo length and IPv6 length is not 0")
-		} else if !jumbo && ip6.Length == 0 {
+		} else if !jumbo && ipv6.Length == 0 {
 			return errors.New("IPv6 length 0, but HopByHop header does not have jumbogram option")
 		} else {
-			ip6.Payload = ip6.Payload[ip6.hbh.ActualLength:]
+			ipv6.Payload = ipv6.Payload[ipv6.hbh.ActualLength:]
 		}
 	}
 
-	if ip6.Length == 0 {
-		return fmt.Errorf("IPv6 length 0, but next header is %v, not HopByHop", ip6.NextHeader)
-	} else {
-		pEnd := int(ip6.Length)
-		if pEnd > len(ip6.Payload) {
-			df.SetTruncated()
-			pEnd = len(ip6.Payload)
-		}
-		ip6.Payload = ip6.Payload[:pEnd]
+	if ipv6.Length == 0 {
+		return fmt.Errorf("IPv6 length 0, but next header is %v, not HopByHop", ipv6.NextHeader)
 	}
+
+	pEnd := int(ipv6.Length)
+	if pEnd > len(ipv6.Payload) {
+		df.SetTruncated()
+		pEnd = len(ipv6.Payload)
+	}
+	ipv6.Payload = ipv6.Payload[:pEnd]
+
 	return nil
 }
 
-func (i *IPv6) CanDecode() gopacket.LayerClass {
+// CanDecode implementation according to gopacket.DecodingLayer
+func (ipv6 *IPv6) CanDecode() gopacket.LayerClass {
 	return LayerTypeIPv6
 }
 
-func (i *IPv6) NextLayerType() gopacket.LayerType {
-	if i.HopByHop != nil {
-		return i.HopByHop.NextHeader.LayerType()
+// NextLayerType implementation according to gopacket.DecodingLayer
+func (ipv6 *IPv6) NextLayerType() gopacket.LayerType {
+	if ipv6.HopByHop != nil {
+		return ipv6.HopByHop.NextHeader.LayerType()
 	}
-	return i.NextHeader.LayerType()
+	return ipv6.NextHeader.LayerType()
 }
 
 func decodeIPv6(data []byte, p gopacket.PacketBuilder) error {
@@ -414,6 +420,7 @@ type IPv6ExtensionSkipper struct {
 	BaseLayer
 }
 
+// DecodeFromBytes implementation according to gopacket.DecodingLayer
 func (i *IPv6ExtensionSkipper) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 	extension := decodeIPv6ExtensionBase(data)
 	i.BaseLayer = BaseLayer{data[:extension.ActualLength], data[extension.ActualLength:]}
@@ -421,10 +428,12 @@ func (i *IPv6ExtensionSkipper) DecodeFromBytes(data []byte, df gopacket.DecodeFe
 	return nil
 }
 
+// CanDecode implementation according to gopacket.DecodingLayer
 func (i *IPv6ExtensionSkipper) CanDecode() gopacket.LayerClass {
 	return LayerClassIPv6Extension
 }
 
+// NextLayerType implementation according to gopacket.DecodingLayer
 func (i *IPv6ExtensionSkipper) NextLayerType() gopacket.LayerType {
 	return i.NextHeader.LayerType()
 }
@@ -441,6 +450,7 @@ type IPv6HopByHop struct {
 // LayerType returns LayerTypeIPv6HopByHop.
 func (i *IPv6HopByHop) LayerType() gopacket.LayerType { return LayerTypeIPv6HopByHop }
 
+// SerializeTo implementation according to gopacket.SerializableLayer
 func (i *IPv6HopByHop) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeOptions) error {
 	var bytes []byte
 	var err error
@@ -473,6 +483,7 @@ func (i *IPv6HopByHop) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.Ser
 	return nil
 }
 
+// DecodeFromBytes implementation according to gopacket.DecodingLayer
 func (i *IPv6HopByHop) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 	i.ipv6ExtensionBase = decodeIPv6ExtensionBase(data)
 	offset := 2
@@ -494,6 +505,7 @@ func decodeIPv6HopByHop(data []byte, p gopacket.PacketBuilder) error {
 	return p.NextDecoder(i.NextHeader)
 }
 
+// SetJumboLength adds the IPv6HopByHopOptionJumbogram with the given length
 func (o *IPv6HopByHopOption) SetJumboLength(len uint32) {
 	o.OptionType = IPv6HopByHopOptionJumbogram
 	o.OptionLength = 4
@@ -586,6 +598,7 @@ type IPv6Destination struct {
 // LayerType returns LayerTypeIPv6Destination.
 func (i *IPv6Destination) LayerType() gopacket.LayerType { return LayerTypeIPv6Destination }
 
+// DecodeFromBytes implementation according to gopacket.DecodingLayer
 func (i *IPv6Destination) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 	i.ipv6ExtensionBase = decodeIPv6ExtensionBase(data)
 	offset := 2
@@ -652,11 +665,12 @@ func checkIPv6Address(addr net.IP) error {
 	return fmt.Errorf("wrong length of %d bytes instead of %d", len(addr), net.IPv6len)
 }
 
-func (ip *IPv6) AddressTo16() error {
-	if err := checkIPv6Address(ip.SrcIP); err != nil {
+// AddressTo16 ensures IPv6.SrcIP and IPv6.DstIP are actually IPv6 addresses (i.e. 16 byte addresses)
+func (ipv6 *IPv6) AddressTo16() error {
+	if err := checkIPv6Address(ipv6.SrcIP); err != nil {
 		return fmt.Errorf("Invalid source IPv6 address (%s)", err)
 	}
-	if err := checkIPv6Address(ip.DstIP); err != nil {
+	if err := checkIPv6Address(ipv6.DstIP); err != nil {
 		return fmt.Errorf("Invalid destination IPv6 address (%s)", err)
 	}
 	return nil

--- a/layers/ip6.go
+++ b/layers/ip6.go
@@ -158,7 +158,17 @@ func (ip6 *IPv6) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.Serialize
 			}
 		}
 	}
+
+	hbhAlreadySerialized := false
 	if ip6.HopByHop != nil {
+		for _, l := range b.Layers() {
+			if l == LayerTypeIPv6HopByHop {
+				hbhAlreadySerialized = true
+				break
+			}
+		}
+	}
+	if ip6.HopByHop != nil && !hbhAlreadySerialized {
 		if ip6.NextHeader != IPProtocolIPv6HopByHop {
 			// Just fix it instead of throwing an error
 			ip6.NextHeader = IPProtocolIPv6HopByHop
@@ -176,6 +186,7 @@ func (ip6 *IPv6) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.Serialize
 			}
 		}
 	}
+
 	if !jumbo && pLen > ipv6MaxPayloadLength {
 		return errors.New("Cannot fit payload into IPv6 header")
 	}

--- a/writer.go
+++ b/writer.go
@@ -36,6 +36,8 @@ type SerializableLayer interface {
 	// LayerPayload.  It just serializes based on struct fields, neither
 	// modifying nor using contents/payload.
 	SerializeTo(b SerializeBuffer, opts SerializeOptions) error
+	// LayerType returns the type of the layer that is being serialized to the buffer
+	LayerType() LayerType
 }
 
 // SerializeOptions provides options for behaviors that SerializableLayers may want to
@@ -97,12 +99,19 @@ type SerializeBuffer interface {
 	// the byte slice returned by any previous call to Bytes() for this buffer
 	// should be considered invalidated.
 	Clear() error
+	// Layers returns all the Layers that have been successfully serialized into this buffer
+	// already.
+	Layers() []LayerType
+	// PushLayer adds the current Layer to the list of Layers that have been serialized
+	// into this buffer.
+	PushLayer(LayerType)
 }
 
 type serializeBuffer struct {
 	data                []byte
 	start               int
 	prepended, appended int
+	layers              []LayerType
 }
 
 // NewSerializeBuffer creates a new instance of the default implementation of
@@ -171,7 +180,16 @@ func (w *serializeBuffer) AppendBytes(num int) ([]byte, error) {
 func (w *serializeBuffer) Clear() error {
 	w.start = w.prepended
 	w.data = w.data[:w.start]
+	w.layers = []LayerType{}
 	return nil
+}
+
+func (w *serializeBuffer) Layers() []LayerType {
+	return w.layers
+}
+
+func (w *serializeBuffer) PushLayer(l LayerType) {
+	w.layers = append(w.layers, l)
 }
 
 // SerializeLayers clears the given write buffer, then writes all layers into it so
@@ -193,6 +211,7 @@ func SerializeLayers(w SerializeBuffer, opts SerializeOptions, layers ...Seriali
 		if err != nil {
 			return err
 		}
+		w.PushLayer(layer.LayerType())
 	}
 	return nil
 }

--- a/writer.go
+++ b/writer.go
@@ -180,7 +180,7 @@ func (w *serializeBuffer) AppendBytes(num int) ([]byte, error) {
 func (w *serializeBuffer) Clear() error {
 	w.start = w.prepended
 	w.data = w.data[:w.start]
-	w.layers = []LayerType{}
+	w.layers = w.layers[:0]
 	return nil
 }
 


### PR DESCRIPTION
This PR adds a way for the current layer to see all the layers that were successfully serialized before the current layer, during the serialization of the current layer.

I've come up with this solution in an attempt to fix #517 in a clean way, i.e. without inspecting the actual buffer. I believe the method I've chosen can be useful for other serialization implementations, like such that have the same challenges as described in #517. (tl;dr: Information is present in the "main layer" but also in a separate layer, but must not be serialized twice).

It's important to understand that the solution, as implemented, always prefers the information present in the extra layer over the information present in the "main layer". E.g. in #517, the HopByHop information of the IPv6 layer is ignored when an IPv6HopByHop layer was serialized before.

Bonus: I've cleaned up the `golint` errors in `ip6.go`. As a reviewer you might want to review this PR commit by commit.