### PR TITLE
afpacket: use PACKET_FANOUT_* consts from x/sys/unix

### DIFF
--- a/afpacket/afpacket.go
+++ b/afpacket/afpacket.go
@@ -483,12 +483,17 @@ type FanoutType int
 
 // FanoutType values.
 const (
-	FanoutHash FanoutType = 0
+	FanoutHash FanoutType = unix.PACKET_FANOUT_HASH
 	// It appears that defrag only works with FanoutHash, see:
 	// http://lxr.free-electrons.com/source/net/packet/af_packet.c#L1204
-	FanoutHashWithDefrag FanoutType = 0x8000
-	FanoutLoadBalance    FanoutType = 1
-	FanoutCPU            FanoutType = 2
+	FanoutHashWithDefrag FanoutType = unix.PACKET_FANOUT_FLAG_DEFRAG
+	FanoutLoadBalance    FanoutType = unix.PACKET_FANOUT_LB
+	FanoutCPU            FanoutType = unix.PACKET_FANOUT_CPU
+	FanoutRollover       FanoutType = unix.PACKET_FANOUT_ROLLOVER
+	FanoutRandom         FanoutType = unix.PACKET_FANOUT_RND
+	FanoutQueueMapping   FanoutType = unix.PACKET_FANOUT_QM
+	FanoutCBPF           FanoutType = unix.PACKET_FANOUT_CBPF
+	FanoutEBPF           FanoutType = unix.PACKET_FANOUT_EBPF
 )
 
 // SetFanout activates TPacket's fanout ability.


### PR DESCRIPTION
Use the unix.PACKET_FANOUT_* constants to define FanoutType values and
add missing values.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>