### PR TITLE
Fix 64-bit alignment of sync.atomic in afpacket and pcap. Fixes #512

### DIFF
--- a/afpacket/afpacket.go
+++ b/afpacket/afpacket.go
@@ -103,6 +103,8 @@ func (s *SocketStatsV3) QueueFreezes() uint {
 
 // TPacket implements packet receiving for Linux AF_PACKET versions 1, 2, and 3.
 type TPacket struct {
+	// stats is simple statistics on TPacket's run. This MUST be the first entry to ensure alignment for sync.atomic
+	stats Stats
 	// fd is the C file descriptor.
 	fd int
 	// ring points to the memory space of the ring buffer shared by tpacket and the kernel.
@@ -130,8 +132,6 @@ type TPacket struct {
 	v3 v3wrapper
 
 	statsMu sync.Mutex // guards stats below
-	// stats is simple statistics on TPacket's run.
-	stats Stats
 	// socketStats contains stats from the socket
 	socketStats SocketStats
 	// same as socketStats, but with an extra field freeze_q_cnt

--- a/pcap/pcap.go
+++ b/pcap/pcap.go
@@ -154,6 +154,10 @@ const bpfInstructionBufferSize = 8 * MaxBpfInstructions
 //
 // Handles are already pcap_activate'd
 type Handle struct {
+	// stop is set to a non-zero value by Handle.Close to signal to
+	// getNextBufPtrLocked to stop trying to read packets
+	// This must be the first entry to ensure alignment for sync.atomic
+	stop uint64
 	// cptr is the handle for the actual pcap C object.
 	cptr        *C.pcap_t
 	timeout     time.Duration
@@ -161,9 +165,6 @@ type Handle struct {
 	deviceIndex int
 	mu          sync.Mutex
 	closeMu     sync.Mutex
-	// stop is set to a non-zero value by Handle.Close to signal to
-	// getNextBufPtrLocked to stop trying to read packets
-	stop uint64
 
 	// Since pointers to these objects are passed into a C function, if
 	// they're declared locally then the Go compiler thinks they may have


### PR DESCRIPTION
This is documented at the end of sync.atomic help (caller is responsible
for 64-bit alignment of 64-bit accesses). First word of allocated
structs can be relied upon to be 64-bit aligned -> this pull request
moves 64-bit sync.atomics to the top of the structs in afpacket and pcap.

Tested in a 32-bit virtual machine (without this patch afpacket crashes
as reported in #512)