### PR TITLE
Proper size calculation for encoded question name

### DIFF
--- a/layers/dns.go
+++ b/layers/dns.go
@@ -636,9 +636,10 @@ func (q *DNSQuestion) decode(data []byte, offset int, df gopacket.DecodeFeedback
 
 func (q *DNSQuestion) encode(data []byte, offset int) int {
 	noff := encodeName(q.Name, data, offset)
+	nSz := noff - offset
 	binary.BigEndian.PutUint16(data[noff:], uint16(q.Type))
 	binary.BigEndian.PutUint16(data[noff+2:], uint16(q.Class))
-	return len(q.Name) + 6
+	return nSz + 4
 }
 
 //  DNSResourceRecord


### PR DESCRIPTION
The encodeName function is returning the correct number of bytes consumed by the Name field in the Resource Record.  However the calculated value to be returned does not match in the case that the Name field is empty.  An empty Name field indicates it refers to the root servers.  The return value needs to make use of the encodeName return value so that the number of bytes consumed is correct.