### PR TITLE
pcap: use C.struct, not _Ctype_struct

### DIFF
--- a/pcap/pcap.go
+++ b/pcap/pcap.go
@@ -368,7 +368,7 @@ func (p *Handle) ListDataLinks() (datalinks []Datalink, err error) {
 	return p.pcapListDatalinks()
 }
 
-// compileBPFFilter always returns an allocated _Ctype_struct_bpf_program
+// compileBPFFilter always returns an allocated C.struct_bpf_program
 // It is the callers responsibility to free the memory again, e.g.
 //
 //    C.pcap_freecode(&bpf)


### PR DESCRIPTION
The future Go 1.12 version of the cgo tool will issue an error for Go
code that uses names like _Ctype_struct_S, as that is in the namespace
that cgo uses for its own generated code. Change this code to use the
supported form C.struct_S, so that it builds with the future 1.12.