### PR TITLE
Soft fail on missing WinPCAP during init()

### DIFF
--- a/pcap/pcap_windows.go
+++ b/pcap/pcap_windows.go
@@ -285,6 +285,11 @@ func pcapSetTstampPrecision(cptr pcapTPtr, precision int) error {
 }
 
 func pcapOpenLive(device string, snaplen int, pro int, timeout int) (*Handle, error) {
+	err := LoadWinPCAP()
+	if err != nil {
+		return nil, err
+	}
+
 	buf := make([]byte, errorBufferSize)
 	dev, err := syscall.BytePtrFromString(device)
 	if err != nil {
@@ -300,6 +305,11 @@ func pcapOpenLive(device string, snaplen int, pro int, timeout int) (*Handle, er
 }
 
 func openOffline(file string) (handle *Handle, err error) {
+	err = LoadWinPCAP()
+	if err != nil {
+		return nil, err
+	}
+
 	buf := make([]byte, errorBufferSize)
 	f, err := syscall.BytePtrFromString(file)
 	if err != nil {
@@ -399,6 +409,11 @@ func pcapBpfProgramFromInstructions(bpfInstructions []BPFInstruction) pcapBpfPro
 }
 
 func pcapLookupnet(device string) (netp, maskp uint32, err error) {
+	err = LoadWinPCAP()
+	if err != nil {
+		return 0, 0, err
+	}
+
 	buf := make([]byte, errorBufferSize)
 	dev, err := syscall.BytePtrFromString(device)
 	if err != nil {
@@ -453,6 +468,11 @@ func (p *Handle) pcapListDatalinks() (datalinks []Datalink, err error) {
 }
 
 func pcapOpenDead(linkType layers.LinkType, captureLength int) (*Handle, error) {
+	err := LoadWinPCAP()
+	if err != nil {
+		return nil, err
+	}
+
 	cptr, _, _ := syscall.Syscall(pcapOpenDeadPtr, 2, uintptr(linkType), uintptr(captureLength), 0)
 	if cptr == 0 {
 		return nil, errors.New("error opening dead capture")
@@ -506,6 +526,10 @@ func pcapDatalinkNameToVal(name string) int {
 }
 
 func pcapLibVersion() string {
+	err := LoadWinPCAP()
+	if err != nil {
+		panic(err)
+	}
 	ret, _, _ := syscall.Syscall(pcapLibVersionPtr, 0, 0, 0, 0)
 	return bytePtrToString(ret)
 }
@@ -589,8 +613,13 @@ func (p pcapDevices) addresses() pcapAddresses {
 }
 
 func pcapFindAllDevs() (pcapDevices, error) {
-	buf := make([]byte, errorBufferSize)
 	var alldevsp pcapDevices
+	err := LoadWinPCAP()
+	if err != nil {
+		return alldevsp, err
+	}
+
+	buf := make([]byte, errorBufferSize)
 
 	ret, _, _ := syscall.Syscall(pcapFindalldevsPtr, 2, uintptr(unsafe.Pointer(&alldevsp.all)), uintptr(unsafe.Pointer(&buf[0])), 0)
 
@@ -807,6 +836,11 @@ func (p *Handle) waitForPacket() {
 
 // openOfflineFile returns contents of input file as a *Handle.
 func openOfflineFile(file *os.File) (handle *Handle, err error) {
+	err = LoadWinPCAP()
+	if err != nil {
+		return nil, err
+	}
+
 	buf := make([]byte, errorBufferSize)
 	cf := file.Fd()
 

--- a/pcap/pcap_windows.go
+++ b/pcap/pcap_windows.go
@@ -507,16 +507,28 @@ func (p *Handle) pcapSetDatalink(dlt layers.LinkType) error {
 }
 
 func pcapDatalinkValToName(dlt int) string {
+	err := LoadWinPCAP()
+	if err != nil {
+		panic(err)
+	}
 	ret, _, _ := syscall.Syscall(pcapDatalinkValToNamePtr, 1, uintptr(dlt), 0, 0)
 	return bytePtrToString(ret)
 }
 
 func pcapDatalinkValToDescription(dlt int) string {
+	err := LoadWinPCAP()
+	if err != nil {
+		panic(err)
+	}
 	ret, _, _ := syscall.Syscall(pcapDatalinkValToDescriptionPtr, 1, uintptr(dlt), 0, 0)
 	return bytePtrToString(ret)
 }
 
 func pcapDatalinkNameToVal(name string) int {
+	err := LoadWinPCAP()
+	if err != nil {
+		panic(err)
+	}
 	cptr, err := syscall.BytePtrFromString(name)
 	if err != nil {
 		return 0
@@ -651,6 +663,11 @@ func (p *Handle) pcapSnapshot() int {
 }
 
 func (t TimestampSource) pcapTstampTypeValToName() string {
+	err := LoadWinPCAP()
+	if err != nil {
+		return err.Error()
+	}
+
 	//libpcap <1.2 doesn't have pcap_*_tstamp_* functions
 	if pcapTstampTypeValToNamePtr == 0 {
 		return "pcap timestamp types not supported"
@@ -660,6 +677,11 @@ func (t TimestampSource) pcapTstampTypeValToName() string {
 }
 
 func pcapTstampTypeNameToVal(s string) (TimestampSource, error) {
+	err := LoadWinPCAP()
+	if err != nil {
+		return 0, err
+	}
+
 	//libpcap <1.2 doesn't have pcap_*_tstamp_* functions
 	if pcapTstampTypeNameToValPtr == 0 {
 		return 0, statusError(pcapCint(pcapError))
@@ -702,6 +724,11 @@ func (p *InactiveHandle) pcapClose() {
 }
 
 func pcapCreate(device string) (*InactiveHandle, error) {
+	err := LoadWinPCAP()
+	if err != nil {
+		return nil, err
+	}
+
 	buf := make([]byte, errorBufferSize)
 	dev, err := syscall.BytePtrFromString(device)
 	if err != nil {


### PR DESCRIPTION
This PR changes the behavior of pcap.init() on Windows to no longer panic if WinPCAP is not found. This allows the caller to install WinPCAP [or npcap] on the fly. A caller that wishes to maintain the previous panic() behavior can add the following code to their package:
```
func init() {
	err := pcap.LoadWinPCAP()
	if err != nil {
		panic(err)
	}
}
```
The downside of this change is that callers that don't check LoadWinPCAP() may crash if they call a pcap function and WinPCAP is not available. This seems mostly harmless, as the program would have crashed either way, and the new behavior offers more control over this process.
