### PR TITLE
Fix length in DHCPv6Option when FixLenghts is true

### DIFF
--- a/layers/dhcpv6.go
+++ b/layers/dhcpv6.go
@@ -157,7 +157,7 @@ func (d *DHCPv6) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.Serialize
 
 	if len(d.Options) > 0 {
 		for _, o := range d.Options {
-			if err := o.encode(data[offset:]); err != nil {
+			if err := o.encode(data[offset:], opts); err != nil {
 				return err
 			}
 			offset += int(o.Length) + 4 // 2 from option code, 2 from option length

--- a/layers/dhcpv6_options.go
+++ b/layers/dhcpv6_options.go
@@ -11,6 +11,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"github.com/google/gopacket"
 )
 
 // DHCPv6Opt represents a DHCP option or parameter from RFC-3315
@@ -594,9 +595,13 @@ func NewDHCPv6Option(code DHCPv6Opt, data []byte) DHCPv6Option {
 	return o
 }
 
-func (o *DHCPv6Option) encode(b []byte) error {
+func (o *DHCPv6Option) encode(b []byte, opts gopacket.SerializeOptions) error {
 	binary.BigEndian.PutUint16(b[0:2], uint16(o.Code))
-	binary.BigEndian.PutUint16(b[2:4], o.Length)
+	if opts.FixLengths {
+		binary.BigEndian.PutUint16(b[2:4], uint16(len(o.Data)))
+	} else {
+		binary.BigEndian.PutUint16(b[2:4], o.Length)
+	}
 	copy(b[4:], o.Data)
 
 	return nil


### PR DESCRIPTION
Previously, `gopacket.SerializeOptions{FixLengths: true}` would not have any effect on the lengths in `layers.DHCPv6Option.encode()`. This has been fixed.