### PR TITLE
Fixed SNAP nextLayerType

### DIFF
--- a/layers/llc.go
+++ b/layers/llc.go
@@ -96,7 +96,7 @@ func (s *SNAP) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 
 // CanDecode returns the set of layer types that this DecodingLayer can decode.
 func (s *SNAP) CanDecode() gopacket.LayerClass {
-	return LayerTypeLLC
+	return LayerTypeSNAP
 }
 
 // NextLayerType returns the layer type contained by this DecodingLayer.


### PR DESCRIPTION
As explained thoroughly in #613, gopacket fails to parse SNAP layers due to a typo in the CanDecode() method.  This push fixes it.