### PR TITLE
Allow conversion of some IPv4 header fields to host byte order when serialized

### DIFF
--- a/layers/ip4.go
+++ b/layers/ip4.go
@@ -323,3 +323,13 @@ func (ip *IPv4) AddressTo4() error {
 	ip.DstIP = dst
 	return nil
 }
+
+// For raw IP sockets on darwin, dragonfly, netbsd, and freebsd (before ver. 11), you must call
+// this method with host byte order before writing b.Bytes() to the socket.
+//
+// On such systems, some packet fields written to raw IP sockets are expected in host byte order.
+func (ip *IPv4) RawSocketByteOrder(b gopacket.SerializeBuffer, o binary.ByteOrder) {
+	bytes := b.Bytes()[2:8]
+	o.PutUint16(bytes[0:], ip.Length)
+	o.PutUint16(bytes[4:], ip.FragOffset&0x1FFF|uint16(ip.Flags)<<13)
+}


### PR DESCRIPTION
Just an unassuming fix for #150.

Just to describe the issue concisely:
darwin, dragonfly, netbsd, and freebsd<11.0 expect native byte ordering (only for length/fragmentation offset fields) when writing serialized IPv4 headers to raw IP sockets, as reflected by a fix for [ipv4/header.go](https://github.com/golang/net/blob/master/ipv4/header.go#L70).

This strange assumption was removed since freebsd 11.0, but the other systems still have issues with this (as used to be the behaviour in [freebsd](https://www.freebsd.org/cgi/man.cgi?ip(4)) with IP_HDRINCL, you will likely get EINVAL from the kernel due to incorrect packet length).

It would be nice to have a fix _inside_ `SerializeTo`, but this would probably require an extra global variable for native byte order along with the magic you see in `header.go` to determine versions/endianness. I also assume changing such a critical method for this fix is not ideal.

Here is an example from some code that lets you craft empty packets with custom source/destination fields. Later the buffer is used with a raw IP socket (this works on Darwin, whereas I got EINVAL before).

I have tested a good amount with Wireshark to ensure that the length, fragmentation offset, and flag fields are preserved properly in transit.
```go
func craftPacket(p *gopacket.SerializeBuffer, src net.IP, dst net.IP) error {
	opts := gopacket.SerializeOptions{
		FixLengths: true,
	}

	ipv4 := layers.IPv4{
		Version:  4,
		IHL:      5,
		SrcIP:    src,
		DstIP:    dst,
		TTL:      64,
		Protocol: layers.IPProtocolUDP,
	}
	if err := gopacket.SerializeLayers(*p, opts, &ipv4); err != nil {
		return err
	}
	ipv4.RawSocketByteOrder(*p, binary.LittleEndian)

	return nil
}

...

p := gopacket.NewSerializeBuffer()
craftPacket(&p, src.IP, dst.IP)

fd, err := syscall.Socket(syscall.AF_INET, syscall.SOCK_RAW, syscall.IPPROTO_RAW)
if err != nil {
	panic(err)
}

if err := syscall.SetsockoptInt(fd, syscall.IPPROTO_IP, syscall.IP_HDRINCL, 1); err != nil {
	panic(err)
}

to := &syscall.SockaddrInet4{
	Addr: [4]byte{127, 0, 0, 1},
	Port: 0,
}

if err := syscall.Sendto(fd, p.Bytes(), 0, to); err != nil {
	panic(err)
}
```

It would be easy enough to include a function that determines host endianness, but maybe that's best left to the user? Please let me know what you think!