### PR TITLE
Add missing length check to decoding of ip4, ip6, tcp, udp

### DIFF
--- a/layers/ip4.go
+++ b/layers/ip4.go
@@ -186,6 +186,10 @@ func (ip *IPv4) flagsfrags() (ff uint16) {
 
 // DecodeFromBytes decodes the given bytes into this layer.
 func (ip *IPv4) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
+	if len(data) < 20 {
+		df.SetTruncated()
+		return fmt.Errorf("Invalid ip4 header. Length %d less than 20", len(data))
+	}
 	flagsfrags := binary.BigEndian.Uint16(data[6:8])
 
 	ip.Version = uint8(data[0]) >> 4

--- a/layers/tcp.go
+++ b/layers/tcp.go
@@ -225,6 +225,10 @@ func (t *TCP) flagsAndOffset() uint16 {
 }
 
 func (tcp *TCP) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
+	if len(data) < 20 {
+		df.SetTruncated()
+		return fmt.Errorf("Invalid TCP header. Length %d less than 20", len(data))
+	}
 	tcp.SrcPort = TCPPort(binary.BigEndian.Uint16(data[0:2]))
 	tcp.sPort = data[0:2]
 	tcp.DstPort = TCPPort(binary.BigEndian.Uint16(data[2:4]))
@@ -275,10 +279,15 @@ func (tcp *TCP) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 		case TCPOptionKindNop: // 1 byte padding
 			opt.OptionLength = 1
 		default:
+			if len(data) < 2 {
+				df.SetTruncated()
+				return fmt.Errorf("Invalid TCP option length. Length %d less than 2", len(data))
+			}
 			opt.OptionLength = data[1]
 			if opt.OptionLength < 2 {
 				return fmt.Errorf("Invalid TCP option length %d < 2", opt.OptionLength)
 			} else if int(opt.OptionLength) > len(data) {
+				df.SetTruncated()
 				return fmt.Errorf("Invalid TCP option length %d exceeds remaining %d bytes", opt.OptionLength, len(data))
 			}
 			opt.OptionData = data[2:opt.OptionLength]

--- a/layers/udp.go
+++ b/layers/udp.go
@@ -28,6 +28,10 @@ type UDP struct {
 func (u *UDP) LayerType() gopacket.LayerType { return LayerTypeUDP }
 
 func (udp *UDP) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
+	if len(data) < 8 {
+		df.SetTruncated()
+		return fmt.Errorf("Invalid UDP header. Length %d less than 8", len(data))
+	}
 	udp.SrcPort = UDPPort(binary.BigEndian.Uint16(data[0:2]))
 	udp.sPort = data[0:2]
 	udp.DstPort = UDPPort(binary.BigEndian.Uint16(data[2:4]))


### PR DESCRIPTION
This is actually dictated by CONTRIBUTING.md and should be there.
Without this out-of-bounds panics happen in truncated files (e.g.
http://mawi.wide.ad.jp/mawi/samplepoint-F/2017/201702011400.html)

This shouldn't add too much overhead since this also removes tons of
slice bounds checks.

Benchmark old vs new (some changes don't make sense - no idea why this
happened):

```
name                                       old time/op  new time/op  delta
LayerClassSliceContains-40                 1.20ns ± 6%  1.20ns ± 4%     ~     (p=0.737 n=10+10)
LayerClassMapContains-40                   7.12ns ±10%  7.07ns ±11%     ~     (p=0.796 n=10+10)
LazyNoCopyEthLayer-40                       527ns ± 8%   531ns ± 8%     ~     (p=0.617 n=10+10)
LazyNoCopyIPLayer-40                        995ns ± 4%  1006ns ± 8%     ~     (p=0.424 n=10+10)
LazyNoCopyTCPLayer-40                      1.62µs ± 8%  1.63µs ± 8%     ~     (p=0.955 n=10+10)
LazyNoCopyAllLayers-40                     1.87µs ±12%  1.86µs ±13%     ~     (p=0.436 n=10+10)
Default-40                                 1.87µs ±11%  1.82µs ±12%     ~     (p=0.183 n=10+10)
SerializeTcpNoOptions-40                    216ns ± 6%   217ns ±12%     ~     (p=0.888 n=9+10)
SerializeTcpFixLengths-40                   239ns ± 4%   215ns ± 5%  -10.25%  (p=0.000 n=9+10)
SerializeTcpComputeChecksums-40             529ns ± 4%   531ns ± 8%     ~     (p=0.781 n=10+10)
SerializeTcpFixLengthsComputeChecksums-40   545ns ± 5%   538ns ± 6%     ~     (p=0.411 n=9+10)
Lazy-40                                     434ns ± 5%   447ns ± 6%   +3.02%  (p=0.049 n=10+10)
NoCopy-40                                  1.41µs ± 5%  1.44µs ± 9%     ~     (p=0.764 n=9+10)
LazyNoCopy-40                               203ns ± 4%   200ns ± 3%     ~     (p=0.254 n=10+10)
KnownStack-40                               104ns ± 4%   102ns ± 7%     ~     (p=0.190 n=10+10)
DecodingLayerParserIgnorePanic-40           166ns ± 5%   167ns ± 6%     ~     (p=0.780 n=9+9)
DecodingLayerParserHandlePanic-40           230ns ± 4%   227ns ± 4%     ~     (p=0.398 n=9+9)
Alloc-40                                   0.37ns ± 4%  0.38ns ± 3%     ~     (p=0.117 n=10+10)
Flow-40                                    16.9ns ± 3%  16.9ns ± 6%     ~     (p=0.882 n=9+9)
Endpoints-40                               2.20ns ± 4%  2.20ns ± 3%     ~     (p=0.984 n=10+9)
TCPLayerFromDecodedPacket-40               14.4ns ± 2%  14.1ns ± 5%     ~     (p=0.063 n=9+9)
TCPLayerClassFromDecodedPacket-40          33.8ns ± 7%  34.1ns ± 4%     ~     (p=0.265 n=9+9)
TCPTransportLayerFromDecodedPacket-40      3.20ns ± 5%  3.14ns ± 5%     ~     (p=0.147 n=10+10)
DecodeFuncCallOverheadDirectCall-40        0.37ns ± 3%  0.37ns ± 6%     ~     (p=0.695 n=9+10)
DecodeFuncCallOverheadDecoderCall-40       6.67ns ± 4%  6.89ns ± 5%   +3.20%  (p=0.029 n=10+9)
DecodeFuncCallOverheadArrayCall-40         11.5ns ± 4%  11.5ns ± 5%     ~     (p=0.948 n=9+10)
FmtVerboseString-40                        40.1µs ±12%  39.0µs ±10%     ~     (p=0.280 n=10+10)
PacketString-40                            59.7µs ± 1%  59.7µs ± 2%     ~     (p=0.796 n=10+10)
PacketDumpString-40                        60.0µs ± 3%  59.9µs ± 1%     ~     (p=0.447 n=10+9)
DecodeICMP-40                              1.52µs ± 1%  1.51µs ± 2%     ~     (p=0.781 n=10+10)
DecodeICMP6-40                             1.78µs ± 1%  1.77µs ± 1%     ~     (p=0.381 n=10+10)
DecodeMPLS-40                              1.70µs ± 2%  1.70µs ± 2%     ~     (p=0.306 n=10+10)
DecodePPPoEICMPv6-40                       2.26µs ± 1%  2.25µs ± 1%     ~     (p=0.093 n=10+10)
DecodePacketDNSRegression-40               2.44µs ± 1%  2.43µs ± 0%     ~     (p=0.395 n=10+8)
DecodePacketDot11CtrlCTS-40                1.01µs ± 1%  0.99µs ± 7%     ~     (p=0.380 n=10+10)
DecodePacketDot11MgmtBeacon-40             5.77µs ± 1%  5.69µs ± 3%   -1.30%  (p=0.001 n=8+9)
DecodePacketDot11DataQOSData-40            2.28µs ± 1%  2.19µs ± 1%   -3.81%  (p=0.000 n=9+9)
DecodePacketDot11MgmtAction-40             1.34µs ± 1%  1.33µs ± 1%   -0.59%  (p=0.045 n=10+9)
DecodePacketDot11CtrlAck-40                1.01µs ± 1%  0.97µs ±11%     ~     (p=0.139 n=8+10)
DecodePacketDot11DataARP-40                2.48µs ± 1%  2.31µs ±12%   -7.06%  (p=0.000 n=8+10)
DecodePacketDot11DataIP-40                 4.66µs ± 1%  4.56µs ± 9%   -2.15%  (p=0.015 n=8+9)
DecodePacketP6196-40                       1.53µs ± 1%  1.45µs ± 2%   -5.12%  (p=0.000 n=8+8)
DecodePacketEAPOLKey-40                    20.8µs ± 3%  20.6µs ± 6%     ~     (p=0.837 n=7+9)
DecodeGeneve1-40                            669ns ± 1%   674ns ± 2%     ~     (p=0.305 n=9+10)
DecodePacketGRE-40                         2.25µs ± 1%  2.23µs ± 0%   -0.91%  (p=0.003 n=8+9)
EncodePacketGRE-40                          406ns ± 7%   414ns ± 4%     ~     (p=0.128 n=10+9)
DecodePacketEthernetOverGRE-40             2.48µs ± 9%  2.38µs ±12%     ~     (p=0.073 n=10+10)
EncodePacketEthernetOverGRE-40              414ns ±14%   425ns ±12%     ~     (p=0.305 n=10+10)
Decodeigmpv1MembershipReportPacket-40      1.13µs ±11%  1.10µs ±10%     ~     (p=0.494 n=10+10)
Decodeigmpv2MembershipQueryPacket-40       1.17µs ±10%  1.14µs ±11%     ~     (p=0.541 n=10+10)
Decodeigmpv2MembershipReportPacket-40      1.36µs ±12%  1.32µs ±10%     ~     (p=0.256 n=10+10)
Decodeigmp3v3MembershipQueryPacket-40      1.44µs ± 9%  1.34µs ±12%   -6.40%  (p=0.029 n=10+10)
Decodeigmpv3MembershipReport2Records-40    1.76µs ±12%  1.68µs ±10%     ~     (p=0.105 n=10+10)
DecodePacketIPSecAHTransport-40            1.69µs ±10%  1.62µs ±11%     ~     (p=0.072 n=10+10)
DecodePacketIPSecAHTunnel-40               2.08µs ± 1%  1.91µs ±11%   -8.22%  (p=0.000 n=8+10)
DecodePacketIPSecESP-40                    1.19µs ± 2%  1.14µs ±10%     ~     (p=0.100 n=8+10)
DecodePacketMPLS-40                        1.85µs ± 1%  1.77µs ±11%     ~     (p=0.306 n=9+10)
DecodePacketPacket5-40                     1.40µs ± 1%  1.34µs ±13%   -4.46%  (p=0.021 n=9+10)
DecodePacketPacket0-40                     1.36µs ± 1%  1.30µs ±10%     ~     (p=0.152 n=8+10)
DecodePacketPacket6-40                     1.38µs ± 7%  1.35µs ±13%     ~     (p=0.459 n=9+10)
DecodePacketPacket1-40                     1.28µs ±10%  1.31µs ±11%     ~     (p=0.542 n=10+10)
DecodePacketPacket7-40                     1.41µs ±11%  1.37µs ±13%     ~     (p=0.926 n=10+10)
DecodePacketPacket2-40                     1.75µs ± 1%  1.71µs ±10%     ~     (p=0.326 n=8+10)
DecodePacketPacket8-40                     3.04µs ± 1%  3.03µs ± 1%     ~     (p=0.898 n=8+8)
DecodePacketPacket3-40                     3.56µs ± 1%  3.56µs ± 2%     ~     (p=0.832 n=9+8)
DecodePacketPacket9-40                     1.91µs ± 1%  1.92µs ± 1%     ~     (p=0.268 n=8+8)
DecodePacketPacket4-40                     1.87µs ± 8%  1.93µs ± 1%   +3.30%  (p=0.001 n=9+8)
DecodePacketPrism-40                       1.75µs ± 7%  1.77µs ± 1%     ~     (p=0.796 n=9+8)
DecodePacketRadiotap0-40                    960ns ± 2%   958ns ± 1%     ~     (p=0.435 n=9+8)
DecodePacketRadiotap1-40                   1.17µs ± 1%  1.19µs ± 2%   +1.29%  (p=0.041 n=8+8)
DecodeSFlowPacket1-40                      19.4µs ± 1%  19.4µs ± 1%     ~     (p=0.963 n=9+8)
DecodeSFlowPacket2-40                      14.8µs ± 2%  14.7µs ± 1%     ~     (p=0.661 n=9+10)
DecodeSFlowPacket3-40                       653ns ± 7%   676ns ± 2%     ~     (p=0.064 n=10+9)
DecodeSFlowPacket4-40                       621ns ±11%   674ns ± 1%     ~     (p=0.165 n=10+8)
DecodeSFlowLayerPacket1-40                 22.3µs ±12%  22.7µs ±12%     ~     (p=0.579 n=10+10)
DecodeSFlowLayerPacket2-40                 14.0µs ± 8%  14.1µs ±12%     ~     (p=0.853 n=10+10)
DecodeDNS-40                               1.94µs ± 2%  1.97µs ± 2%   +1.86%  (p=0.001 n=9+9)
DecodeDNSLayer-40                          1.21µs ±10%  1.20µs ±13%     ~     (p=0.754 n=10+10)
DecodePacketUSB0-40                         805ns ± 9%   793ns ± 8%     ~     (p=0.542 n=10+10)
DecodeVRRPPacket0-40                       1.40µs ±11%  1.35µs ± 9%     ~     (p=0.165 n=10+10)
DecodePacketVXLAN-40                       3.00µs ± 7%  2.87µs ± 9%     ~     (p=0.315 n=9+10)
```