### PR TITLE
Implement ASF and ASF Presence Pong layer types

### DIFF
--- a/layers/asf.go
+++ b/layers/asf.go
@@ -15,69 +15,83 @@ import (
 	"github.com/google/gopacket"
 )
 
-// ASFType indicates the format of the RMCP Data block when the Enterprise
-// number is set to ASF-RMCP (4542). For the purpose of open source, this is the
-// only type.
-type ASFType uint8
+// ASFDataIdentifier encapsulates fields used to uniquely identify the format of
+// the data block.
+//
+// While the enterprise number is almost always 4542 (ASF-RMCP), we support
+// registering layers using structs of this type as a key in case any users are
+// using OEM-extensions.
+type ASFDataIdentifier struct {
+
+	// Enterprise is the IANA Enterprise Number associated with the entity that
+	// defines the message type. A list can be found at
+	// https://www.iana.org/assignments/enterprise-numbers/enterprise-numbers.
+	// This can be thought of as the namespace for the message type.
+	Enterprise uint32
+
+	// Type is the message type, defined by the entity associated with the
+	// enterprise above. No pressure, but in the context of EN 4542, 1 byte is
+	// the difference between sending a ping and telling a machine to do an
+	// unconditional power down (0x80 and 0x12 respectively).
+	Type uint8
+}
 
 // LayerType returns the payload layer type corresponding to an ASF message
 // type.
-func (a ASFType) LayerType() gopacket.LayerType {
-	if lt := asfClassLayerTypes[uint8(a)]; lt != 0 {
+func (a ASFDataIdentifier) LayerType() gopacket.LayerType {
+	if lt := asfDataLayerTypes[a]; lt != 0 {
 		return lt
 	}
 
-	// some layer types don't have a payload, e.g. Presence Ping.
+	// some layer types don't have a payload, e.g. ASF-RMCP Presence Ping.
 	return gopacket.LayerTypePayload
 }
 
-func (a ASFType) String() string {
-	return fmt.Sprintf("%v(%v)", uint8(a), a.LayerType())
+// RegisterASFLayerType allows specifying that the data block of ASF packets
+// with a given enterprise number and type should be processed by a given layer
+// type. This overrides any existing registrations, including defaults.
+func RegisterASFLayerType(a ASFDataIdentifier, l gopacket.LayerType) {
+	asfDataLayerTypes[a] = l
 }
 
 var (
-	asfClassLayerTypes = [255]gopacket.LayerType{
-		ASFTypePresencePong: LayerTypeASFPresencePong,
+	// ASFDataIdentifierPresencePong is the message type of the response to a
+	// Presence Ping message. It indicates the sender is ASF-RMCP-aware.
+	ASFDataIdentifierPresencePong ASFDataIdentifier = ASFDataIdentifier{
+		Enterprise: ASFRMCPEnterprise,
+		Type:       0x40,
+	}
+
+	// ASFDataIdentifierPresencePing is a message type sent to a managed client
+	// to solicit a Presence Pong response. Clients may ignore this if the RMCP
+	// version is unsupported. Sending this message with a sequence number <255
+	// is the recommended way of finding out whether an implementation sends
+	// RMCP ACKs (e.g. iDRAC does, Super Micro does not).
+	//
+	// Systems implementing IPMI must respond to this ping to conform to the
+	// spec, so it is a good substitute for an ICMP ping.
+	ASFDataIdentifierPresencePing ASFDataIdentifier = ASFDataIdentifier{
+		Enterprise: ASFRMCPEnterprise,
+		Type:       0x80,
+	}
+
+	// asfDataLayerTypes is used to find the next layer for a given ASF header.
+	asfDataLayerTypes = map[ASFDataIdentifier]gopacket.LayerType{
+		ASFDataIdentifierPresencePong: LayerTypeASFPresencePong,
 	}
 )
 
 const (
 	// ASFEnterprise is the IANA-assigned Enterprise Number of the ASF-RMCP
 	// organisation.
-	ASFEnterprise uint32 = 4542
-
-	// ASFTypePresencePong is the message type of the response to a Presence
-	// Ping message. It indicates the sender is ASF-RMCP-aware.
-	ASFTypePresencePong ASFType = 0x40
-
-	// ASFTypePresencePing is a message type sent to a managed client to solicit
-	// a Presence Pong response. Clients may ignore this is the RMCP version is
-	// unsupported. Sending this message with a sequence number <255 is the
-	// recommended way of finding out whether an implementation sends RMCP ACKs.
-	// (Super Micro does not).
-	//
-	// Systems implementing IPMI must respond to this ping to conform to the
-	// spec, so it is a good substitute for an ICMP ping.
-	ASFTypePresencePing ASFType = 0x80
+	ASFRMCPEnterprise uint32 = 4542
 )
 
 // ASF defines ASF's generic RMCP message Data block format. See section
 // 3.2.2.3.
 type ASF struct {
 	BaseLayer
-
-	// Enterprise is the IANA Enterprise Number associated with the entity that
-	// defines the message type. A list can be found at
-	// https://www.iana.org/assignments/enterprise-numbers/enterprise-numbers.
-	// This can be thought of as the namespace for the message type. N.B.
-	// network byte order.
-	Enterprise uint32
-
-	// Type is the message type, defined by the entity associated with the
-	// enterprise above. No pressure, but 1 byte is the difference between
-	// sending a ping and telling a machine to do an unconditional power down
-	// (0x80 and 0x12 respectively).
-	Type ASFType
+	ASFDataIdentifier
 
 	// Tag is the message tag, used to match request/response pairs. The tag of
 	// a response is set to that of the message it is responding to. If a
@@ -114,7 +128,7 @@ func (a *ASF) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 	a.BaseLayer.Payload = data[8:]
 
 	a.Enterprise = binary.BigEndian.Uint32(data[:4])
-	a.Type = ASFType(data[4])
+	a.Type = uint8(data[4])
 	a.Tag = uint8(data[5])
 	// 1 byte reserved
 	a.Length = uint8(data[7])
@@ -124,7 +138,7 @@ func (a *ASF) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 // NextLayerType returns the layer type corresponding to the message type of
 // this ASF data layer. This partially satisfies DecodingLayer.
 func (a *ASF) NextLayerType() gopacket.LayerType {
-	return a.Type.LayerType()
+	return a.ASFDataIdentifier.LayerType()
 }
 
 // SerializeTo writes the serialized fom of this layer into the SerializeBuffer,

--- a/layers/asf.go
+++ b/layers/asf.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	// ASFEnterprise is the IANA-assigned Enterprise Number of the ASF-RMCP
+	// ASFRMCPEnterprise is the IANA-assigned Enterprise Number of the ASF-RMCP
 	// organisation.
 	ASFRMCPEnterprise uint32 = 4542
 )
@@ -63,7 +63,7 @@ func RegisterASFLayerType(a ASFDataIdentifier, l gopacket.LayerType) {
 var (
 	// ASFDataIdentifierPresencePong is the message type of the response to a
 	// Presence Ping message. It indicates the sender is ASF-RMCP-aware.
-	ASFDataIdentifierPresencePong ASFDataIdentifier = ASFDataIdentifier{
+	ASFDataIdentifierPresencePong = ASFDataIdentifier{
 		Enterprise: ASFRMCPEnterprise,
 		Type:       0x40,
 	}
@@ -76,7 +76,7 @@ var (
 	//
 	// Systems implementing IPMI must respond to this ping to conform to the
 	// spec, so it is a good substitute for an ICMP ping.
-	ASFDataIdentifierPresencePing ASFDataIdentifier = ASFDataIdentifier{
+	ASFDataIdentifierPresencePing = ASFDataIdentifier{
 		Enterprise: ASFRMCPEnterprise,
 		Type:       0x80,
 	}

--- a/layers/asf.go
+++ b/layers/asf.go
@@ -1,0 +1,148 @@
+// Copyright 2019 The GoPacket Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file in the root of the source tree.
+
+package layers
+
+// This file implements the ASF RMCP payload specified in section 3.2.2.3 of
+// https://www.dmtf.org/sites/default/files/standards/documents/DSP0136.pdf
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/google/gopacket"
+)
+
+// ASFType indicates the format of the RMCP Data block when the Enterprise
+// number is set to ASF-RMCP (4542). For the purpose of open source, this is the
+// only type.
+type ASFType uint8
+
+// LayerType returns the payload layer type corresponding to an ASF message
+// type.
+func (a ASFType) LayerType() gopacket.LayerType {
+	if lt := asfClassLayerTypes[uint8(a)]; lt != 0 {
+		return lt
+	}
+
+	// some layer types don't have a payload, e.g. Presence Ping.
+	return gopacket.LayerTypePayload
+}
+
+func (a ASFType) String() string {
+	return fmt.Sprintf("%v(%v)", uint8(a), a.LayerType())
+}
+
+var (
+	asfClassLayerTypes = [255]gopacket.LayerType{
+		ASFTypePresencePong: LayerTypeASFPresencePong,
+	}
+)
+
+const (
+	// ASFEnterprise is the IANA-assigned Enterprise Number of the ASF-RMCP
+	// organisation.
+	ASFEnterprise uint32 = 4542
+
+	// ASFTypePresencePong is the message type of the response to a Presence
+	// Ping message. It indicates the sender is ASF-RMCP-aware.
+	ASFTypePresencePong ASFType = 0x40
+
+	// ASFTypePresencePing is a message type sent to a managed client to solicit
+	// a Presence Pong response. Clients may ignore this is the RMCP version is
+	// unsupported. Sending this message with a sequence number <255 is the
+	// recommended way of finding out whether an implementation sends RMCP ACKs.
+	// (Super Micro does not).
+	//
+	// Systems implementing IPMI must respond to this ping to conform to the
+	// spec, so it is a good substitute for an ICMP ping.
+	ASFTypePresencePing ASFType = 0x80
+)
+
+// ASF defines ASF's generic RMCP message Data block format. See section
+// 3.2.2.3.
+type ASF struct {
+	BaseLayer
+
+	// Enterprise is the IANA Enterprise Number associated with the entity that
+	// defines the message type. A list can be found at
+	// https://www.iana.org/assignments/enterprise-numbers/enterprise-numbers.
+	// This can be thought of as the namespace for the message type. N.B.
+	// network byte order.
+	Enterprise uint32
+
+	// Type is the message type, defined by the entity associated with the
+	// enterprise above. No pressure, but 1 byte is the difference between
+	// sending a ping and telling a machine to do an unconditional power down
+	// (0x80 and 0x12 respectively).
+	Type ASFType
+
+	// Tag is the message tag, used to match request/response pairs. The tag of
+	// a response is set to that of the message it is responding to. If a
+	// message is not of the request/response type, this is set to 255.
+	Tag uint8
+
+	// 1 byte reserved, set to 0x00.
+
+	// Length is the length of this layer's payload in bytes.
+	Length uint8
+}
+
+// LayerType returns LayerTypeASF. It partially satisfies Layer and
+// SerializableLayer.
+func (*ASF) LayerType() gopacket.LayerType {
+	return LayerTypeASF
+}
+
+// CanDecode returns LayerTypeASF. It partially satisfies DecodingLayer.
+func (a *ASF) CanDecode() gopacket.LayerClass {
+	return a.LayerType()
+}
+
+// DecodeFromBytes makes the layer represent the provided bytes. It partially
+// satisfies DecodingLayer.
+func (a *ASF) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
+	if len(data) < 8 {
+		df.SetTruncated()
+		return fmt.Errorf("invalid ASF data header, length %v less than 8",
+			len(data))
+	}
+
+	a.BaseLayer.Contents = data[:8]
+	a.BaseLayer.Payload = data[8:]
+
+	a.Enterprise = binary.BigEndian.Uint32(data[:4])
+	a.Type = ASFType(data[4])
+	a.Tag = uint8(data[5])
+	// 1 byte reserved
+	a.Length = uint8(data[7])
+	return nil
+}
+
+// NextLayerType returns the layer type corresponding to the message type of
+// this ASF data layer. This partially satisfies DecodingLayer.
+func (a *ASF) NextLayerType() gopacket.LayerType {
+	return a.Type.LayerType()
+}
+
+// SerializeTo writes the serialized fom of this layer into the SerializeBuffer,
+// partially satisfying SerializableLayer.
+func (a *ASF) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeOptions) error {
+	bytes, err := b.PrependBytes(8)
+	if err != nil {
+		return err
+	}
+	binary.BigEndian.PutUint32(bytes[:4], a.Enterprise)
+	bytes[4] = uint8(a.Type)
+	bytes[5] = a.Tag
+	bytes[6] = 0x00
+	bytes[7] = a.Length
+	return nil
+}
+
+// decodeASF decodes the byte slice into an RMCP-ASF data struct.
+func decodeASF(data []byte, p gopacket.PacketBuilder) error {
+	return decodingLayerDecoder(&ASF{}, data, p)
+}

--- a/layers/asf.go
+++ b/layers/asf.go
@@ -144,6 +144,7 @@ func (a *ASF) NextLayerType() gopacket.LayerType {
 // SerializeTo writes the serialized fom of this layer into the SerializeBuffer,
 // partially satisfying SerializableLayer.
 func (a *ASF) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeOptions) error {
+	payload := b.Bytes()
 	bytes, err := b.PrependBytes(8)
 	if err != nil {
 		return err
@@ -152,6 +153,9 @@ func (a *ASF) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeOpt
 	bytes[4] = uint8(a.Type)
 	bytes[5] = a.Tag
 	bytes[6] = 0x00
+	if opts.FixLengths {
+		a.Length = uint8(len(payload))
+	}
 	bytes[7] = a.Length
 	return nil
 }

--- a/layers/asf.go
+++ b/layers/asf.go
@@ -15,6 +15,12 @@ import (
 	"github.com/google/gopacket"
 )
 
+const (
+	// ASFEnterprise is the IANA-assigned Enterprise Number of the ASF-RMCP
+	// organisation.
+	ASFRMCPEnterprise uint32 = 4542
+)
+
 // ASFDataIdentifier encapsulates fields used to uniquely identify the format of
 // the data block.
 //
@@ -79,12 +85,6 @@ var (
 	asfDataLayerTypes = map[ASFDataIdentifier]gopacket.LayerType{
 		ASFDataIdentifierPresencePong: LayerTypeASFPresencePong,
 	}
-)
-
-const (
-	// ASFEnterprise is the IANA-assigned Enterprise Number of the ASF-RMCP
-	// organisation.
-	ASFRMCPEnterprise uint32 = 4542
 )
 
 // ASF defines ASF's generic RMCP message Data block format. See section

--- a/layers/asf.go
+++ b/layers/asf.go
@@ -16,8 +16,7 @@ import (
 )
 
 const (
-	// ASFRMCPEnterprise is the IANA-assigned Enterprise Number of the ASF-RMCP
-	// organisation.
+	// ASFRMCPEnterprise is the IANA-assigned Enterprise Number of the ASF-RMCP.
 	ASFRMCPEnterprise uint32 = 4542
 )
 
@@ -93,9 +92,10 @@ type ASF struct {
 	BaseLayer
 	ASFDataIdentifier
 
-	// Tag is the message tag, used to match request/response pairs. The tag of
-	// a response is set to that of the message it is responding to. If a
-	// message is not of the request/response type, this is set to 255.
+	// Tag is used to match request/response pairs. The tag of a response is set
+	// to that of the message it is responding to. If a message is
+	// unidirectional, i.e. not part of a request/response pair, this is set to
+	// 255.
 	Tag uint8
 
 	// 1 byte reserved, set to 0x00.

--- a/layers/asf_presencepong.go
+++ b/layers/asf_presencepong.go
@@ -146,13 +146,19 @@ func (a *ASFPresencePong) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.
 	if err != nil {
 		return err
 	}
+
 	binary.BigEndian.PutUint32(bytes[:4], a.Enterprise)
 	copy(bytes[4:8], a.OEM[:])
 	bytes[8] = bool2uint8(a.IPMI)&uint8(ASFPresencePongEntityIPMI) |
 		bool2uint8(a.ASFv1)&uint8(ASFPresencePongEntityASFv1)
 	bytes[9] = bool2uint8(a.SecurityExtensions)&uint8(ASFPresencePongInteractionSecurityExtensions) |
 		bool2uint8(a.DASH)&uint8(ASFPresencePongInteractionDASH)
-	// remaining 6 bytes all 0s
+
+	// zero-out remaining 6 bytes
+	for i := 10; i < len(bytes); i++ {
+		bytes[i] = 0x00
+	}
+
 	return nil
 }
 

--- a/layers/asf_presencepong.go
+++ b/layers/asf_presencepong.go
@@ -1,0 +1,161 @@
+// Copyright 2019 The GoPacket Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file in the root of the source tree.
+
+package layers
+
+// This file implements the RMCP ASF Presence Pong message, specified in section
+// 3.2.4.3 of
+// https://www.dmtf.org/sites/default/files/standards/documents/DSP0136.pdf. It
+// also contains non-competing elements from IPMI v2.0, specified in section
+// 13.2.4 of
+// https://www.intel.com/content/dam/www/public/us/en/documents/specification-updates/ipmi-intelligent-platform-mgt-interface-spec-2nd-gen-v2-0-spec-update.pdf.
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/google/gopacket"
+)
+
+type (
+	// ASFEntity is the type of individual entities that a Presence Pong
+	// response can indicate support of. The entities currently implemented by
+	// the spec are IPMI and ASFv1.
+	ASFEntity uint8
+
+	// ASFInteraction is the type of individual interactions that a Presence
+	// Pong response can indicate support for. The interactions currently
+	// implemented by the spec are RMCP security extensions. Although not
+	// specified, IPMI uses this field to indicate support for DASH, which is
+	// supported as well.
+	ASFInteraction uint8
+)
+
+const (
+	// ASFPresencePongEntityIPMI ANDs with Presence Pong's supported entities
+	// field if the managed system supports IPMI.
+	ASFPresencePongEntityIPMI ASFEntity = 1 << 7
+
+	// ASFPresencePongEntityASFv1 ANDs with Presence Pong's supported entities
+	// field if the managed system supports ASF v1.0.
+	ASFPresencePongEntityASFv1 ASFEntity = 1
+
+	// ASFPresencePongInteractionSecurityExtensions ANDs with Presence Pong's
+	// supported interactions field if the managed system supports RMCP v2.0
+	// security extensions. See section 3.2.3.
+	ASFPresencePongInteractionSecurityExtensions ASFInteraction = 1 << 7
+
+	// ASFPresencePongInteractionDASH ANDs with Presence Pong's supported
+	// interactions field if the managed system supports DMTF DASH. See
+	// https://www.dmtf.org/standards/dash.
+	ASFPresencePongInteractionDASH ASFInteraction = 1 << 5
+)
+
+// ASFPresencePong defines the structure of a Presence Pong message's payload.
+// See section 3.2.4.3.
+type ASFPresencePong struct {
+	BaseLayer
+
+	// Enterprise is the IANA Enterprise Number of an entity that has defined
+	// OEM-specific capabilities for the managed client. If no such capabilities
+	// exist, this is set to ASF's IANA Enterprise Number.
+	Enterprise uint32
+
+	// OEM identifies OEM-specific capabilities. Its structure is defined by the
+	// OEM. This is set to 0s if no OEM-specific capabilities exist. This
+	// implementation does not change byte order from the wire for this field.
+	OEM [4]byte
+
+	// We break out entities and interactions into separate booleans as
+	// discovery is the entire point of this type of message, so we assume they
+	// are accessed. It also makes gopacket's default layer printing more
+	// useful.
+
+	// IPMI is true if IPMI is supported by the managed system. There is no
+	// explicit version in the specification, however given the dates, this is
+	// assumed to be IPMI v1.0.  Support for IPMI is contained in the "supported
+	// entities" field of the presence pong payload.
+	IPMI bool
+
+	// ASFv1 indicates support for ASF v1.0. This seems somewhat redundant as
+	// ASF must be supported in order to receive a response. This is contained
+	// in the "supported entities" field of the presence pong payload.
+	ASFv1 bool
+
+	// SecurityExtensions indicates support for RMCP Security Extensions,
+	// specified in ASF v2.0. This will always be false for v1.x
+	// implementations. This is contained in the "supported interactions" field
+	// of the presence pong payload. This field is defined in ASF v1.0, but has
+	// no useful value.
+	SecurityExtensions bool
+
+	// DASH is true if DMTF DASH is supported. This is not specified in ASF
+	// v2.0, but in IPMI v2.0, however the former does not preclude it, so we
+	// support it.
+	DASH bool
+
+	// 6 bytes reserved after the entities and interactions fields, set to 0s.
+}
+
+// LayerType returns LayerTypeASFPresencePong. It partially satisfies Layer and
+// SerializableLayer.
+func (*ASFPresencePong) LayerType() gopacket.LayerType {
+	return LayerTypeASFPresencePong
+}
+
+// CanDecode returns LayerTypeASFPresencePong. It partially satisfies
+// DecodingLayer.
+func (a *ASFPresencePong) CanDecode() gopacket.LayerClass {
+	return a.LayerType()
+}
+
+// DecodeFromBytes makes the layer represent the provided bytes. It partially
+// satisfies DecodingLayer.
+func (a *ASFPresencePong) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
+	if len(data) < 16 {
+		df.SetTruncated()
+		return fmt.Errorf("invalid ASF presence pong payload, length %v less than 16",
+			len(data))
+	}
+
+	a.BaseLayer.Contents = data[:16]
+	a.BaseLayer.Payload = data[16:]
+
+	a.Enterprise = binary.BigEndian.Uint32(data[:4])
+	copy(a.OEM[:], data[4:8]) // N.B. no byte order change
+	a.IPMI = data[8]&uint8(ASFPresencePongEntityIPMI) != 0
+	a.ASFv1 = data[8]&uint8(ASFPresencePongEntityASFv1) != 0
+	a.SecurityExtensions = data[9]&uint8(ASFPresencePongInteractionSecurityExtensions) != 0
+	a.DASH = data[9]&uint8(ASFPresencePongInteractionDASH) != 0
+	// ignore remaining 6 bytes; should be set to 0s
+	return nil
+}
+
+// NextLayerType returns LayerTypePayload, as there are no further layers to
+// decode. This partially satisfies DecodingLayer.
+func (a *ASFPresencePong) NextLayerType() gopacket.LayerType {
+	return gopacket.LayerTypePayload
+}
+
+// SerializeTo writes the serialized fom of this layer into the SerializeBuffer,
+// partially satisfying SerializableLayer.
+func (a *ASFPresencePong) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeOptions) error {
+	bytes, err := b.PrependBytes(16)
+	if err != nil {
+		return err
+	}
+	binary.BigEndian.PutUint32(bytes[:4], a.Enterprise)
+	copy(bytes[4:8], a.OEM[:])
+	bytes[8] = bool2uint8(a.IPMI)&uint8(ASFPresencePongEntityIPMI) | bool2uint8(a.ASFv1)&uint8(ASFPresencePongEntityASFv1)
+	bytes[9] = bool2uint8(a.SecurityExtensions)&uint8(ASFPresencePongInteractionSecurityExtensions) | bool2uint8(a.DASH)&uint8(ASFPresencePongInteractionDASH)
+	// remaining 6 bytes all 0s
+	return nil
+}
+
+// decodeASFPresencePong decodes the byte slice into an RMCP-ASF Presence Pong
+// struct.
+func decodeASFPresencePong(data []byte, p gopacket.PacketBuilder) error {
+	return decodingLayerDecoder(&ASFPresencePong{}, data, p)
+}

--- a/layers/asf_presencepong.go
+++ b/layers/asf_presencepong.go
@@ -148,8 +148,10 @@ func (a *ASFPresencePong) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.
 	}
 	binary.BigEndian.PutUint32(bytes[:4], a.Enterprise)
 	copy(bytes[4:8], a.OEM[:])
-	bytes[8] = bool2uint8(a.IPMI)&uint8(ASFPresencePongEntityIPMI) | bool2uint8(a.ASFv1)&uint8(ASFPresencePongEntityASFv1)
-	bytes[9] = bool2uint8(a.SecurityExtensions)&uint8(ASFPresencePongInteractionSecurityExtensions) | bool2uint8(a.DASH)&uint8(ASFPresencePongInteractionDASH)
+	bytes[8] = bool2uint8(a.IPMI)&uint8(ASFPresencePongEntityIPMI) |
+		bool2uint8(a.ASFv1)&uint8(ASFPresencePongEntityASFv1)
+	bytes[9] = bool2uint8(a.SecurityExtensions)&uint8(ASFPresencePongInteractionSecurityExtensions) |
+		bool2uint8(a.DASH)&uint8(ASFPresencePongInteractionDASH)
 	// remaining 6 bytes all 0s
 	return nil
 }

--- a/layers/asf_presencepong.go
+++ b/layers/asf_presencepong.go
@@ -34,6 +34,12 @@ type (
 )
 
 const (
+	// ASFDCMIEnterprise is the IANA-assigned Enterprise Number of the Data
+	// Center Manageability Interface Forum. The Presence Pong response's
+	// Enterprise field being set to this value indicates support for DCMI. The
+	// DCMI spec regards the OEM field as reserved, so these should be null.
+	ASFDCMIEnterprise uint32 = 36465
+
 	// ASFPresencePongEntityIPMI ANDs with Presence Pong's supported entities
 	// field if the managed system supports IPMI.
 	ASFPresencePongEntityIPMI ASFEntity = 1 << 7
@@ -97,6 +103,12 @@ type ASFPresencePong struct {
 	DASH bool
 
 	// 6 bytes reserved after the entities and interactions fields, set to 0s.
+}
+
+// SupportsDCMI returns whether the Presence Pong message indicates support for
+// the Data Center Management Interface, which is an extension of IPMI v2.0.
+func (a *ASFPresencePong) SupportsDCMI() bool {
+	return a.Enterprise == ASFDCMIEnterprise && a.IPMI && a.ASFv1
 }
 
 // LayerType returns LayerTypeASFPresencePong. It partially satisfies Layer and

--- a/layers/asf_presencepong.go
+++ b/layers/asf_presencepong.go
@@ -160,11 +160,24 @@ func (a *ASFPresencePong) SerializeTo(b gopacket.SerializeBuffer, _ gopacket.Ser
 	}
 
 	binary.BigEndian.PutUint32(bytes[:4], a.Enterprise)
+
 	copy(bytes[4:8], a.OEM[:])
-	bytes[8] = bool2uint8(a.IPMI)&uint8(ASFPresencePongEntityIPMI) |
-		bool2uint8(a.ASFv1)&uint8(ASFPresencePongEntityASFv1)
-	bytes[9] = bool2uint8(a.SecurityExtensions)&uint8(ASFPresencePongInteractionSecurityExtensions) |
-		bool2uint8(a.DASH)&uint8(ASFPresencePongInteractionDASH)
+
+	bytes[8] = 0
+	if a.IPMI {
+		bytes[8] |= uint8(ASFPresencePongEntityIPMI)
+	}
+	if a.ASFv1 {
+		bytes[8] |= uint8(ASFPresencePongEntityASFv1)
+	}
+
+	bytes[9] = 0
+	if a.SecurityExtensions {
+		bytes[9] |= uint8(ASFPresencePongInteractionSecurityExtensions)
+	}
+	if a.DASH {
+		bytes[9] |= uint8(ASFPresencePongInteractionDASH)
+	}
 
 	// zero-out remaining 6 bytes
 	for i := 10; i < len(bytes); i++ {

--- a/layers/asf_presencepong.go
+++ b/layers/asf_presencepong.go
@@ -153,7 +153,7 @@ func (a *ASFPresencePong) NextLayerType() gopacket.LayerType {
 
 // SerializeTo writes the serialized fom of this layer into the SerializeBuffer,
 // partially satisfying SerializableLayer.
-func (a *ASFPresencePong) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeOptions) error {
+func (a *ASFPresencePong) SerializeTo(b gopacket.SerializeBuffer, _ gopacket.SerializeOptions) error {
 	bytes, err := b.PrependBytes(16)
 	if err != nil {
 		return err

--- a/layers/asf_presencepong_test.go
+++ b/layers/asf_presencepong_test.go
@@ -29,8 +29,8 @@ func ASFPresencePongTestDecodeFromBytes(t *testing.T) {
 	if !bytes.Equal(pp.BaseLayer.Contents, b) {
 		t.Errorf("contents is %v, want %v", pp.BaseLayer.Contents, b)
 	}
-	if pp.Enterprise != ASFEnterprise {
-		t.Errorf("want enterprise %v, got %v", ASFEnterprise, pp.Enterprise)
+	if pp.Enterprise != ASFRMCPEnterprise {
+		t.Errorf("want enterprise %v, got %v", ASFRMCPEnterprise, pp.Enterprise)
 	}
 	if !bytes.Equal(pp.OEM[:], make([]byte, 4)) {
 		t.Errorf("want null OEM, got %v", pp.OEM[:])
@@ -62,7 +62,7 @@ func ASFPresencePongTestSerializeTo(t *testing.T) {
 	}{
 		{
 			&ASFPresencePong{
-				Enterprise: ASFEnterprise,
+				Enterprise: ASFRMCPEnterprise,
 				IPMI:       true,
 				ASFv1:      true,
 			},

--- a/layers/asf_presencepong_test.go
+++ b/layers/asf_presencepong_test.go
@@ -1,0 +1,92 @@
+// Copyright 2019 The GoPacket Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file in the root of the source tree.
+
+package layers
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/google/gopacket"
+)
+
+func ASFPresencePongTestDecodeFromBytes(t *testing.T) {
+	b, err := hex.DecodeString("000011be000000008100000000000000")
+	if err != nil {
+		t.Fatalf("Failed to decode ASF Presence Pong message")
+	}
+
+	pp := &ASFPresencePong{}
+	if err := pp.DecodeFromBytes(b, gopacket.NilDecodeFeedback); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if !bytes.Equal(pp.BaseLayer.Payload, []byte{}) {
+		t.Errorf("payload is %v, want %v", pp.BaseLayer.Payload, b)
+	}
+	if !bytes.Equal(pp.BaseLayer.Contents, b) {
+		t.Errorf("contents is %v, want %v", pp.BaseLayer.Contents, b)
+	}
+	if pp.Enterprise != ASFEnterprise {
+		t.Errorf("want enterprise %v, got %v", ASFEnterprise, pp.Enterprise)
+	}
+	if !bytes.Equal(pp.OEM[:], make([]byte, 4)) {
+		t.Errorf("want null OEM, got %v", pp.OEM[:])
+	}
+	if !pp.IPMI {
+		t.Errorf("want IPMI, got false")
+	}
+	if !pp.ASFv1 {
+		t.Errorf("want ASFv1, got false")
+	}
+	if pp.SecurityExtensions {
+		t.Errorf("do not want security extensions, got true")
+	}
+	if pp.DASH {
+		t.Errorf("do not want DASH, got true")
+	}
+}
+
+func serializeASFPresencePong(pp *ASFPresencePong) ([]byte, error) {
+	sb := gopacket.NewSerializeBuffer()
+	err := pp.SerializeTo(sb, gopacket.SerializeOptions{})
+	return sb.Bytes(), err
+}
+
+func ASFPresencePongTestSerializeTo(t *testing.T) {
+	table := []struct {
+		layer *ASFPresencePong
+		want  []byte
+	}{
+		{
+			&ASFPresencePong{
+				Enterprise: ASFEnterprise,
+				IPMI:       true,
+				ASFv1:      true,
+			},
+			[]byte{0, 0, 0x11, 0xbe, 0, 0, 0, 0, 0x81, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			&ASFPresencePong{
+				Enterprise:         1234,
+				OEM:                [4]byte{1, 2, 3, 4},
+				ASFv1:              true,
+				SecurityExtensions: true,
+				DASH:               true,
+			},
+			[]byte{0, 0, 0x4, 0xd2, 1, 2, 3, 4, 0x01, 0x9, 0, 0, 0, 0, 0, 0},
+		},
+	}
+	for _, test := range table {
+		b, err := serializeASFPresencePong(test.layer)
+		switch {
+		case err != nil && test.want != nil:
+			t.Errorf("serialize %v failed with %v, wanted %v", test.layer,
+				err, test.want)
+		case err == nil && !bytes.Equal(b, test.want):
+			t.Errorf("serialize %v = %v, want %v", test.layer, b, test.want)
+		}
+	}
+}

--- a/layers/asf_presencepong_test.go
+++ b/layers/asf_presencepong_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/gopacket"
 )
 
-func ASFPresencePongTestDecodeFromBytes(t *testing.T) {
+func TestASFPresencePongDecodeFromBytes(t *testing.T) {
 	b, err := hex.DecodeString("000011be000000008100000000000000")
 	if err != nil {
 		t.Fatalf("Failed to decode ASF Presence Pong message")
@@ -49,7 +49,7 @@ func ASFPresencePongTestDecodeFromBytes(t *testing.T) {
 	}
 }
 
-func ASFPresencePongTestSupportsDCMI(t *testing.T) {
+func TestASFPresencePongSupportsDCMI(t *testing.T) {
 	table := []struct {
 		layer *ASFPresencePong
 		want  bool
@@ -101,7 +101,7 @@ func serializeASFPresencePong(pp *ASFPresencePong) ([]byte, error) {
 	return sb.Bytes(), err
 }
 
-func ASFPresencePongTestSerializeTo(t *testing.T) {
+func TestASFPresencePongSerializeTo(t *testing.T) {
 	table := []struct {
 		layer *ASFPresencePong
 		want  []byte
@@ -122,7 +122,7 @@ func ASFPresencePongTestSerializeTo(t *testing.T) {
 				SecurityExtensions: true,
 				DASH:               true,
 			},
-			[]byte{0, 0, 0x4, 0xd2, 1, 2, 3, 4, 0x01, 0x9, 0, 0, 0, 0, 0, 0},
+			[]byte{0, 0, 0x4, 0xd2, 1, 2, 3, 4, 0x01, 0xa0, 0, 0, 0, 0, 0, 0},
 		},
 	}
 	for _, test := range table {

--- a/layers/asf_presencepong_test.go
+++ b/layers/asf_presencepong_test.go
@@ -49,6 +49,52 @@ func ASFPresencePongTestDecodeFromBytes(t *testing.T) {
 	}
 }
 
+func ASFPresencePongTestSupportsDCMI(t *testing.T) {
+	table := []struct {
+		layer *ASFPresencePong
+		want  bool
+	}{
+		{
+			&ASFPresencePong{
+				Enterprise: ASFRMCPEnterprise,
+				IPMI:       true,
+				ASFv1:      true,
+			},
+			false,
+		},
+		{
+			&ASFPresencePong{
+				Enterprise: ASFDCMIEnterprise,
+				IPMI:       false,
+				ASFv1:      true,
+			},
+			false,
+		},
+		{
+			&ASFPresencePong{
+				Enterprise: ASFDCMIEnterprise,
+				IPMI:       true,
+				ASFv1:      false,
+			},
+			false,
+		},
+		{
+			&ASFPresencePong{
+				Enterprise: ASFDCMIEnterprise,
+				IPMI:       true,
+				ASFv1:      true,
+			},
+			true,
+		},
+	}
+	for _, test := range table {
+		got := test.layer.SupportsDCMI()
+		if got != test.want {
+			t.Errorf("%v SupportsDCMI() = %v, want %v", test.layer, got, test.want)
+		}
+	}
+}
+
 func serializeASFPresencePong(pp *ASFPresencePong) ([]byte, error) {
 	sb := gopacket.NewSerializeBuffer()
 	err := pp.SerializeTo(sb, gopacket.SerializeOptions{})

--- a/layers/asf_test.go
+++ b/layers/asf_test.go
@@ -29,11 +29,11 @@ func ASFTestDecodeFromBytes(t *testing.T) {
 	if !bytes.Equal(asf.BaseLayer.Contents, b) {
 		t.Errorf("contents is %v, want %v", asf.BaseLayer.Contents, b)
 	}
-	if asf.Enterprise != ASFEnterprise {
-		t.Errorf("enterprise is %v, want %v", asf.Enterprise, ASFEnterprise)
+	if asf.Enterprise != ASFRMCPEnterprise {
+		t.Errorf("enterprise is %v, want %v", asf.Enterprise, ASFRMCPEnterprise)
 	}
-	if asf.Type != ASFTypePresencePong {
-		t.Errorf("type is %v, want %v", asf.Type, ASFTypePresencePong)
+	if asf.Type != ASFDataIdentifierPresencePong.Type {
+		t.Errorf("type is %v, want %v", asf.Type, ASFDataIdentifierPresencePong)
 	}
 	if asf.Tag != 0 {
 		t.Errorf("tag is %v, want 0", asf.Tag)
@@ -56,16 +56,14 @@ func ASFTestSerializeTo(t *testing.T) {
 	}{
 		{
 			&ASF{
-				Enterprise: ASFEnterprise,
-				Type:       ASFTypePresencePing,
+				ASFDataIdentifier: ASFDataIdentifierPresencePing,
 			},
 			[]byte{0, 0, 0x11, 0xbe, 0x80, 0, 0, 0},
 		},
 		{
 			&ASF{
-				Enterprise: ASFEnterprise,
-				Type:       ASFTypePresencePong,
-				Length:     0x10,
+				ASFDataIdentifier: ASFDataIdentifierPresencePong,
+				Length:            0x10,
 			},
 			[]byte{0, 0, 0x11, 0xbe, 0x40, 0, 0, 0x10},
 		},

--- a/layers/asf_test.go
+++ b/layers/asf_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/google/gopacket"
 )
 
-func ASFTestDecodeFromBytes(t *testing.T) {
-	b, err := hex.DecodeString("000011be4000100000000000000000")
+func TestASFDecodeFromBytes(t *testing.T) {
+	b, err := hex.DecodeString("000011be4000001000000000000000")
 	if err != nil {
 		t.Fatalf("Failed to decode ASF message")
 	}
@@ -23,11 +23,11 @@ func ASFTestDecodeFromBytes(t *testing.T) {
 	if err := asf.DecodeFromBytes(b, gopacket.NilDecodeFeedback); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	if !bytes.Equal(asf.BaseLayer.Payload, []byte{}) {
-		t.Errorf("payload is %v, want %v", asf.BaseLayer.Payload, b)
+	if !bytes.Equal(asf.BaseLayer.Contents, b[:8]) {
+		t.Errorf("contents is %v, want %v", asf.BaseLayer.Contents, b[:8])
 	}
-	if !bytes.Equal(asf.BaseLayer.Contents, b) {
-		t.Errorf("contents is %v, want %v", asf.BaseLayer.Contents, b)
+	if !bytes.Equal(asf.BaseLayer.Payload, b[8:]) {
+		t.Errorf("payload is %v, want %v", asf.BaseLayer.Payload, b[8:])
 	}
 	if asf.Enterprise != ASFRMCPEnterprise {
 		t.Errorf("enterprise is %v, want %v", asf.Enterprise, ASFRMCPEnterprise)
@@ -51,7 +51,7 @@ func serializeASF(asf *ASF) ([]byte, error) {
 	return sb.Bytes(), err
 }
 
-func ASFTestSerializeTo(t *testing.T) {
+func TestASFSerializeTo(t *testing.T) {
 	table := []struct {
 		layer *ASF
 		want  []byte
@@ -65,9 +65,11 @@ func ASFTestSerializeTo(t *testing.T) {
 		{
 			&ASF{
 				ASFDataIdentifier: ASFDataIdentifierPresencePong,
-				// length calculated automatically
+				// ensures length is being overridden - should be encoded to 0
+				// as there is no payload
+				Length: 1,
 			},
-			[]byte{0, 0, 0x11, 0xbe, 0x40, 0, 0, 0x10},
+			[]byte{0, 0, 0x11, 0xbe, 0x40, 0, 0, 0},
 		},
 	}
 	for _, test := range table {

--- a/layers/asf_test.go
+++ b/layers/asf_test.go
@@ -1,0 +1,83 @@
+// Copyright 2019 The GoPacket Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file in the root of the source tree.
+
+package layers
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/google/gopacket"
+)
+
+func ASFTestDecodeFromBytes(t *testing.T) {
+	b, err := hex.DecodeString("000011be4000100000000000000000")
+	if err != nil {
+		t.Fatalf("Failed to decode ASF message")
+	}
+
+	asf := &ASF{}
+	if err := asf.DecodeFromBytes(b, gopacket.NilDecodeFeedback); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if !bytes.Equal(asf.BaseLayer.Payload, []byte{}) {
+		t.Errorf("payload is %v, want %v", asf.BaseLayer.Payload, b)
+	}
+	if !bytes.Equal(asf.BaseLayer.Contents, b) {
+		t.Errorf("contents is %v, want %v", asf.BaseLayer.Contents, b)
+	}
+	if asf.Enterprise != ASFEnterprise {
+		t.Errorf("enterprise is %v, want %v", asf.Enterprise, ASFEnterprise)
+	}
+	if asf.Type != ASFTypePresencePong {
+		t.Errorf("type is %v, want %v", asf.Type, ASFTypePresencePong)
+	}
+	if asf.Tag != 0 {
+		t.Errorf("tag is %v, want 0", asf.Tag)
+	}
+	if asf.Length != 16 {
+		t.Errorf("length is %v, want 16", asf.Length)
+	}
+}
+
+func serializeASF(asf *ASF) ([]byte, error) {
+	sb := gopacket.NewSerializeBuffer()
+	err := asf.SerializeTo(sb, gopacket.SerializeOptions{})
+	return sb.Bytes(), err
+}
+
+func ASFTestSerializeTo(t *testing.T) {
+	table := []struct {
+		layer *ASF
+		want  []byte
+	}{
+		{
+			&ASF{
+				Enterprise: ASFEnterprise,
+				Type:       ASFTypePresencePing,
+			},
+			[]byte{0, 0, 0x11, 0xbe, 0x80, 0, 0, 0},
+		},
+		{
+			&ASF{
+				Enterprise: ASFEnterprise,
+				Type:       ASFTypePresencePong,
+				Length:     0x10,
+			},
+			[]byte{0, 0, 0x11, 0xbe, 0x40, 0, 0, 0x10},
+		},
+	}
+	for _, test := range table {
+		b, err := serializeASF(test.layer)
+		switch {
+		case err != nil && test.want != nil:
+			t.Errorf("serialize %v failed with %v, wanted %v", test.layer,
+				err, test.want)
+		case err == nil && !bytes.Equal(b, test.want):
+			t.Errorf("serialize %v = %v, want %v", test.layer, b, test.want)
+		}
+	}
+}

--- a/layers/asf_test.go
+++ b/layers/asf_test.go
@@ -45,7 +45,9 @@ func ASFTestDecodeFromBytes(t *testing.T) {
 
 func serializeASF(asf *ASF) ([]byte, error) {
 	sb := gopacket.NewSerializeBuffer()
-	err := asf.SerializeTo(sb, gopacket.SerializeOptions{})
+	err := asf.SerializeTo(sb, gopacket.SerializeOptions{
+		FixLengths: true,
+	})
 	return sb.Bytes(), err
 }
 
@@ -63,7 +65,7 @@ func ASFTestSerializeTo(t *testing.T) {
 		{
 			&ASF{
 				ASFDataIdentifier: ASFDataIdentifierPresencePong,
-				Length:            0x10,
+				// length calculated automatically
 			},
 			[]byte{0, 0, 0x11, 0xbe, 0x40, 0, 0, 0x10},
 		},

--- a/layers/layertypes.go
+++ b/layers/layertypes.go
@@ -144,6 +144,8 @@ var (
 	LayerTypeTLS                          = gopacket.RegisterLayerType(140, gopacket.LayerTypeMetadata{Name: "TLS", Decoder: gopacket.DecodeFunc(decodeTLS)})
 	LayerTypeModbusTCP                    = gopacket.RegisterLayerType(141, gopacket.LayerTypeMetadata{Name: "ModbusTCP", Decoder: gopacket.DecodeFunc(decodeModbusTCP)})
 	LayerTypeRMCP                         = gopacket.RegisterLayerType(142, gopacket.LayerTypeMetadata{Name: "RMCP", Decoder: gopacket.DecodeFunc(decodeRMCP)})
+	LayerTypeASF                          = gopacket.RegisterLayerType(143, gopacket.LayerTypeMetadata{Name: "ASF", Decoder: gopacket.DecodeFunc(decodeASF)})
+	LayerTypeASFPresencePong              = gopacket.RegisterLayerType(144, gopacket.LayerTypeMetadata{Name: "ASFPresencePong", Decoder: gopacket.DecodeFunc(decodeASFPresencePong)})
 )
 
 var (

--- a/layers/rmcp.go
+++ b/layers/rmcp.go
@@ -57,8 +57,9 @@ const (
 
 var (
 	rmcpClassLayerTypes = [16]gopacket.LayerType{
-		// RMCPClassASF and RMCPClassIPMI are to implement; OEM layer type (8)
-		// is deliberately not implemented, so we return LayerTypePayload
+		RMCPClassASF: LayerTypeASF,
+		// RMCPClassIPMI is to implement; RMCPClassOEM is deliberately not
+		// implemented, so we return LayerTypePayload
 	}
 )
 

--- a/layers/rmcp.go
+++ b/layers/rmcp.go
@@ -139,7 +139,7 @@ func (r *RMCP) Payload() []byte {
 
 // SerializeTo writes the serialized fom of this layer into the SerializeBuffer,
 // partially satisfying SerializableLayer.
-func (r *RMCP) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeOptions) error {
+func (r *RMCP) SerializeTo(b gopacket.SerializeBuffer, _ gopacket.SerializeOptions) error {
 	// The IPMI v1.5 spec contains a pad byte for frame sizes of certain lengths
 	// to work around issues in LAN chips. This is no longer necessary as of
 	// IPMI v2.0 (renamed to "legacy pad") so we do not attempt to add it. The

--- a/layers/rmcp.go
+++ b/layers/rmcp.go
@@ -63,6 +63,13 @@ var (
 	}
 )
 
+// RegisterRMCPLayerType allows specifying that the payload of a RMCP packet of
+// a certain class should processed by the provided layer type. This overrides
+// any existing registrations, including defaults.
+func RegisterRMCPLayerType(c RMCPClass, l gopacket.LayerType) {
+	rmcpClassLayerTypes[c] = l
+}
+
 // RMCP describes the format of an RMCP header, which forms a UDP payload. See
 // section 3.2.2.2.
 type RMCP struct {


### PR DESCRIPTION
This builds on top of #653 to add support for the ASF RMCP message type. Presence Ping and Presence Pong are supported; the latter has a dedicated layer type for its payload.

Please merge #653 first; I'll then rebase this as necessary.