### PR TITLE
Fix issue https://github.com/google/gopacket/issues/668#issue-459392815

### DIFF
--- a/layers/ospf.go
+++ b/layers/ospf.go
@@ -129,6 +129,12 @@ type NetworkLSA struct {
 	AttachedRouter []uint32
 }
 
+// NetworkLSAV2 is the struct from RFC 2328  A.4.3.
+type NetworkLSAV2 struct {
+	NetworkMask    uint32
+	AttachedRouter []uint32
+}
+
 // RouterV2 extends RouterLSAV2
 type RouterV2 struct {
 	Type     uint8
@@ -301,6 +307,16 @@ func extractLSAInformation(lstype, lsalength uint16, data []byte) (interface{}, 
 			Metric:            binary.BigEndian.Uint32(data[24:28]) & 0x00FFFFFF,
 			ForwardingAddress: binary.BigEndian.Uint32(data[28:32]),
 			ExternalRouteTag:  binary.BigEndian.Uint32(data[32:36]),
+		}
+	case NetworkLSAtypeV2:
+		var routers []uint32
+		var j uint32
+		for j = 24; j < uint32(lsalength); j += 4 {
+			routers = append(routers, binary.BigEndian.Uint32(data[j:j+4]))
+		}
+		content = NetworkLSAV2{
+			NetworkMask:    binary.BigEndian.Uint32(data[20:24]),
+			AttachedRouter: routers,
 		}
 	case RouterLSAtype:
 		var routers []Router

--- a/layers/ospf_test.go
+++ b/layers/ospf_test.go
@@ -601,6 +601,98 @@ func BenchmarkDecodePacketPacket8(b *testing.B) {
 	}
 }
 
+// testPacketOSPF2LSUpdateLSA2 is the packet:
+// 00:50:17.836469 IP 172.24.27.86 > ospf-all.mcast.net: OSPFv2, LS-Update, length 104
+//	0x0000:  0100 5e00 0005 d4e8 80c2 b1c9 8100 017f  ..^.............
+//	0x0010:  0800 45c0 008c f7e4 0000 0159 1901 ac18  ..E........Y....
+//	0x0020:  1b56 e000 0005 0204 0068 ac18 0446 0000  .V.......h...F..
+//	0x0030:  000c 0000 0000 0000 0000 0000 0000 0000  ................
+//	0x0040:  0002 0001 2801 ac18 0446 ac18 0446 8000  ....(....F...F..
+//	0x0050:  041a 6025 0024 0000 0001 ac18 1b56 ac18  ..`%.$.......V..
+//	0x0060:  1b56 0200 0001 0001 2802 ac18 1b56 ac18  .V......(....V..
+//	0x0070:  0446 8000 041f 390e 0028 ffff fff8 ac18  .F....9..(......
+//	0x0080:  0446 ac18 0445 ac18 1b53 ac18 1b54 760e  .F...E...S...Tv.
+//	0x0090:  3106 0f2f 6711 fb1d eb5c c98d 4070       1../g....\..@p
+var testPacketOSPF2LSUpdateLSA2 = []byte{
+	0x01, 0x00, 0x5e, 0x00, 0x00, 0x05, 0xd4, 0xe8, 0x80, 0xc2, 0xb1, 0xc9, 0x81, 0x00, 0x01, 0x7f,
+	0x08, 0x00, 0x45, 0xc0, 0x00, 0x8c, 0xf7, 0xe4, 0x00, 0x00, 0x01, 0x59, 0x19, 0x01, 0xac, 0x18,
+	0x1b, 0x56, 0xe0, 0x00, 0x00, 0x05, 0x02, 0x04, 0x00, 0x68, 0xac, 0x18, 0x04, 0x46, 0x00, 0x00,
+	0x00, 0x0c, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x02, 0x00, 0x01, 0x28, 0x01, 0xac, 0x18, 0x04, 0x46, 0xac, 0x18, 0x04, 0x46, 0x80, 0x00,
+	0x04, 0x1a, 0x60, 0x25, 0x00, 0x24, 0x00, 0x00, 0x00, 0x01, 0xac, 0x18, 0x1b, 0x56, 0xac, 0x18,
+	0x1b, 0x56, 0x02, 0x00, 0x00, 0x01, 0x00, 0x01, 0x28, 0x02, 0xac, 0x18, 0x1b, 0x56, 0xac, 0x18,
+	0x04, 0x46, 0x80, 0x00, 0x04, 0x1f, 0x39, 0x0e, 0x00, 0x28, 0xff, 0xff, 0xff, 0xf8, 0xac, 0x18,
+	0x04, 0x46, 0xac, 0x18, 0x04, 0x45, 0xac, 0x18, 0x1b, 0x53, 0xac, 0x18, 0x1b, 0x54, 0x76, 0x0e,
+	0x31, 0x06, 0x0f, 0x2f, 0x67, 0x11, 0xfb, 0x1d, 0xeb, 0x5c, 0xc9, 0x8d, 0x40, 0x70,
+}
+
+func TestPacketOSPF2LSUpdateLSA2(t *testing.T) {
+	p := gopacket.NewPacket(testPacketOSPF2LSUpdateLSA2, LinkTypeEthernet, gopacket.Default)
+	if p.ErrorLayer() != nil {
+		t.Error("Failed to decode packet:", p.ErrorLayer().Error())
+	}
+	checkLayers(p, []gopacket.LayerType{LayerTypeEthernet, LayerTypeDot1Q, LayerTypeIPv4, LayerTypeOSPF}, t)
+	if got, ok := p.Layer(LayerTypeOSPF).(*OSPFv2); ok {
+		want := &OSPFv2{
+			OSPF: OSPF{
+				Version:      2,
+				Type:         OSPFLinkStateUpdate,
+				PacketLength: 104,
+				RouterID:     0xac180446,
+				AreaID:       12,
+				Checksum:     0x0000,
+				Content: LSUpdate{
+					NumOfLSAs: 2,
+					LSAs: []LSA{
+						LSA{
+							LSAheader: LSAheader{
+								LSAge:       0x1,
+								LSType:      0x1,
+								LinkStateID: 0xac180446,
+								AdvRouter:   0xac180446,
+								LSSeqNumber: 0x8000041a,
+								LSChecksum:  0x6025,
+								Length:      0x24,
+								LSOptions:   0x28,
+							},
+							Content: RouterLSAV2{
+								Flags: 0x0,
+								Links: 0x1,
+							},
+						},
+						LSA{
+							LSAheader: LSAheader{
+								LSAge:       0x1,
+								LSType:      0x2,
+								LinkStateID: 0xac181b56,
+								AdvRouter:   0xac180446,
+								LSSeqNumber: 0x8000041f,
+								LSChecksum:  0x390e,
+								Length:      0x28,
+								LSOptions:   0x28,
+							},
+							Content: NetworkLSAV2{
+								NetworkMask: 0xfffffff8,
+								AttachedRouter: []uint32{
+									0xac180446,
+									0xac180445,
+									0xac181b53,
+									0xac181b54,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("OSPF packet processing failed:\ngot  :\n%#v\n\nwant :\n%#v\n\n", got, want)
+		}
+	} else {
+		t.Error("No OSPF layer type found in packet")
+	}
+}
+
 // testPacketOSPF3LSUpdate is the packet:
 //   14:43:51.681554 IP6 fe80::1 > fe80::2: OSPFv3, LS-Update, length 288
 //   	0x0000:  c201 1ffa 0001 c200 1ffa 0001 86dd 6e00  ..............n.


### PR DESCRIPTION
Please check this fix for issue https://github.com/google/gopacket/issues/668#issue-459392815 (OSPF Layer not parsing OSPFv2 Type 2 LSAs properly).
