### PR TITLE
#638: Fix for serializing DNS packet panic with empty authority name

### DIFF
--- a/layers/dns.go
+++ b/layers/dns.go
@@ -740,6 +740,7 @@ func encodeName(name []byte, data []byte, offset int) int {
 func (rr *DNSResourceRecord) encode(data []byte, offset int, opts gopacket.SerializeOptions) (int, error) {
 
 	noff := encodeName(rr.Name, data, offset)
+	nSz := noff - offset
 
 	binary.BigEndian.PutUint16(data[noff:], uint16(rr.Type))
 	binary.BigEndian.PutUint16(data[noff+2:], uint16(rr.Class))
@@ -799,7 +800,7 @@ func (rr *DNSResourceRecord) encode(data []byte, offset int, opts gopacket.Seria
 		rr.DataLength = uint16(dSz)
 	}
 
-	return len(rr.Name) + 1 + 11 + dSz, nil
+	return nSz + 10 + dSz, nil
 }
 
 func (rr *DNSResourceRecord) String() string {


### PR DESCRIPTION
Addresses submitted issue #638.

A recent commit (https://github.com/google/gopacket/commit/65567310658fb392f4408da7d375b10e7343eb83#diff-4d9bce33bc5ccd203264657a890010dc) computeSize in dns.go adds an 11 or 12 byte offset to account for packet fields based on if the resource record Name field is empty or not.  This function is used to calculate the required destination buffer size for the serialized data.  However when encoding the data during serialization, the encode function in dns.go would always report it had consumed 12 bytes (1 + 11).  This was causing the caller of the encode function to incorrectly advance the offset by 1 extra byte each time an authority resource record was encoded having an empty Name field and would eventually cause a panic for an "index out of range" condition.

A simple adjustment was made to the code to ensure the number of consumed bytes being returned is correct in all cases to prevent the panic.