### PR TITLE
Fix poll in afpacket. This fixes #529

### DIFF
--- a/afpacket/afpacket.go
+++ b/afpacket/afpacket.go
@@ -455,13 +455,13 @@ func (h *TPacket) getTPacketHeader() header {
 func (h *TPacket) pollForFirstPacket(hdr header) error {
 	tm := int(h.opts.pollTimeout / time.Millisecond)
 	for hdr.getStatus()&C.TP_STATUS_USER == 0 {
-		pollset := []unix.PollFd{
-			unix.PollFd{
+		pollset := [1]unix.PollFd{
+			{
 				Fd:     int32(h.fd),
 				Events: unix.POLLIN,
 			},
 		}
-		n, err := unix.Poll(pollset, tm)
+		n, err := unix.Poll(pollset[:], tm)
 		if n == 0 {
 			return ErrTimeout
 		}

--- a/afpacket/afpacket.go
+++ b/afpacket/afpacket.go
@@ -116,8 +116,6 @@ type TPacket struct {
 	offset int
 	// current is the current header.
 	current header
-	// pollset is used by TPacket for its poll() call.
-	pollset unix.PollFd
 	// shouldReleasePacket is set to true whenever we return packet data, to make sure we remember to release that data back to the kernel.
 	shouldReleasePacket bool
 	// headerNextNeeded is set to true when header need to move to the next packet. No need to move it case of poll error.
@@ -457,16 +455,19 @@ func (h *TPacket) getTPacketHeader() header {
 func (h *TPacket) pollForFirstPacket(hdr header) error {
 	tm := int(h.opts.pollTimeout / time.Millisecond)
 	for hdr.getStatus()&C.TP_STATUS_USER == 0 {
-		h.pollset.Fd = int32(h.fd)
-		h.pollset.Events = unix.POLLIN
-		h.pollset.Revents = 0
-		n, err := unix.Poll([]unix.PollFd{h.pollset}, tm)
+		pollset := []unix.PollFd{
+			unix.PollFd{
+				Fd:     int32(h.fd),
+				Events: unix.POLLIN,
+			},
+		}
+		n, err := unix.Poll(pollset, tm)
 		if n == 0 {
 			return ErrTimeout
 		}
 
 		atomic.AddInt64(&h.stats.Polls, 1)
-		if h.pollset.Revents&unix.POLLERR > 0 {
+		if pollset[0].Revents&unix.POLLERR > 0 {
 			return ErrPoll
 		}
 		if err != nil {


### PR DESCRIPTION
As mentioned in #529 Revents is empty. Well the original code copied
h.pollset into a slice as argument to unix.Poll and then discards this
slice.... -> unix.Poll modified the slice, which was immediately
discarded. No wonder h.pollset.Revents is empty.

This removes pollset from the TPacket struct (according to the compiler
pollset doesn't escape to the heap anyway), and properly uses a slice
for everything.