### PR TITLE
pcapgo/read.go: ReadPacketData also check that CaptureLength <= Length

### DIFF
--- a/pcapgo/read.go
+++ b/pcapgo/read.go
@@ -15,6 +15,7 @@ import (
 
 	"bufio"
 	"compress/gzip"
+
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
 )
@@ -121,7 +122,11 @@ func (r *Reader) ReadPacketData() (data []byte, ci gopacket.CaptureInfo, err err
 		return
 	}
 	if ci.CaptureLength > int(r.snaplen) {
-		err = fmt.Errorf("capture length exceeds snap length: %d > %d", 16+ci.CaptureLength, r.snaplen)
+		err = fmt.Errorf("capture length exceeds snap length: %d > %d", ci.CaptureLength, r.snaplen)
+		return
+	}
+	if ci.CaptureLength > ci.Length {
+		err = fmt.Errorf("capture length exceeds original packet length: %d > %d", ci.CaptureLength, ci.Length)
 		return
 	}
 	data = make([]byte, ci.CaptureLength)


### PR DESCRIPTION
According to the [pcap packet header specs](https://wiki.wireshark.org/Development/LibpcapFileFormat#Record_.28Packet.29_Header), `CaptureLength <= Length`.