### PR TITLE
Fix reassembly pages allocation/shrinking

### DIFF
--- a/reassembly/memory.go
+++ b/reassembly/memory.go
@@ -44,11 +44,12 @@ func newPageCache() *pageCache {
 
 // grow exponentially increases the size of our page cache as much as necessary.
 func (c *pageCache) grow() {
-	pages := make([]page, c.pcSize)
-	c.size += c.pcSize
-	for i := range pages {
-		c.free = append(c.free, &pages[i])
+	pages := make([]*page, 0, c.pcSize)
+	for i := 0; i < c.pcSize; i++ {
+		pages = append(pages, &page{})
 	}
+	c.size += c.pcSize
+	c.free = append(c.free, pages...)
 	if *memLog {
 		log.Println("PageCache: created", c.pcSize, "new pages, size:", c.size, "cap:", cap(c.free), "len:", len(c.free))
 	}


### PR DESCRIPTION
I have noticed, that an application which uses reassembly package will start consuming more and more memory over time. After some profiling, I found out that most of the memory was taken at 
https://github.com/google/gopacket/blob/0f680daf16b80a573e90e62cd91ce8e02e72f9a4/reassembly/memory.go#L47  
These pages are used by tcp assembly logic for packets which came out of order. After tcp assembly is done with a page, it puts it back to the `free` list. This list may, at some point, be too big for current traffic rate, therefore we have shrinking logic. `tryShrink` function shrinks the `free` slice to some size, and assigns `nil` to the pointers which pointed to preallocated pages in order to let GC collect those unused pages: 
https://github.com/google/gopacket/blob/0f680daf16b80a573e90e62cd91ce8e02e72f9a4/reassembly/memory.go#L73

However, as we saw, those pages are allocated as a slice of pages, which afaik, should be a single memory block. Therefore, in order for GC to collect that memory, all the pages allocated in that memory block should have no pointers to them. So, we may turn up wasting 1023 pages, while using only one page of that memory block.

Proposed fix, is to allocate pages separately, so that they can be collected by GC independently of each other. However, this hits our performance, because allocating pages one by one is slower than allocating them all at once.