### PR TITLE
afpacket: use constants from x/sys/unix instead of C headers

### DIFF
--- a/afpacket/afpacket.go
+++ b/afpacket/afpacket.go
@@ -450,7 +450,7 @@ func (h *TPacket) getTPacketHeader() header {
 
 func (h *TPacket) pollForFirstPacket(hdr header) error {
 	tm := int(h.opts.pollTimeout / time.Millisecond)
-	for hdr.getStatus()&C.TP_STATUS_USER == 0 {
+	for hdr.getStatus()&unix.TP_STATUS_USER == 0 {
 		pollset := [1]unix.PollFd{
 			{
 				Fd:     int32(h.fd),

--- a/afpacket/header.go
+++ b/afpacket/header.go
@@ -12,6 +12,8 @@ import (
 	"reflect"
 	"time"
 	"unsafe"
+
+	"golang.org/x/sys/unix"
 )
 
 // #include <linux/if_packet.h>
@@ -52,7 +54,7 @@ type header interface {
 	next() bool
 }
 
-const tpacketAlignment = uint(C.TPACKET_ALIGNMENT)
+const tpacketAlignment = uint(unix.TPACKET_ALIGNMENT)
 
 func tpAlign(x int) int {
 	return int((uint(x) + tpacketAlignment - 1) &^ (tpacketAlignment - 1))
@@ -147,7 +149,7 @@ func initV3Wrapper(block unsafe.Pointer) (w v3wrapper) {
 }
 
 func (w *v3wrapper) getVLAN() int {
-	if w.packet.tp_status&C.TP_STATUS_VLAN_VALID != 0 {
+	if w.packet.tp_status&unix.TP_STATUS_VLAN_VALID != 0 {
 		hv1 := (*C.struct_tpacket_hdr_variant1)(unsafe.Pointer(&w.packet.anon0[0]))
 		return int(hv1.tp_vlan_tci & 0xfff)
 	}

--- a/afpacket/options.go
+++ b/afpacket/options.go
@@ -12,11 +12,9 @@ import (
 	"errors"
 	"fmt"
 	"time"
-)
 
-// #include <linux/if_packet.h>
-// #include <sys/socket.h>
-import "C"
+	"golang.org/x/sys/unix"
+)
 
 // OptTPacketVersion is the version of TPacket to use.
 // It can be passed into NewTPacket.
@@ -55,17 +53,17 @@ const (
 	// TPacketVersionHighestAvailable tells NewHandle to use the highest available version of tpacket the kernel has available.
 	// This is the default, should a version number not be given in NewHandle's options.
 	TPacketVersionHighestAvailable = OptTPacketVersion(-1)
-	TPacketVersion1                = OptTPacketVersion(C.TPACKET_V1)
-	TPacketVersion2                = OptTPacketVersion(C.TPACKET_V2)
-	TPacketVersion3                = OptTPacketVersion(C.TPACKET_V3)
+	TPacketVersion1                = OptTPacketVersion(unix.TPACKET_V1)
+	TPacketVersion2                = OptTPacketVersion(unix.TPACKET_V2)
+	TPacketVersion3                = OptTPacketVersion(unix.TPACKET_V3)
 	tpacketVersionMax              = TPacketVersion3
 	tpacketVersionMin              = -1
 	// SocketRaw is the default socket type.  It returns packet data
 	// including the link layer (ethernet headers, etc).
-	SocketRaw = OptSocketType(C.SOCK_RAW)
+	SocketRaw = OptSocketType(unix.SOCK_RAW)
 	// SocketDgram strips off the link layer when reading packets, and adds
 	// the link layer back automatically on packet writes (coming soon...)
-	SocketDgram = OptSocketType(C.SOCK_DGRAM)
+	SocketDgram = OptSocketType(unix.SOCK_DGRAM)
 )
 
 // OptInterface is the specific interface to bind to.


### PR DESCRIPTION
The golang.org/x/sys/unix package provides all these constants so there
is no need to use cgo to get them.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>