### PR TITLE
Fix endless loop when encountering io.ErrUnexpectedEOF

### DIFF
--- a/packet.go
+++ b/packet.go
@@ -814,9 +814,10 @@ func (p *PacketSource) packetsToChannel() {
 	defer close(p.c)
 	for {
 		packet, err := p.NextPacket()
-		if err == io.EOF {
+		switch err {
+		case io.EOF, io.ErrUnexpectedEOF:
 			return
-		} else if err == nil {
+		case nil:
 			p.c <- packet
 		}
 	}


### PR DESCRIPTION
When stumbled upon a corrupted section in a compressed cap file, PacketSource.NextPacket()
returns io.ErrUnexpectedEOF. packetsToChannel() ignores this error and
proceeds with the next call to PacketSource.NextPacket(). It returns
the same io.ErrUnexpectedEOF error again and again, creating an endless loop
inside packetsToChannel().

Treat io.ErrUnexpectedEOF the same way as io.EOF in PacketSource.packetsToChannel()