### PR TITLE
reassembly: small optimizations to overlapExisting

### DIFF
--- a/reassembly/tcpassembly.go
+++ b/reassembly/tcpassembly.go
@@ -945,15 +945,13 @@ func (a *Assembler) overlapExisting(half *halfconnection, start, end Sequence, b
 		half.overlapPackets++
 		half.overlapBytes += diff
 	}
-	start = start.Add(diff)
 	s += diff
 	if s >= e {
 		// Completely included in sent
 		s = e
 	}
 	bytes = bytes[s:]
-	e -= diff
-	return bytes, start
+	return bytes, half.nextSeq
 }
 
 // Prepare send or queue


### PR DESCRIPTION
Reassembly's overlapExisting function had 2 unnecessary operations

- Adding `diff` to `start` when we already know that result will be same as `half.nextSeq`
- Subtracting `diff` from a variable `e` which is never used later