### PR TITLE
macs: parse flags at startup

### DIFF
--- a/macs/gen.go
+++ b/macs/gen.go
@@ -60,6 +60,7 @@ func (m macs) Less(i, j int) bool { return bytes.Compare(m[i].prefix[:], m[j].pr
 func (m macs) Swap(i, j int)      { m[i], m[j] = m[j], m[i] }
 
 func main() {
+	flag.Parse()
 	fmt.Fprintf(os.Stderr, "Fetching MACs from %q\n", *url)
 	resp, err := http.Get(*url)
 	if err != nil {


### PR DESCRIPTION
Parse command flags at startup to make the URL customizable as was
originally intended.