### PR TITLE
fix: unix.Timespec/Timeval member type various

### DIFF
--- a/pcapgo/capture.go
+++ b/pcapgo/capture.go
@@ -92,10 +92,10 @@ func (h *EthernetHandle) readOne() (ci gopacket.CaptureInfo, vlan int, haveVlan 
 			gotAux = true
 		case hdr.Level == unix.SOL_SOCKET && hdr.Type == unix.SO_TIMESTAMPNS && len(oob) >= timensLen:
 			tstamp := (*unix.Timespec)(unsafe.Pointer(&oob[hdrLen]))
-			ci.Timestamp = time.Unix(tstamp.Sec, tstamp.Nsec)
+			ci.Timestamp = time.Unix(int64(tstamp.Sec), int64(tstamp.Nsec))
 		case hdr.Level == unix.SOL_SOCKET && hdr.Type == unix.SO_TIMESTAMP && len(oob) >= timeLen:
 			tstamp := (*unix.Timeval)(unsafe.Pointer(&oob[hdrLen]))
-			ci.Timestamp = time.Unix(tstamp.Sec, tstamp.Usec*1000)
+			ci.Timestamp = time.Unix(int64(tstamp.Sec), int64(tstamp.Usec)*1000)
 		}
 		oob = oob[unix.CmsgSpace(int(hdr.Len))-hdrLen:]
 	}


### PR DESCRIPTION
`unix.Timespec`/`unix.Timeval` members are `int32` in 32-bit arch
 - https://github.com/golang/sys/blob/master/unix/ztypes_linux_arm.go#L24
 - https://github.com/golang/sys/blob/master/unix/ztypes_linux_386.go#L24

But `time.Unix` always accept int64 arguments. Type casting is needed.