### PR TITLE
 Add ZeroCopyReadPacketData to pcapgo.Reader 

### DIFF
--- a/pcapgo/ngread.go
+++ b/pcapgo/ngread.go
@@ -547,6 +547,9 @@ func (r *NgReader) ReadPacketData() (data []byte, ci gopacket.CaptureInfo, err e
 // ZeroCopyReadPacketData returns the next packet available from this data source.
 // If WantMixedLinkType is true, ci.AncillaryData[0] contains the link type.
 // Warning: Like data, ci.AncillaryData is also reused and overwritten on the next call to ZeroCopyReadPacketData.
+//
+// It is not true zero copy, as data is still copied from the underlying reader. However,
+// this method avoids allocating heap memory for every packet.
 func (r *NgReader) ZeroCopyReadPacketData() (data []byte, ci gopacket.CaptureInfo, err error) {
 	if err = r.readPacketHeader(); err != nil {
 		return

--- a/pcapgo/read.go
+++ b/pcapgo/read.go
@@ -138,6 +138,9 @@ func (r *Reader) ReadPacketData() (data []byte, ci gopacket.CaptureInfo, err err
 
 // ZeroCopyReadPacketData reads next packet from file. The data buffer is owned by the Reader,
 // and each call to ZeroCopyReadPacketData invalidates data returned by the previous one.
+//
+// It is not true zero copy, as data is still copied from the underlying reader. However,
+// this method avoids allocating heap memory for every packet.
 func (r *Reader) ZeroCopyReadPacketData() (data []byte, ci gopacket.CaptureInfo, err error) {
 	if ci, err = r.readPacketHeader(); err != nil {
 		return


### PR DESCRIPTION
Like ZeroCopyReadPacketData in pcapco.NgReader, it's not true zero copy, as data is still copied from the io.Reader. Still, memory allocation for every packet is avoided.