### PR TITLE
Fix issue #669 (OSPF layer fails to decode type 7 LSAs)

### DIFF
--- a/layers/ospf.go
+++ b/layers/ospf.go
@@ -38,6 +38,7 @@ const (
 	ASExternalLSAtypeV2     = 0x5
 	ASExternalLSAtype       = 0x4005
 	NSSALSAtype             = 0x2007
+	NSSALSAtypeV2           = 0x7
 	LinkLSAtype             = 0x0008
 	IntraAreaPrefixLSAtype  = 0x2009
 )
@@ -294,6 +295,8 @@ func extractLSAInformation(lstype, lsalength uint16, data []byte) (interface{}, 
 			Links:   links,
 			Routers: routers,
 		}
+	case NSSALSAtypeV2:
+		fallthrough
 	case ASExternalLSAtypeV2:
 		content = ASExternalLSAV2{
 			NetworkMask:       binary.BigEndian.Uint32(data[20:24]),


### PR DESCRIPTION
Please check this PR which fixes issue https://github.com/google/gopacket/issues/669#issue-459395018

The Type 7 LSA is specified in RFC 3101 Appendix C. It has the same fields as Type 5 AS External LSA, so this PR reuses the existing ASExternalLSAV2 struct and code.