### PR TITLE
Avoid a cpu spin when NextPacket() returns EBADF

### DIFF
--- a/packet.go
+++ b/packet.go
@@ -16,6 +16,7 @@ import (
 	"reflect"
 	"runtime/debug"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -814,7 +815,7 @@ func (p *PacketSource) packetsToChannel() {
 	defer close(p.c)
 	for {
 		packet, err := p.NextPacket()
-		if err == io.EOF {
+		if err == io.EOF || err == syscall.EBADF {
 			return
 		} else if err == nil {
 			p.c <- packet


### PR DESCRIPTION
The NextPacket() function can return EBADF when a gopcap EthernetHandle has been closed (triggered by the raw SetTimeout()). The packetsToChannel() function should probably break on any error, but I figured there was a reason for its current behavior.