### PR TITLE
Ip4defrag - set IPv4 Id field to match the value of the packets instead of 0

### DIFF
--- a/ip4defrag/defrag.go
+++ b/ip4defrag/defrag.go
@@ -309,7 +309,7 @@ func (f *fragmentList) build(in *layers.IPv4) (*layers.IPv4, error) {
 		IHL:        in.IHL,
 		TOS:        in.TOS,
 		Length:     f.Highest,
-		Id:         0,
+		Id:         in.Id,
 		Flags:      0,
 		FragOffset: 0,
 		TTL:        in.TTL,

--- a/ip4defrag/defrag_test.go
+++ b/ip4defrag/defrag_test.go
@@ -8,12 +8,11 @@ package ip4defrag
 
 import (
 	"bytes"
-	"fmt"
 	"encoding/binary"
+	"fmt"
 	"net"
 	"testing"
 	"time"
-
 
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/bytediff"


### PR DESCRIPTION
According to the RFC791:
- "the identification field is used to distinguish the fragments of one datagram from those of another"
- "To assemble the fragments of an internet datagram, an internet protocol module (for example at a destination host) combines internet datagrams that all have the same value for the four fields: identification, source, destination, and protocol".

It is fine to use the Id of the last packet for the output packet because the Id field is used to identify seen flows (all packets in the same flow have the same Id value).

Added fixed code + test that validate it.