### PR TITLE
afpacket: use single implementation of tpacket alignment function

### DIFF
--- a/afpacket/afpacket.go
+++ b/afpacket/afpacket.go
@@ -42,17 +42,12 @@ import (
 import "C"
 
 var pageSize = unix.Getpagesize()
-var tpacketAlignment = uint(C.TPACKET_ALIGNMENT)
 
 // ErrPoll returned by poll
 var ErrPoll = errors.New("packet poll failed")
 
 // ErrTimeout returned on poll timeout
 var ErrTimeout = errors.New("packet poll timeout expired")
-
-func tpacketAlign(v int) int {
-	return int((uint(v) + tpacketAlignment - 1) & ((^tpacketAlignment) - 1))
-}
 
 // AncillaryVLAN structures are used to pass the captured VLAN
 // as ancillary data via CaptureInfo.

--- a/afpacket/header.go
+++ b/afpacket/header.go
@@ -52,6 +52,8 @@ type header interface {
 	next() bool
 }
 
+const tpacketAlignment = uint(C.TPACKET_ALIGNMENT)
+
 func tpAlign(x int) int {
 	return int((uint(x) + tpacketAlignment - 1) &^ (tpacketAlignment - 1))
 }
@@ -184,7 +186,7 @@ func (w *v3wrapper) next() bool {
 	if w.packet.tp_next_offset != 0 {
 		next += uintptr(w.packet.tp_next_offset)
 	} else {
-		next += uintptr(tpacketAlign(int(w.packet.tp_snaplen) + int(w.packet.tp_mac)))
+		next += uintptr(tpAlign(int(w.packet.tp_snaplen) + int(w.packet.tp_mac)))
 	}
 	w.packet = (*C.struct_tpacket3_hdr)(unsafe.Pointer(next))
 	return true


### PR DESCRIPTION
There are two tpacket alignment functions, tpacketAlign and tpAlign. The
former has a bug (i.e. it doesn't match TPACKET_ALIGN from
linux/if_packet.h), so only use the latter. Also make tpacketAlignment a
const.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>