### PR TITLE
reassemblydump example: Fixed data races on errorsMap and tcpStream

### DIFF
--- a/examples/reassemblydump/main.go
+++ b/examples/reassemblydump/main.go
@@ -117,13 +117,16 @@ func (h *httpReader) Read(p []byte) (int, error) {
 
 var outputLevel int
 var errorsMap map[string]uint
+var errorsMapMutex sync.Mutex
 var errors uint
 
 // Too bad for perf that a... is evaluated
 func Error(t string, s string, a ...interface{}) {
+	errorsMapMutex.Lock()
 	errors++
 	nb, _ := errorsMap[t]
 	errorsMap[t] = nb + 1
+	errorsMapMutex.Unlock()
 	if outputLevel >= 0 {
 		fmt.Printf(s, a...)
 	}
@@ -160,15 +163,19 @@ func (h *httpReader) run(wg *sync.WaitGroup) {
 			}
 			req.Body.Close()
 			Info("HTTP/%s Request: %s %s (body:%d)\n", h.ident, req.Method, req.URL, s)
+			h.parent.Lock()
 			h.parent.urls = append(h.parent.urls, req.URL.String())
+			h.parent.Unlock()
 		} else {
 			res, err := http.ReadResponse(b, nil)
 			var req string
+			h.parent.Lock()
 			if len(h.parent.urls) == 0 {
 				req = fmt.Sprintf("<no-request-seen>")
 			} else {
 				req, h.parent.urls = h.parent.urls[0], h.parent.urls[1:]
 			}
+			h.parent.Unlock()
 			if err == io.EOF || err == io.ErrUnexpectedEOF {
 				break
 			} else if err != nil {
@@ -323,6 +330,7 @@ type tcpStream struct {
 	server         httpReader
 	urls           []string
 	ident          string
+	sync.Mutex
 }
 
 func (t *tcpStream) Accept(tcp *layers.TCP, ci gopacket.CaptureInfo, dir reassembly.TCPFlowDirection, nextSeq reassembly.Sequence, start *bool, ac reassembly.AssemblerContext) bool {
@@ -594,7 +602,10 @@ func main() {
 
 		done := *maxcount > 0 && count >= *maxcount
 		if count%*statsevery == 0 || done {
-			fmt.Fprintf(os.Stderr, "Processed %v packets (%v bytes) in %v (errors: %v, type:%v)\n", count, bytes, time.Since(start), errors, len(errorsMap))
+			errorsMapMutex.Lock()
+			errorMapLen := len(errorsMap)
+			errorsMapMutex.Unlock()
+			fmt.Fprintf(os.Stderr, "Processed %v packets (%v bytes) in %v (errors: %v, errTypes:%v)\n", count, bytes, time.Since(start), errors, errorMapLen)
 		}
 		select {
 		case <-signalChan:


### PR DESCRIPTION
The reassemblydump example contains two data races:

The errorsMap is potentially accessed simultaneously by multiple goroutines.
A mutex was added to make it thread safe.

When using stream.run for both client and server for parsing http requests and responses,
both use a pointer to the parent stream to access the stream.urls array without any synchronization.
A mutex was also added to the tcpStream structure to prevent this.