### PR TITLE
Fix double release bug in reassembly

### DIFF
--- a/reassembly/tcpassembly.go
+++ b/reassembly/tcpassembly.go
@@ -1292,6 +1292,7 @@ func (a *Assembler) flushClose(conn *connection, half *halfconnection, t time.Ti
 		a.skipFlush(conn, half)
 		if half.closed {
 			closed = true
+			return flushed, closed
 		}
 	}
 	// Close the connection only if both halfs of the connection last seen before tc.

--- a/reassembly/tcpassembly_test.go
+++ b/reassembly/tcpassembly_test.go
@@ -872,6 +872,51 @@ func TestFlush(t *testing.T) {
 			delay:          time.Millisecond * 50,
 			flushOlderThan: time.Millisecond * 99,
 		},
+		// a late RST packet
+		{
+			seq: []testSequence{
+				{
+					in: layers.TCP{
+						SrcPort:   1,
+						DstPort:   2,
+						Seq:       1005,
+						BaseLayer: layers.BaseLayer{Payload: []byte{5, 6, 7}},
+					},
+					// gets queued
+					want: []Reassembly{},
+				},
+				{
+					in: layers.TCP{
+						SrcPort:   1,
+						DstPort:   2,
+						RST:       true,
+						Seq:       1001,
+						BaseLayer: layers.BaseLayer{Payload: []byte{1, 2, 3}},
+					},
+					// gets queued just before the first packet
+					// and should close its half-connection (RST) during next flush
+					want: []Reassembly{},
+				},
+				{
+					// triggers flush/close
+					in: layers.TCP{
+						SrcPort:   1,
+						DstPort:   2,
+						Seq:       1010,
+						BaseLayer: layers.BaseLayer{Payload: []byte{10, 11, 12}},
+					},
+					want: []Reassembly{
+						Reassembly{
+							Skip:  -1,
+							End:   true,
+							Bytes: []byte{1, 2, 3},
+						},
+					},
+				},
+			},
+			delay:          time.Millisecond * 40,
+			flushOlderThan: time.Millisecond * 50,
+		},
 	} {
 		testFlush(t, test.seq, test.delay, test.flushOlderThan)
 	}


### PR DESCRIPTION
While testing `reassembly` package on live traffic, I have encountered a problem with `checkOverlap` function hanging in an infinite loop. After some investigation, I found out that assembler's `pageCache` sometimes returns a `page` that is already in use, i.e. which was already taken from pageCache before, and not yet released. That made me think, that at some point in past that `page` was released twice.  

After more debugging, I found a test case which triggers a double release of a page (8d08f07).
You can verify it, by running the test and adding a check in `sendToConnection`, such as:
```
if half.closed {
    panic("sending on a closed half")
}
```

The bug happens because:
- `sendToConnection` might close a connection and thus free all pending pages, if it's a RST|FIN packet
- in `flushClose` we don't check if halfConnection is already closed before flushing next page (which was already released)
