### PR TITLE
Implement MPLS Echo layer

### DIFF
--- a/layers/layertypes.go
+++ b/layers/layertypes.go
@@ -146,6 +146,7 @@ var (
 	LayerTypeRMCP                         = gopacket.RegisterLayerType(142, gopacket.LayerTypeMetadata{Name: "RMCP", Decoder: gopacket.DecodeFunc(decodeRMCP)})
 	LayerTypeASF                          = gopacket.RegisterLayerType(143, gopacket.LayerTypeMetadata{Name: "ASF", Decoder: gopacket.DecodeFunc(decodeASF)})
 	LayerTypeASFPresencePong              = gopacket.RegisterLayerType(144, gopacket.LayerTypeMetadata{Name: "ASFPresencePong", Decoder: gopacket.DecodeFunc(decodeASFPresencePong)})
+	LayerTypeMPLSEcho                     = gopacket.RegisterLayerType(145, gopacket.LayerTypeMetadata{Name: "MPLSEcho", Decoder: gopacket.DecodeFunc(decodeMPLSEcho)})
 )
 
 var (

--- a/layers/mpls_echo.go
+++ b/layers/mpls_echo.go
@@ -1,0 +1,529 @@
+// Copyright 2018 GoPacket Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file in the root of the source
+// tree.
+
+package layers
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"github.com/google/gopacket" // BSD license
+	"net"
+)
+
+// This file implements a layer that enables Label Switched Path (LSP) Ping/Traceroute operations to be conducted
+// inside Multiprotocol Label Switching (MPLS) networks for data plane failure detection and localization, per RFC8029.
+
+// The version number is to be incremented whenever a change is made that affects the ability of an implementation to
+// correctly parse or process an MPLS echo request/reply.
+type MPLSEchoVersion uint16
+
+const (
+	MPLSEchoVersion1 MPLSEchoVersion = iota + 1
+)
+
+// Bitmask type that represents an MPLS echo request/reply's global flags.
+type MPLSEchoGlobalFlags uint16
+
+const (
+	// Flag is 1 if the sender wants the receiver to perform FEC Stack validation;
+	// if flag is 0, the choice is left to the receiver.
+	MPLSEchoFlagValidateFECStack MPLSEchoGlobalFlags = 1 << iota // 1
+
+	// Can only be set in echo request packets.  If set to 1 in an incoming echo request and the TTL of the incoming
+	// MPLS label is greater than 1, the receiving node MUST drop the oacket and MUST NOT send back an echo reply.
+	MPLSEchoFlagRespondOnlyIfTTLExpired // 2
+
+	// If this flag is set in the echo request, the Responder SHOULD return reverse-path FEC information (see RFC6426).
+	MPLSEchoFlagValidateReversePath // 4
+)
+
+// Define bitmask operations.
+func SetMPLSEchoGlobalFlag(b, flag MPLSEchoGlobalFlags) MPLSEchoGlobalFlags   { return b | flag }
+func ClearMPLSEchoGlobalFlag(b, flag MPLSEchoGlobalFlags) MPLSEchoGlobalFlags { return b &^ flag }
+func HasMPLSEchoGlobalFlag(b, flag MPLSEchoGlobalFlags) bool                  { return b&flag != 0 }
+
+// Specifies the MPLS echo message type (request/reply/...).
+type MPLSEchoMessageType uint8
+
+const (
+	MPLSEchoRequest MPLSEchoMessageType = iota + 1
+	MPLSEchoReply
+)
+
+// Specifies the desired receiver-side behavior.
+type MPLSEchoReplyMode uint8
+
+const (
+	// For one-way connectivity tests.
+	MPLSEchoModeDoNotReply MPLSEchoReplyMode = iota + 1
+
+	// Reply with an IPv4/IPv6 UDP packet (i.e., mainstream scenario).
+	MPLSEchoModeReplyViaUDP
+
+	// To be used when the normal IP return path is deemed unreliable.
+	// Requires that all intermediate routers know how to forward MPLS echo replies.
+	MPLSEchoModeReplyViaUDPWithRouterAlert
+
+	// Applications that support an IP control channel between its control entities may use this mode
+	// to ensure that replies use that same channel.
+	MPLSEchoModeReplyViaAppLevelChannel
+)
+
+// The Return Code is set to zero by the sender of an echo request. The receiver of said echo request can set it to
+// one of the values listed below in the corresponding echo reply that it generates.
+type MPLSReplyReturnCode uint8
+
+// In the enum comments, <RSC> refers to the Return Subcode.
+const (
+	// No return code.
+	MPLSEchoReturnCodeNone MPLSReplyReturnCode = iota
+
+	// Malformed echo request received.
+	MPLSEchoReturnCodeMalformedRequest
+
+	// One or more of the TLVs was not understood.
+	MPLSEchoReturnCodeTLVNotUnderstood
+
+	// Replying router is an egress for the FEC at stack-depth <RSC>.
+	MPLSEchoReturnCodeEgressForFEC
+
+	// Replying router has no mapping for the FEC at stack-depth <RSC>.
+	MPLSEchoReturnCodeNoMappingForFEC
+
+	// Downstream Mapping Mismatch.
+	MPLSEchoReturnCodeDownstreamMappingMismatch
+
+	// Upstream Interface Index Unknown.
+	MPLSEchoReturnCodeUpstreamIfaceIndexUnknown
+
+	MPLSEchoReturnCodeReserved
+
+	// Label switched at stack-depth <RSC>.
+	MPLSEchoReturnCodeLabelSwitched
+
+	// Label switched but no MPLS forwarding at stack-depth <RSC>.
+	MPLSEchoReturnCodeLabelSwitchButNoMPLSForwarding
+
+	// Mapping for this FEC is not the given label at stack-depth <RSC>.
+	MPLSEchoReturnCodeLabelMappingMismatchForFEC
+
+	// No label entry at stack-depth <RSC>.
+	MPLSEchoReturnCodeNoLabelEntry
+
+	// Protocol not associated with interface at FEC stack-depth <RSC>.
+	MPLSEchoReturnCodeNoProtocolAtIfaceForFEC
+
+	// Premature termination of ping due to label stack shrinking to a single label.
+	MPLSEchoReturnCodePrematureTerminationSingleLabel
+
+	// When this Return Code is set, each Downstream Detailed Mapping TLV MUST have an appropriate Return Code and
+	// Return Subcode.  This Return Code MUST be used when there are multiple downstreams for a given node (such as
+	// Point-to-Multipoint (P2MP) or ECMP), and the node needs to return a Return Code/Return Subcode for each
+	// downstream. This Return Code MAY be used even when there is only one downstream for a given node.
+	MPLSEchoReturnCodeMultipleDownstreams
+
+	//  A transit node stitching two LSPs SHOULD include two FEC stack change sub-TLVs.  One with a pop operation for
+	// the old FEC (ingress) and one with the PUSH operation for the new FEC (egress).  The replying node SHOULD set
+	// the Return Code to "Label switched with FEC change" to indicate change in the FEC being traced.
+	MPLSEchoReturnCodeLabelSwitchedWithFECChange
+)
+
+// TLVs (Type-Length-Value tuples) may be nested within other TLVs, in which case the nested TLVs are called sub-TLVs.
+// TLVs and sub-TLVs have independent types, but both MUST be 4-octet aligned in their encoded form.
+type MPLSEchoTLV struct {
+	Type uint16
+
+	// The Value field depends on the Type. When encoded, the value is zero padded to align to a 4-byte boundary.
+	// The Value contents MUST be in network order (i.e., big endian).
+	Value []byte
+}
+
+// List of TLV and sub-TLV types that are implemented in this file. All other types are handled as MPLSEchoTLV instances
+// with arbitrary byte BLOBs as their values. Gopacket apps will need to encode/decode those (sub-)TLVs at their layer.
+//
+// MPLS Echo implementations may transmit non-standard (sub-)TLV types, so we use uint16 to allow for custom (sub-)TLVs.
+const (
+	MPLSEchoTLVTypeTargetFECStack                 uint16 = 1
+	MPLSEchoSubTLVTypeTargetFECStackLDPPrefixIPv4 uint16 = 1
+	MPLSEchoSubTLVTypeTargetFECStackLDPPrefixIPv6 uint16 = 2
+)
+
+// Interface for encoding/decoding a TLV value.
+type MPLSEchoValue interface {
+	// Returns value's TLV representation.
+	EncodeAsTLV() (*MPLSEchoTLV, error)
+
+	// Populates the value based on the user-provided TLV representation.
+	DecodeFromTLV(tlv *MPLSEchoTLV) error
+}
+
+// Represents an LDP IPv4/IPv6 Prefix FEC. Implements the MPLSEchoValue interface.
+type LDPPrefixFECValue struct {
+	Prefix       net.IP
+	PrefixLength uint8
+}
+
+// This TLV value defines a stack of FECs, the first FEC element corresponding to the top of the label stack, etc.
+type TargetFECStackValue struct {
+	FECs []MPLSEchoValue
+}
+
+// An MPLS echo request/reply is a (possibly labeled) IPv4 or IPv6 UDP packet, where
+// the packet's payload has the format of the MPLSEcho struct below (refer to RFC8029, Section 3).
+//
+// In the UDP packet's IP header:
+// 1. The source IP address is a routable address of the sender.
+// 2. The destination IP address is a (randomly chosen) IPv4 address from the range 127/8 or an IPv6 address
+//    from the range 0:0:0:0:0:FFFF:7F00:0/104.
+// 3. The IP TTL is set to 1.
+// 4. The source UDP port is chosen by the sender.
+// 5. The destination UDP port is set to 3503 (assigned by IANA for MPLS echo requests).
+// 6. The Router Alert IP Option of value 0x0 [RFC2113] for IPv4 or value 69 [RFC7506] for IPv6 MUST be set.
+type MPLSEcho struct {
+	BaseLayer
+	VersionNumber MPLSEchoVersion
+	GlobalFlags   MPLSEchoGlobalFlags
+	MessageType   MPLSEchoMessageType
+	ReplyMode     MPLSEchoReplyMode
+	ReturnCode    MPLSReplyReturnCode
+
+	// The Return Subcode (RSC) contains the point in the label stack where processing was terminated.
+	// If the RSC is 0, no labels were processed.  Otherwise, the packet was label switched at depth RSC.
+	ReturnSubcode uint8
+
+	// Arbitrary context filled in by the sender and returned unchanged by the receiver in the echo reply (if any).
+	// There are no semantics associated with this field; a sender may use it to match up requests with replies.
+	SenderHandle uint32
+
+	// The Sequence Number is assigned by the sender of the MPLS echo request and can be (for example) used to detect
+	// missed replies.
+	SequenceNumber uint32
+
+	// Time of day, according to the sender's clock, in 64-bit NTP timestamp format [RFC5905] when the MPLS echo
+	// request is sent.
+	TimestampSentSeconds         uint32
+	TimestampSentSecondsFraction uint32 // divide by 2^32 to get the fractions of a second
+
+	// Time of day, according to the receiver's clock, in 64-bit NTP timestamp format in which the corresponding echo
+	// request was received.
+	TimestampReceivedSeconds         uint32
+	TimestampReceivedSecondsFraction uint32 // divide by 2^32 to get the fractions of a second
+
+	// TLV types less than 32768 (i.e., with the high-order bit equal to 0) are mandatory TLVs that MUST either be
+	// supported by an implementation or result in MPLSEchoReturnCodeTLVNotUnderstood being sent in the echo response.
+	//
+	// Types greater than or equal to 32768 (i.e., with the high-order bit equal to 1) are optional TLVs that SHOULD be
+	// ignored if the implementation does not understand or support them.
+	TLVs []*MPLSEchoTLV
+}
+
+func roundUpToNearestMultiple(numToRound uint, multiple uint) uint {
+	return ((numToRound + multiple - 1) / multiple) * multiple
+}
+
+// Target format (from RFC8029, Section 3):
+// 0                   1                   2                   3
+// 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |             Type              |            Length             |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |                             Value                             |
+// .                                                               .
+// .                                                               .
+// .                                                               .
+// |                                                               |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// <ZERO OR MORE ADDITIONAL TLVs> ...
+func (p *MPLSEchoTLV) EncodeAsBytes() ([]byte, error) {
+	valueByteCount := uint(len(p.Value))
+	valueByteCountWithPadding := roundUpToNearestMultiple(valueByteCount, 4) // Pad to a multiple of 4 bytes
+	tlvByteCountWithPadding := 4 + valueByteCountWithPadding
+	tlvByteRepresentation := make([]byte, tlvByteCountWithPadding)
+	binary.BigEndian.PutUint16(tlvByteRepresentation[0:], uint16(p.Type))
+	binary.BigEndian.PutUint16(tlvByteRepresentation[2:], uint16(valueByteCount))
+
+	bytesCopied := copy(tlvByteRepresentation[4:], p.Value[:])
+	if uint(bytesCopied) != valueByteCount {
+		return nil, fmt.Errorf(
+			"MPLSEchoTLV encoding error - TLV of type %v, bytesCopied (%v) != valueByteCount (%v)",
+			p.Type,
+			bytesCopied,
+			valueByteCount)
+	}
+
+	return tlvByteRepresentation, nil
+}
+
+// On success, the first return value contains the total number of bytes decoded.
+func (p *MPLSEchoTLV) DecodeFromBytes(data []byte) (int, error) {
+	totalByteCount := len(data)
+	if totalByteCount < 4 {
+		return 0, fmt.Errorf(
+			"MPLSEchoTLV decoding error - data is less than 4 bytes long (actual length: %v)",
+			totalByteCount)
+	}
+
+	p.Type = binary.BigEndian.Uint16(data[0:2])
+	valueByteCount := uint(binary.BigEndian.Uint16(data[2:4]))
+	valueByteCountWithPadding := roundUpToNearestMultiple(valueByteCount, 4) // Padded to a multiple of 4 bytes
+
+	tlvByteCountWithPadding := 4 + int(valueByteCountWithPadding)
+	if tlvByteCountWithPadding > totalByteCount {
+		return 0, fmt.Errorf(
+			"MPLSEchoTLV decoding error - TLV of type %v goes beyond the valid data: tlvByteCountWithPadding (%v) > totalByteCount (%v)",
+			p.Type,
+			tlvByteCountWithPadding,
+			totalByteCount)
+	}
+
+	p.Value = data[4 : 4+valueByteCount]
+	return tlvByteCountWithPadding, nil
+}
+
+func (p *LDPPrefixFECValue) EncodeAsTLV() (*MPLSEchoTLV, error) {
+	prefixType := MPLSEchoSubTLVTypeTargetFECStackLDPPrefixIPv4 // Assume IPv4
+	prefixByteRepresentation := p.Prefix.To4()
+	if prefixByteRepresentation == nil {
+		prefixType = MPLSEchoSubTLVTypeTargetFECStackLDPPrefixIPv6 // Assume IPv6
+		prefixByteRepresentation = p.Prefix.To16()
+		if prefixByteRepresentation == nil {
+			return nil, errors.New("LDPPrefixFECValue encoding error - Prefix isn't a valid IPv4 or IPv6 address")
+		}
+	}
+
+	return &MPLSEchoTLV{
+		Type:  prefixType,
+		Value: append(prefixByteRepresentation, p.PrefixLength),
+	}, nil
+}
+
+func (p *LDPPrefixFECValue) DecodeFromTLV(tlv *MPLSEchoTLV) error {
+	valueByteCount := len(tlv.Value)
+	if tlv.Type == MPLSEchoSubTLVTypeTargetFECStackLDPPrefixIPv4 && valueByteCount == 5 {
+		p.Prefix = tlv.Value[0:4]
+		p.PrefixLength = tlv.Value[4]
+	} else if tlv.Type == MPLSEchoSubTLVTypeTargetFECStackLDPPrefixIPv6 && valueByteCount == 17 {
+		p.Prefix = tlv.Value[0:16]
+		p.PrefixLength = tlv.Value[16]
+	} else {
+		return fmt.Errorf(
+			"LDPPrefixFECValue decoding error - Unknown LDPPrefixFECValue type (%v) or unexpected valueByteCount (%v)",
+			tlv.Type,
+			valueByteCount)
+	}
+
+	return nil
+}
+
+func (s *TargetFECStackValue) EncodeAsTLV() (*MPLSEchoTLV, error) {
+	var byteRepresentation []byte
+	for _, currentFEC := range s.FECs {
+		subTLV, err := currentFEC.EncodeAsTLV()
+		if err != nil {
+			return nil, err
+		}
+
+		subTLVBytes, err := subTLV.EncodeAsBytes()
+		if err != nil {
+			return nil, err
+		}
+
+		byteRepresentation = append(byteRepresentation, subTLVBytes...)
+	}
+
+	return &MPLSEchoTLV{
+		Type:  MPLSEchoTLVTypeTargetFECStack,
+		Value: byteRepresentation,
+	}, nil
+}
+
+func (s *TargetFECStackValue) DecodeFromTLV(tlv *MPLSEchoTLV) error {
+	if tlv.Type != MPLSEchoTLVTypeTargetFECStack {
+		return fmt.Errorf(
+			"TargetFECStackValue decoding error - type mismatch: expected %v, got %v",
+			MPLSEchoTLVTypeTargetFECStack,
+			tlv.Type)
+	}
+
+	s.FECs = nil
+	currentTLVStartOffset := 0
+	valueByteCount := len(tlv.Value)
+	for currentTLVStartOffset < valueByteCount {
+		currentTLV := &MPLSEchoTLV{}
+		numBytesDecoded, err := currentTLV.DecodeFromBytes(tlv.Value[currentTLVStartOffset:])
+		if err != nil {
+			return err
+		}
+
+		var newFEC MPLSEchoValue
+		switch currentTLV.Type {
+		case MPLSEchoSubTLVTypeTargetFECStackLDPPrefixIPv4:
+			fallthrough
+		case MPLSEchoSubTLVTypeTargetFECStackLDPPrefixIPv6:
+			newFEC = &LDPPrefixFECValue{}
+			err = newFEC.DecodeFromTLV(currentTLV)
+			if err != nil {
+				return err
+			}
+
+		default:
+			return fmt.Errorf("TargetFECStackValue decoding error - unknown sub-type: %v", currentTLV.Type)
+		}
+
+		s.FECs = append(s.FECs, newFEC)
+		currentTLVStartOffset += numBytesDecoded
+	}
+
+	if currentTLVStartOffset != valueByteCount {
+		return fmt.Errorf(
+			"TargetFECStackValue decoding error - sub-TLVs don't match the valid data bounds (Total Valid Bytes = %v, Last TLV End Offset = %v)",
+			valueByteCount,
+			currentTLVStartOffset)
+	}
+
+	return nil
+}
+
+func (m *MPLSEcho) LayerType() gopacket.LayerType {
+	return LayerTypeMPLSEcho
+}
+
+// DecodeFromBytes decodes the given bytes into this layer.
+func (m *MPLSEcho) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
+	if len(data) < 32 {
+		df.SetTruncated()
+		return fmt.Errorf("Invalid MPLSEcho content - length %v less than 32 bytes", len(data))
+	}
+
+	totalTLVBytes := len(data) - 32
+	if totalTLVBytes%4 != 0 {
+		return fmt.Errorf("Invalid MPLSEcho content - TLVs aren't 4-octet aligned (TLV bytes = %v)", totalTLVBytes)
+	}
+
+	m.VersionNumber = MPLSEchoVersion(binary.BigEndian.Uint16(data[0:2]))
+	m.GlobalFlags = MPLSEchoGlobalFlags(binary.BigEndian.Uint16(data[2:4]))
+	m.MessageType = MPLSEchoMessageType(data[4])
+	m.ReplyMode = MPLSEchoReplyMode(data[5])
+	m.ReturnCode = MPLSReplyReturnCode(data[6])
+	m.ReturnSubcode = data[7]
+	m.SenderHandle = binary.BigEndian.Uint32(data[8:12])
+	m.SequenceNumber = binary.BigEndian.Uint32(data[12:16])
+	m.TimestampSentSeconds = binary.BigEndian.Uint32(data[16:20])
+	m.TimestampSentSecondsFraction = binary.BigEndian.Uint32(data[20:24])
+	m.TimestampReceivedSeconds = binary.BigEndian.Uint32(data[24:28])
+	m.TimestampReceivedSecondsFraction = binary.BigEndian.Uint32(data[28:32])
+
+	currentTLVStartOffset := 32
+	for currentTLVStartOffset < len(data) {
+		currentTLV := &MPLSEchoTLV{}
+		numBytesDecoded, err := currentTLV.DecodeFromBytes(data[currentTLVStartOffset:])
+		if err != nil {
+			return err
+		}
+
+		m.TLVs = append(m.TLVs, currentTLV)
+		currentTLVStartOffset += numBytesDecoded
+	}
+
+	if currentTLVStartOffset != len(data) {
+		return fmt.Errorf(
+			"Invalid MPLSEcho content - TLVs don't match the valid data bounds (Total Valid Bytes = %v, Last TLV End Offset = %v)",
+			len(data),
+			currentTLVStartOffset)
+	}
+
+	return nil
+
+}
+
+// SerializeTo writes the serialized form of this layer into the SerializationBuffer, implementing gopacket.SerializableLayer.
+// See the docs for gopacket.SerializableLayer for more info.
+func (m *MPLSEcho) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeOptions) error {
+	totalBytes := 32
+	for _, currentTLV := range m.TLVs {
+		valueByteCount := uint(len(currentTLV.Value))
+		tlvByteCountWithPadding := 4 + roundUpToNearestMultiple(valueByteCount, 4) // Pad to a multiple of 4 bytes
+		totalBytes += int(tlvByteCountWithPadding)
+	}
+
+	bytes, err := b.PrependBytes(totalBytes)
+	if err != nil {
+		return err
+	}
+
+	binary.BigEndian.PutUint16(bytes[0:], uint16(m.VersionNumber))
+	binary.BigEndian.PutUint16(bytes[2:], uint16(m.GlobalFlags))
+	bytes[4] = uint8(m.MessageType)
+	bytes[5] = uint8(m.ReplyMode)
+	bytes[6] = uint8(m.ReturnCode)
+	bytes[7] = uint8(m.ReturnSubcode)
+	binary.BigEndian.PutUint32(bytes[8:], m.SenderHandle)
+	binary.BigEndian.PutUint32(bytes[12:], m.SequenceNumber)
+	binary.BigEndian.PutUint32(bytes[16:], m.TimestampSentSeconds)
+	binary.BigEndian.PutUint32(bytes[20:], m.TimestampSentSecondsFraction)
+	binary.BigEndian.PutUint32(bytes[24:], m.TimestampReceivedSeconds)
+	binary.BigEndian.PutUint32(bytes[28:], m.TimestampReceivedSecondsFraction)
+
+	currentTLVStartOffset := 32
+	for _, currentTLV := range m.TLVs {
+		tlvByteRepresentation, err := currentTLV.EncodeAsBytes()
+		if err != nil {
+			return err
+		}
+
+		tlvByteCount := len(tlvByteRepresentation)
+		totalBytesNeeded := currentTLVStartOffset + tlvByteCount
+		if totalBytesNeeded > totalBytes {
+			return fmt.Errorf(
+				"MPLSEcho serialization error for TLV of type %v: totalBytesNeeded (%v) > totalBytes (%v)",
+				currentTLV.Type,
+				totalBytesNeeded,
+				totalBytes)
+		}
+
+		bytesCopied := copy(bytes[currentTLVStartOffset:], tlvByteRepresentation[:])
+		if bytesCopied != tlvByteCount {
+			return fmt.Errorf(
+				"MPLSEcho serialization error for TLV of type %v: bytesCopied (%v) != tlvByteCount (%v)",
+				currentTLV.Type,
+				bytesCopied,
+				tlvByteCount)
+		}
+
+		currentTLVStartOffset = totalBytesNeeded
+	}
+
+	if currentTLVStartOffset != totalBytes {
+		return fmt.Errorf(
+			"Unexpected MPLSEcho serialization error: Last TLV End Offset (%v) != totalBytes (%v)",
+			currentTLVStartOffset,
+			totalBytes)
+	}
+
+	return nil
+}
+
+// CanDecode returns the set of layer types that this DecodingLayer can decode.
+func (m *MPLSEcho) CanDecode() gopacket.LayerClass {
+	return LayerTypeMPLSEcho
+}
+
+// NextLayerType returns the layer type contained by this DecodingLayer.
+func (m *MPLSEcho) NextLayerType() gopacket.LayerType {
+	return gopacket.LayerTypeZero
+}
+
+func decodeMPLSEcho(data []byte, p gopacket.PacketBuilder) error {
+	d := &MPLSEcho{}
+	err := d.DecodeFromBytes(data, p)
+	if err != nil {
+		return err
+	}
+
+	p.AddLayer(d)
+	return nil
+}

--- a/layers/mpls_echo_test.go
+++ b/layers/mpls_echo_test.go
@@ -1,0 +1,933 @@
+// Copyright 2018 GoPacket Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file in the root of the source
+// tree.
+
+package layers
+
+import (
+	"bytes"
+	"github.com/google/gopacket"
+	"net"
+	"reflect"
+	"runtime"
+	"testing"
+)
+
+// Based on Wireshark capture of LSP Ping operation on CISCO IOS-XRv 9000 device.
+// CISCO CLI command: ping mpls ipv4 104.44.1.118/32
+func TestMPLSEcho_FullEncodedPacket_MatchesWiresharkDump(t *testing.T) {
+	// MPLS Echo Request
+	//
+	// Frame 9: 110 bytes on wire (880 bits), 110 bytes captured (880 bits)
+	// Ethernet II, Src: 52:54:f3:02:fd:7a (52:54:f3:02:fd:7a), Dst: Cisco_45:7f:2b (00:30:7b:45:7f:2b)
+	// 	Destination: Cisco_45:7f:2b (00:30:7b:45:7f:2b)
+	// 	Source: 52:54:f3:02:fd:7a (52:54:f3:02:fd:7a)
+	// 	Type: IPv4 (0x0800)
+	// Internet Protocol Version 4, Src: 104.44.18.245, Dst: 127.0.0.1
+	// User Datagram Protocol, Src Port: 3503, Dst Port: 3503
+	// 	Source Port: 3503
+	// 	Destination Port: 3503
+	// 	Length: 72
+	// 	Checksum: 0x18a1 [unverified]
+	// 	[Checksum Status: Unverified]
+	// 	[Stream index: 0]
+	// 	[Timestamps]
+	// Multiprotocol Label Switching Echo
+	// 	Version: 1
+	// 	Global Flags: 0x0000
+	// 	Message Type: MPLS Echo Request (1)
+	// 	Reply Mode: Reply via an IPv4/IPv6 UDP packet (2)
+	// 	Return Code: No return code (0)
+	// 	Return Subcode: 0
+	// 	Sender's Handle: 0x289514a2
+	// 	Sequence Number: 1
+	// 	Timestamp Sent: Jul  2, 2019 21:50:30.489873816 UTC
+	// 	Timestamp Received: Feb  7, 2036 06:28:16.000000000 UTC
+	// 	Vendor Private
+	// 		Type: Vendor Private (64512)
+	// 		Length: 12
+	// 		Vendor Id: ciscoSystems (9)
+	// 		Value: 0001000400000004
+	// 	Target FEC Stack
+	// 		Type: Target FEC Stack (1)
+	// 		Length: 12
+	// 		FEC Element 1: LDP IPv4 prefix
+	// 			Type: LDP IPv4 prefix (1)
+	// 			Length: 5
+	// 			IPv4 Prefix: 104.44.1.118
+	// 			Prefix Length: 32
+	// 			Padding: 000000
+	expectedRequestPacketBytes := []byte{
+		0x00, 0x30, 0x7b, 0x45, 0x7f, 0x2b, 0x52, 0x54, 0xf3, 0x02, 0xfd, 0x7a, 0x08, 0x00, 0x46, 0x00,
+		0x00, 0x60, 0x01, 0x31, 0x40, 0x00, 0x01, 0x11, 0xe9, 0x35, 0x68, 0x2c, 0x12, 0xf5, 0x7f, 0x00,
+		0x00, 0x01, 0x94, 0x04, 0x00, 0x00, 0x0d, 0xaf, 0x0d, 0xaf, 0x00, 0x48, 0x18, 0xa1, 0x00, 0x01,
+		0x00, 0x00, 0x01, 0x02, 0x00, 0x00, 0x28, 0x95, 0x14, 0xa2, 0x00, 0x00, 0x00, 0x01, 0xe0, 0xc6,
+		0x50, 0x26, 0x7d, 0x68, 0x5e, 0xd7, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xfc, 0x00,
+		0x00, 0x0c, 0x00, 0x00, 0x00, 0x09, 0x00, 0x01, 0x00, 0x04, 0x00, 0x00, 0x00, 0x04, 0x00, 0x01,
+		0x00, 0x0c, 0x00, 0x01, 0x00, 0x05, 0x68, 0x2c, 0x01, 0x76, 0x20, 0x00, 0x00, 0x00,
+	}
+
+	// MPLS Echo Reply
+	//
+	// Frame 7: 90 bytes on wire (720 bits), 90 bytes captured (720 bits)
+	// Ethernet II, Src: 52:54:91:a8:48:40 (52:54:91:a8:48:40), Dst: Cisco_21:8d:f2 (00:10:7b:21:8d:f2)
+	// 	Destination: Cisco_21:8d:f2 (00:10:7b:21:8d:f2)
+	// 	Source: 52:54:91:a8:48:40 (52:54:91:a8:48:40)
+	// 	Type: IPv4 (0x0800)
+	// Internet Protocol Version 4, Src: 104.44.18.244, Dst: 104.44.18.245
+	// User Datagram Protocol, Src Port: 3503, Dst Port: 3503
+	// 	Source Port: 3503
+	// 	Destination Port: 3503
+	// 	Length: 56
+	// 	Checksum: 0xd42b [unverified]
+	// 	[Checksum Status: Unverified]
+	// 	[Stream index: 0]
+	// 	[Timestamps]
+	// Multiprotocol Label Switching Echo
+	// 	Version: 1
+	// 	Global Flags: 0x0000
+	// 	Message Type: MPLS Echo Reply (2)
+	// 	Reply Mode: Reply via an IPv4/IPv6 UDP packet (2)
+	// 	Return Code: Replying router is an egress for the FEC at stack depth RSC (3)
+	// 	Return Subcode: 1
+	// 	Sender's Handle: 0x289514a2
+	// 	Sequence Number: 1
+	// 	Timestamp Sent: Jul  2, 2019 21:50:30.489873816 UTC
+	// 	Timestamp Received: Jul  2, 2019 21:50:31.489873817 UTC
+	// 	Vendor Private
+	echoReplyPacketBytes := []byte{
+		0x00, 0x10, 0x7b, 0x21, 0x8d, 0xf2, 0x52, 0x54, 0x91, 0xa8, 0x48, 0x40, 0x08, 0x00, 0x45, 0xc0,
+		0x00, 0x4c, 0x01, 0x45, 0x00, 0x00, 0xff, 0x11, 0xc3, 0x5a, 0x68, 0x2c, 0x12, 0xf4, 0x68, 0x2c,
+		0x12, 0xf5, 0x0d, 0xaf, 0x0d, 0xaf, 0x00, 0x38, 0xd4, 0x2b, 0x00, 0x01, 0x00, 0x00, 0x02, 0x02,
+		0x03, 0x01, 0x28, 0x95, 0x14, 0xa2, 0x00, 0x00, 0x00, 0x01, 0xe0, 0xc6, 0x50, 0x26, 0x7d, 0x68,
+		0x5e, 0xd7, 0xe0, 0xc6, 0x50, 0x27, 0x7d, 0x68, 0x5e, 0xd8, 0xfc, 0x00, 0x00, 0x0c, 0x00, 0x00,
+		0x00, 0x09, 0x00, 0x01, 0x00, 0x04, 0x00, 0x00, 0x00, 0x04,
+	}
+
+	ethernet := &Ethernet{
+		SrcMAC:       net.HardwareAddr{0x52, 0x54, 0xf3, 0x02, 0xfd, 0x7a},
+		DstMAC:       net.HardwareAddr{0x00, 0x30, 0x7b, 0x45, 0x7f, 0x2b},
+		EthernetType: EthernetTypeIPv4,
+	}
+
+	ip := &IPv4{
+		Version:  4,
+		IHL:      24,
+		Length:   96,
+		Id:       0x0131,
+		Flags:    IPv4DontFragment,
+		TTL:      1,
+		Protocol: IPProtocolUDP,
+		SrcIP:    net.IP{104, 44, 18, 245},
+		DstIP:    net.IP{127, 0, 0, 1},
+		Options:  []IPv4Option{IPv4Option{OptionType: 148, OptionLength: 4, OptionData: []byte{0x0, 0x0}}},
+	}
+
+	udp := &UDP{
+		SrcPort: 3503,
+		DstPort: 3503,
+		Length:  72,
+	}
+	err := udp.SetNetworkLayerForChecksum(ip)
+	verifyNil(t, err)
+
+	// Build the Target FEC Stack TLV.
+	targetPrefixIP := net.ParseIP("104.44.1.118")
+	verifyNotNil(t, targetPrefixIP)
+
+	targetFECStackVal := TargetFECStackValue{
+		FECs: []MPLSEchoValue{
+			&LDPPrefixFECValue{
+				Prefix:       targetPrefixIP,
+				PrefixLength: 32,
+			},
+		},
+	}
+
+	targetFECStackAsTLV, err := targetFECStackVal.EncodeAsTLV()
+	verifyNil(t, err)
+	verifyNotNil(t, targetFECStackAsTLV)
+
+	mplsEchoRequestContents := &MPLSEcho{
+		VersionNumber:                    MPLSEchoVersion1,
+		GlobalFlags:                      0,
+		MessageType:                      MPLSEchoRequest,
+		ReplyMode:                        MPLSEchoModeReplyViaUDP,
+		ReturnCode:                       MPLSEchoReturnCodeNone,
+		ReturnSubcode:                    0,
+		SenderHandle:                     0x289514a2,
+		SequenceNumber:                   1,
+		TimestampSentSeconds:             0xe0c65026,
+		TimestampSentSecondsFraction:     0x7d685ed7,
+		TimestampReceivedSeconds:         0,
+		TimestampReceivedSecondsFraction: 0,
+		TLVs: []*MPLSEchoTLV{
+			// Vendor Private TLV.
+			&MPLSEchoTLV{Type: 64512, Value: []byte{0x0, 0x0, 0x0, 0x9, 0x0, 0x1, 0x0, 0x4, 0x0, 0x0, 0x0, 0x4}},
+
+			// Target FEC Stack TLV.
+			targetFECStackAsTLV,
+		},
+	}
+
+	options := gopacket.SerializeOptions{
+		FixLengths:       true,
+		ComputeChecksums: true,
+	}
+
+	buffer := gopacket.NewSerializeBuffer()
+	err = gopacket.SerializeLayers(
+		buffer,
+		options,
+		ethernet,
+		ip,
+		udp,
+		mplsEchoRequestContents)
+	verifyNil(t, err)
+
+	// The encoded MPLS Echo request should match the Wireshark capture's raw bytes.
+	requestPacketBytes := buffer.Bytes()
+	verifyEqual(t, expectedRequestPacketBytes, requestPacketBytes)
+
+	// The decoded MPLS Echo reply should match the Wireshark capture's contents.
+	replyPacket := gopacket.NewPacket(echoReplyPacketBytes, LayerTypeEthernet, gopacket.Lazy)
+	mplsEchoReplyLayer := replyPacket.Layer(LayerTypeMPLSEcho)
+	verifyNotNil(t, mplsEchoReplyLayer)
+
+	mplsEchoReplyContents, ok := mplsEchoReplyLayer.(*MPLSEcho)
+	verifyTrue(t, ok)
+
+	// Fields that should match the MPLS Echo request.
+	verifyEqual(t, mplsEchoRequestContents.VersionNumber, mplsEchoReplyContents.VersionNumber)
+	verifyEqual(t, mplsEchoRequestContents.GlobalFlags, mplsEchoReplyContents.GlobalFlags)
+	verifyEqual(t, mplsEchoRequestContents.SenderHandle, mplsEchoReplyContents.SenderHandle)
+	verifyEqual(t, mplsEchoRequestContents.SequenceNumber, mplsEchoReplyContents.SequenceNumber)
+	verifyEqual(t, mplsEchoRequestContents.TimestampSentSeconds, mplsEchoReplyContents.TimestampSentSeconds)
+	verifyEqual(t, mplsEchoRequestContents.TimestampSentSecondsFraction, mplsEchoReplyContents.TimestampSentSecondsFraction)
+
+	// Fields generated by the MPLS Echo request's receiver.
+	verifyEqual(t, MPLSEchoReply, mplsEchoReplyContents.MessageType)
+	verifyEqual(t, MPLSEchoReturnCodeEgressForFEC, mplsEchoReplyContents.ReturnCode)
+	verifyEqual(t, uint8(1), mplsEchoReplyContents.ReturnSubcode)
+	verifyEqual(t, uint32(0xe0c65027), mplsEchoReplyContents.TimestampReceivedSeconds)
+	verifyEqual(t, uint32(0x7d685ed8), mplsEchoReplyContents.TimestampReceivedSecondsFraction)
+
+	// Reply should contain the vendor-private TLV, but not the Target FEC Stack TLV.
+	verifyEqual(t, 1, len(mplsEchoReplyContents.TLVs))
+	verifyEqual(t, mplsEchoRequestContents.TLVs[0].Type, mplsEchoReplyContents.TLVs[0].Type)
+	verifyEqual(t, mplsEchoRequestContents.TLVs[0].Value, mplsEchoReplyContents.TLVs[0].Value)
+
+	// Try to decode 'targetFECStackAsTLV' the same way that a receiver would.
+	verifyEqual(t, MPLSEchoTLVTypeTargetFECStack, mplsEchoRequestContents.TLVs[1].Type)
+	targetFECStack := &TargetFECStackValue{}
+	err = targetFECStack.DecodeFromTLV(mplsEchoRequestContents.TLVs[1])
+	verifyNil(t, err)
+
+	verifyEqual(t, 1, len(targetFECStack.FECs))
+	ldpPrefixFECValue, ok := targetFECStack.FECs[0].(*LDPPrefixFECValue)
+	verifyTrue(t, ok)
+
+	verifyEqual(t, uint8(32), ldpPrefixFECValue.PrefixLength)
+	verifyEqual(t, targetPrefixIP.To4(), ldpPrefixFECValue.Prefix)
+}
+
+func TestMPLSEcho_DecodeUnexpectedlyShortByteArray_Fail(t *testing.T) {
+	// Byte array containing less than 32 bytes.
+	badData := []byte{0x1, 0x2, 0x3}
+
+	decodedMPLSEcho := &MPLSEcho{}
+	err := decodedMPLSEcho.DecodeFromBytes(badData, gopacket.NilDecodeFeedback)
+	verifyNotNil(t, err)
+	verifyEqual(t,
+		"Invalid MPLSEcho content - length 3 less than 32 bytes",
+		err.Error())
+}
+
+func TestMPLSEcho_DecodeUnalignedTLVs_Fail(t *testing.T) {
+	validMplsEchoRequestContents := &MPLSEcho{
+		VersionNumber:                    MPLSEchoVersion1,
+		GlobalFlags:                      0,
+		MessageType:                      MPLSEchoRequest,
+		ReplyMode:                        MPLSEchoModeReplyViaUDP,
+		ReturnCode:                       MPLSEchoReturnCodeNone,
+		ReturnSubcode:                    0,
+		SenderHandle:                     0x289514a2,
+		SequenceNumber:                   1,
+		TimestampSentSeconds:             0xe0c65026,
+		TimestampSentSecondsFraction:     0x7d685ed7,
+		TimestampReceivedSeconds:         0,
+		TimestampReceivedSecondsFraction: 0,
+		TLVs: []*MPLSEchoTLV{
+			// Vendor Private TLV.
+			&MPLSEchoTLV{Type: 64512, Value: []byte{0x0, 0x0, 0x0, 0x9, 0x0, 0x1, 0x0, 0x4, 0x0, 0x0, 0x0, 0x4}},
+		},
+	}
+
+	buf := gopacket.NewSerializeBuffer()
+	opts := gopacket.SerializeOptions{}
+	err := validMplsEchoRequestContents.SerializeTo(buf, opts)
+	verifyNil(t, err)
+
+	// Append an extra byte to the end of the TLV section, so it's no longer 4-octet aligned.
+	validEncodedBytes := buf.Bytes()
+	badEncodedBytes := append(validEncodedBytes, 0x1)
+
+	decodedMPLSEcho := &MPLSEcho{}
+	err = decodedMPLSEcho.DecodeFromBytes(badEncodedBytes, gopacket.NilDecodeFeedback)
+	verifyNotNil(t, err)
+	verifyEqual(t,
+		"Invalid MPLSEcho content - TLVs aren't 4-octet aligned (TLV bytes = 17)",
+		err.Error())
+}
+
+func TestMPLSEcho_DecodeMaliciousTLVs_Fail(t *testing.T) {
+	validMplsEchoRequestContents := &MPLSEcho{
+		VersionNumber:                    MPLSEchoVersion1,
+		GlobalFlags:                      0,
+		MessageType:                      MPLSEchoRequest,
+		ReplyMode:                        MPLSEchoModeReplyViaUDP,
+		ReturnCode:                       MPLSEchoReturnCodeNone,
+		ReturnSubcode:                    0,
+		SenderHandle:                     0x289514a2,
+		SequenceNumber:                   1,
+		TimestampSentSeconds:             0xe0c65026,
+		TimestampSentSecondsFraction:     0x7d685ed7,
+		TimestampReceivedSeconds:         0,
+		TimestampReceivedSecondsFraction: 0,
+		TLVs: []*MPLSEchoTLV{
+			// Vendor Private TLV.
+			&MPLSEchoTLV{Type: 64512, Value: []byte{0x0, 0x0, 0x0, 0x9, 0x0, 0x1, 0x0, 0x4, 0x0, 0x0, 0x0, 0x4}},
+		},
+	}
+
+	buf := gopacket.NewSerializeBuffer()
+	opts := gopacket.SerializeOptions{}
+	err := validMplsEchoRequestContents.SerializeTo(buf, opts)
+	verifyNil(t, err)
+
+	// Craft a TLV encoding that attempts to force a read outside of valid data boundaries.
+	badEncodedBytes := buf.Bytes()
+	badEncodedBytes[34] = 0xFF
+	badEncodedBytes[35] = 0xFF
+
+	decodedMPLSEcho := &MPLSEcho{}
+	err = decodedMPLSEcho.DecodeFromBytes(badEncodedBytes, gopacket.NilDecodeFeedback)
+	verifyNotNil(t, err)
+	verifyEqual(t,
+		"MPLSEchoTLV decoding error - TLV of type 64512 goes beyond the valid data: tlvByteCountWithPadding (65540) > totalByteCount (16)",
+		err.Error())
+}
+
+func TestMPLSEcho_CanDecode_ReturnsExpectedValue(t *testing.T) {
+	mplsEcho := &MPLSEcho{}
+	verifyEqual(t, LayerTypeMPLSEcho, mplsEcho.CanDecode())
+}
+
+func TestMPLSEcho_NextLayerType_ReturnsExpectedValue(t *testing.T) {
+	mplsEcho := &MPLSEcho{}
+	verifyEqual(t, gopacket.LayerTypeZero, mplsEcho.NextLayerType())
+}
+
+func TestMPLSEchoGlobalFlags_SetClearHas_ExpectedBehavior(t *testing.T) {
+	globalFlags := MPLSEchoGlobalFlags(0)
+	verifyFalse(t, HasMPLSEchoGlobalFlag(globalFlags, MPLSEchoFlagValidateFECStack))
+	verifyFalse(t, HasMPLSEchoGlobalFlag(globalFlags, MPLSEchoFlagRespondOnlyIfTTLExpired))
+	verifyFalse(t, HasMPLSEchoGlobalFlag(globalFlags, MPLSEchoFlagValidateReversePath))
+
+	globalFlags = SetMPLSEchoGlobalFlag(globalFlags, MPLSEchoFlagRespondOnlyIfTTLExpired)
+	verifyFalse(t, HasMPLSEchoGlobalFlag(globalFlags, MPLSEchoFlagValidateFECStack))
+	verifyTrue(t, HasMPLSEchoGlobalFlag(globalFlags, MPLSEchoFlagRespondOnlyIfTTLExpired))
+	verifyFalse(t, HasMPLSEchoGlobalFlag(globalFlags, MPLSEchoFlagValidateReversePath))
+
+	globalFlags = SetMPLSEchoGlobalFlag(globalFlags, MPLSEchoFlagValidateFECStack)
+	verifyTrue(t, HasMPLSEchoGlobalFlag(globalFlags, MPLSEchoFlagValidateFECStack))
+	verifyTrue(t, HasMPLSEchoGlobalFlag(globalFlags, MPLSEchoFlagRespondOnlyIfTTLExpired))
+	verifyFalse(t, HasMPLSEchoGlobalFlag(globalFlags, MPLSEchoFlagValidateReversePath))
+
+	globalFlags = SetMPLSEchoGlobalFlag(globalFlags, MPLSEchoFlagValidateReversePath)
+	verifyTrue(t, HasMPLSEchoGlobalFlag(globalFlags, MPLSEchoFlagValidateFECStack))
+	verifyTrue(t, HasMPLSEchoGlobalFlag(globalFlags, MPLSEchoFlagRespondOnlyIfTTLExpired))
+	verifyTrue(t, HasMPLSEchoGlobalFlag(globalFlags, MPLSEchoFlagValidateReversePath))
+
+	globalFlags = ClearMPLSEchoGlobalFlag(globalFlags, MPLSEchoFlagRespondOnlyIfTTLExpired)
+	verifyTrue(t, HasMPLSEchoGlobalFlag(globalFlags, MPLSEchoFlagValidateFECStack))
+	verifyFalse(t, HasMPLSEchoGlobalFlag(globalFlags, MPLSEchoFlagRespondOnlyIfTTLExpired))
+	verifyTrue(t, HasMPLSEchoGlobalFlag(globalFlags, MPLSEchoFlagValidateReversePath))
+
+	globalFlags = ClearMPLSEchoGlobalFlag(globalFlags, MPLSEchoFlagValidateReversePath)
+	verifyTrue(t, HasMPLSEchoGlobalFlag(globalFlags, MPLSEchoFlagValidateFECStack))
+	verifyFalse(t, HasMPLSEchoGlobalFlag(globalFlags, MPLSEchoFlagRespondOnlyIfTTLExpired))
+	verifyFalse(t, HasMPLSEchoGlobalFlag(globalFlags, MPLSEchoFlagValidateReversePath))
+
+	globalFlags = ClearMPLSEchoGlobalFlag(globalFlags, MPLSEchoFlagValidateFECStack)
+	verifyFalse(t, HasMPLSEchoGlobalFlag(globalFlags, MPLSEchoFlagValidateFECStack))
+	verifyFalse(t, HasMPLSEchoGlobalFlag(globalFlags, MPLSEchoFlagRespondOnlyIfTTLExpired))
+	verifyFalse(t, HasMPLSEchoGlobalFlag(globalFlags, MPLSEchoFlagValidateReversePath))
+}
+
+func TestMPLSEchoTLV_EncodeDecodeEmptyValue_Success(t *testing.T) {
+	emptyValueTLV := &MPLSEchoTLV{
+		Type:  1337,
+		Value: nil,
+	}
+
+	encodedBytes, err := emptyValueTLV.EncodeAsBytes()
+	verifyNil(t, err)
+	verifyNotNil(t, encodedBytes)
+	verifyEqual(t, 4, len(encodedBytes))
+
+	decodedTLV := &MPLSEchoTLV{}
+	numBytesDecoded, err := decodedTLV.DecodeFromBytes(encodedBytes)
+	verifyNil(t, err)
+	verifyEqual(t, 4, numBytesDecoded)
+
+	verifyEqual(t, emptyValueTLV.Type, decodedTLV.Type)
+	verifyNotNil(t, decodedTLV.Value)
+	verifyEqual(t, 0, len(decodedTLV.Value))
+}
+
+func TestMPLSEchoTLV_EncodeDecodeUnalignedValue_Success(t *testing.T) {
+	// Value that isn't 4-octet aligned.
+	unalignedValueTLV := &MPLSEchoTLV{
+		Type:  101,
+		Value: []byte{0xB, 0xA, 0xD, 0xB, 0xE, 0xE, 0xF}, // 7-byte value
+	}
+
+	encodedBytes, err := unalignedValueTLV.EncodeAsBytes()
+	verifyNil(t, err)
+	verifyNotNil(t, encodedBytes)
+	verifyEqual(t, 12, len(encodedBytes)) // 4 + 7-byte value + 1-byte padding
+
+	decodedTLV := &MPLSEchoTLV{}
+	numBytesDecoded, err := decodedTLV.DecodeFromBytes(encodedBytes)
+	verifyNil(t, err)
+	verifyEqual(t, 12, numBytesDecoded)
+
+	verifyEqual(t, unalignedValueTLV.Type, decodedTLV.Type)
+	verifyNotNil(t, decodedTLV.Value)
+	verifyEqual(t, unalignedValueTLV.Value, decodedTLV.Value)
+}
+
+func TestMPLSEchoTLV_EncodeDecodeAlignedValue_Success(t *testing.T) {
+	// Value that is 4-octet aligned.
+	unalignedValueTLV := &MPLSEchoTLV{
+		Type:  65535,
+		Value: []byte{0xB, 0xA, 0xD, 0xB, 0xE, 0xE, 0xF, 0xF}, // 8-byte value
+	}
+
+	encodedBytes, err := unalignedValueTLV.EncodeAsBytes()
+	verifyNil(t, err)
+	verifyNotNil(t, encodedBytes)
+	verifyEqual(t, 12, len(encodedBytes)) // 4 + 8-byte value
+
+	decodedTLV := &MPLSEchoTLV{}
+	numBytesDecoded, err := decodedTLV.DecodeFromBytes(encodedBytes)
+	verifyNil(t, err)
+	verifyEqual(t, 12, numBytesDecoded)
+
+	verifyEqual(t, unalignedValueTLV.Type, decodedTLV.Type)
+	verifyNotNil(t, decodedTLV.Value)
+	verifyEqual(t, unalignedValueTLV.Value, decodedTLV.Value)
+}
+
+// Decode a byte array containing multiple TLVs.
+func TestMPLSEchoTLV_DecodeConcatenatedTLVs_Success(t *testing.T) {
+	originalTLVs := []*MPLSEchoTLV{
+		&MPLSEchoTLV{
+			Type:  65535,
+			Value: []byte{0xB, 0xA, 0xD, 0xB, 0xE, 0xE, 0xF},
+		},
+		&MPLSEchoTLV{
+			Type:  65534,
+			Value: []byte{0xA, 0xB, 0xC, 0xD, 0xE, 0xF},
+		},
+		&MPLSEchoTLV{
+			Type:  7,
+			Value: []byte{0x1, 0x3, 0x3, 0x7},
+		},
+	}
+
+	var allTLVBytes []byte
+	for _, currentTLV := range originalTLVs {
+		encodedBytes, err := currentTLV.EncodeAsBytes()
+		verifyNil(t, err)
+
+		allTLVBytes = append(allTLVBytes, encodedBytes...)
+	}
+
+	// Decode all bytes by calling DecodeFromBytes multiple times.
+	currentOffset := 0
+	var decodedTLVs []*MPLSEchoTLV
+	for currentOffset < len(allTLVBytes) {
+		currentTLV := &MPLSEchoTLV{}
+		numBytesDecoded, err := currentTLV.DecodeFromBytes(allTLVBytes[currentOffset:])
+		verifyNil(t, err)
+		verifyLessOrEqual(t, numBytesDecoded, len(allTLVBytes)-currentOffset)
+
+		decodedTLVs = append(decodedTLVs, currentTLV)
+		currentOffset += numBytesDecoded
+	}
+
+	verifyEqual(t, len(allTLVBytes), currentOffset)
+	verifyEqual(t, originalTLVs, decodedTLVs)
+}
+
+func TestMPLSEchoTLV_DecodeUnexpectedlyShortByteArray_Fail(t *testing.T) {
+	// Byte array containing less than 4 bytes.
+	badData := []byte{0x1, 0x2, 0x3}
+
+	decodedTLV := &MPLSEchoTLV{}
+	numBytesDecoded, err := decodedTLV.DecodeFromBytes(badData)
+	verifyEqual(t, 0, numBytesDecoded)
+	verifyNotNil(t, err)
+	verifyEqual(t,
+		"MPLSEchoTLV decoding error - data is less than 4 bytes long (actual length: 3)",
+		err.Error())
+}
+
+func TestMPLSEchoTLV_DecodeMaliciousData_Fail(t *testing.T) {
+	// Encoding that attempts to force a read outside of valid data boundaries.
+	maliciousData := []byte{0xFF, 0xFF, 0xFF, 0xFF, 0x3, 0x5}
+
+	decodedTLV := &MPLSEchoTLV{}
+	numBytesDecoded, err := decodedTLV.DecodeFromBytes(maliciousData)
+	verifyEqual(t, 0, numBytesDecoded)
+	verifyNotNil(t, err)
+	verifyEqual(t,
+		"MPLSEchoTLV decoding error - TLV of type 65535 goes beyond the valid data: tlvByteCountWithPadding (65540) > totalByteCount (6)",
+		err.Error())
+}
+
+func TestLDPPrefixFECValue_EncodeDecodeIPv4_Success(t *testing.T) {
+	targetPrefixIP := net.ParseIP("1.2.3.0")
+	verifyNotNil(t, targetPrefixIP)
+
+	originalFEC := &LDPPrefixFECValue{
+		Prefix:       targetPrefixIP,
+		PrefixLength: 24,
+	}
+
+	encodedFEC, err := originalFEC.EncodeAsTLV()
+	verifyNil(t, err)
+	verifyNotNil(t, encodedFEC)
+	verifyEqual(t, MPLSEchoSubTLVTypeTargetFECStackLDPPrefixIPv4, encodedFEC.Type)
+
+	decodedFEC := &LDPPrefixFECValue{}
+	err = decodedFEC.DecodeFromTLV(encodedFEC)
+	verifyNil(t, err)
+
+	verifyEqual(t, originalFEC.PrefixLength, decodedFEC.PrefixLength)
+	verifyEqual(t, originalFEC.Prefix.To4(), decodedFEC.Prefix)
+}
+
+func TestLDPPrefixFECValue_EncodeDecodeIPv6_Success(t *testing.T) {
+	targetPrefixIP := net.ParseIP("2001:db8:abcd:0012::0")
+	verifyNotNil(t, targetPrefixIP)
+
+	originalFEC := &LDPPrefixFECValue{
+		Prefix:       targetPrefixIP,
+		PrefixLength: 64,
+	}
+
+	encodedFEC, err := originalFEC.EncodeAsTLV()
+	verifyNil(t, err)
+	verifyNotNil(t, encodedFEC)
+	verifyEqual(t, MPLSEchoSubTLVTypeTargetFECStackLDPPrefixIPv6, encodedFEC.Type)
+
+	decodedFEC := &LDPPrefixFECValue{}
+	err = decodedFEC.DecodeFromTLV(encodedFEC)
+	verifyNil(t, err)
+
+	verifyEqual(t, originalFEC.PrefixLength, decodedFEC.PrefixLength)
+	verifyEqual(t, originalFEC.Prefix.To16(), decodedFEC.Prefix)
+}
+
+func TestLDPPrefixFECValue_EncodeInvalidPrefixIP_Fail(t *testing.T) {
+	invalidPrefixIP := net.IP{0x1, 0x0, 0x1} // Not a a valid IPv4 or IPv6 address
+	originalFEC := &LDPPrefixFECValue{
+		Prefix:       invalidPrefixIP,
+		PrefixLength: 1,
+	}
+
+	encodedFEC, err := originalFEC.EncodeAsTLV()
+	verifyNil(t, encodedFEC)
+	verifyNotNil(t, err)
+	verifyEqual(t,
+		"LDPPrefixFECValue encoding error - Prefix isn't a valid IPv4 or IPv6 address",
+		err.Error())
+}
+
+func TestLDPPrefixFECValue_DecodeUnknownType_Fail(t *testing.T) {
+	unknownTypeTLV := &MPLSEchoTLV{
+		Type:  1337,                             // Unknown type
+		Value: []byte{0x1, 0x2, 0x3, 0x0, 0x18}, // Valid IPv4 address + prefix length
+	}
+
+	decodedFEC := &LDPPrefixFECValue{}
+	err := decodedFEC.DecodeFromTLV(unknownTypeTLV)
+	verifyNotNil(t, err)
+	verifyEqual(t,
+		"LDPPrefixFECValue decoding error - Unknown LDPPrefixFECValue type (1337) or unexpected valueByteCount (5)",
+		err.Error())
+}
+
+func TestLDPPrefixFECValue_DecodeUnexpectedByteCount_Fail(t *testing.T) {
+	unknownTypeTLV := &MPLSEchoTLV{
+		Type:  MPLSEchoSubTLVTypeTargetFECStackLDPPrefixIPv4,
+		Value: []byte{0x1, 0x2, 0x3, 0x0, 0x1, 0x18}, // Too long for an IPv4 address + prefix length
+	}
+
+	decodedFEC := &LDPPrefixFECValue{}
+	err := decodedFEC.DecodeFromTLV(unknownTypeTLV)
+	verifyNotNil(t, err)
+	verifyEqual(t,
+		"LDPPrefixFECValue decoding error - Unknown LDPPrefixFECValue type (1) or unexpected valueByteCount (6)",
+		err.Error())
+}
+
+func TestTargetFECStackValue_EncodeDecodeSingleIPv4FEC_Success(t *testing.T) {
+	targetPrefixIPv4 := net.ParseIP("104.44.1.0")
+	verifyNotNil(t, targetPrefixIPv4)
+
+	originalFECStackIPv4Val := TargetFECStackValue{
+		FECs: []MPLSEchoValue{
+			&LDPPrefixFECValue{
+				Prefix:       targetPrefixIPv4.To4(),
+				PrefixLength: 24,
+			},
+		},
+	}
+
+	encodedFECStackVal, err := originalFECStackIPv4Val.EncodeAsTLV()
+	verifyNil(t, err)
+	verifyNotNil(t, encodedFECStackVal)
+	verifyEqual(t, MPLSEchoTLVTypeTargetFECStack, encodedFECStackVal.Type)
+
+	decodedFECStackVal := &TargetFECStackValue{}
+	err = decodedFECStackVal.DecodeFromTLV(encodedFECStackVal)
+	verifyNil(t, err)
+
+	verifyEqual(t, originalFECStackIPv4Val.FECs, decodedFECStackVal.FECs)
+}
+
+func TestTargetFECStackValue_EncodeDecodeSingleIPv6FEC_Success(t *testing.T) {
+	targetPrefixIPv6 := net.ParseIP("2001:db8:abcd:0012::0")
+	verifyNotNil(t, targetPrefixIPv6)
+
+	originalFECStackIPv6Val := TargetFECStackValue{
+		FECs: []MPLSEchoValue{
+			&LDPPrefixFECValue{
+				Prefix:       targetPrefixIPv6.To16(),
+				PrefixLength: 64,
+			},
+		},
+	}
+
+	encodedFECStackVal, err := originalFECStackIPv6Val.EncodeAsTLV()
+	verifyNil(t, err)
+	verifyNotNil(t, encodedFECStackVal)
+	verifyEqual(t, MPLSEchoTLVTypeTargetFECStack, encodedFECStackVal.Type)
+
+	decodedFECStackVal := &TargetFECStackValue{}
+	err = decodedFECStackVal.DecodeFromTLV(encodedFECStackVal)
+	verifyNil(t, err)
+
+	verifyEqual(t, originalFECStackIPv6Val.FECs, decodedFECStackVal.FECs)
+}
+
+func TestTargetFECStackValue_EncodeDecodeMultipleFECs_Success(t *testing.T) {
+	targetPrefixIPv4 := net.ParseIP("104.44.1.0")
+	verifyNotNil(t, targetPrefixIPv4)
+
+	targetPrefixIPv6 := net.ParseIP("2001:db8:abcd:0012::0")
+	verifyNotNil(t, targetPrefixIPv6)
+
+	originalFECStackVal := TargetFECStackValue{
+		FECs: []MPLSEchoValue{
+			&LDPPrefixFECValue{
+				Prefix:       targetPrefixIPv6.To16(),
+				PrefixLength: 64,
+			},
+			&LDPPrefixFECValue{
+				Prefix:       targetPrefixIPv6.To16(),
+				PrefixLength: 64,
+			},
+			&LDPPrefixFECValue{
+				Prefix:       targetPrefixIPv4.To4(),
+				PrefixLength: 24,
+			},
+			&LDPPrefixFECValue{
+				Prefix:       targetPrefixIPv4.To4(),
+				PrefixLength: 24,
+			},
+			&LDPPrefixFECValue{
+				Prefix:       targetPrefixIPv6.To16(),
+				PrefixLength: 64,
+			},
+		},
+	}
+
+	encodedFECStackVal, err := originalFECStackVal.EncodeAsTLV()
+	verifyNil(t, err)
+	verifyNotNil(t, encodedFECStackVal)
+	verifyEqual(t, MPLSEchoTLVTypeTargetFECStack, encodedFECStackVal.Type)
+
+	decodedFECStackVal := &TargetFECStackValue{}
+	err = decodedFECStackVal.DecodeFromTLV(encodedFECStackVal)
+	verifyNil(t, err)
+
+	verifyEqual(t, originalFECStackVal.FECs, decodedFECStackVal.FECs)
+}
+
+func TestTargetFECStackValue_EncodeStackWithInvalidFEC_Fail(t *testing.T) {
+	invalidPrefixIP := net.IP{0x1, 0x0, 0x1} // Not a a valid IPv4 or IPv6 address
+
+	targetPrefixIPv4 := net.ParseIP("104.44.1.0")
+	verifyNotNil(t, targetPrefixIPv4)
+
+	targetPrefixIPv6 := net.ParseIP("2001:db8:abcd:0012::0")
+	verifyNotNil(t, targetPrefixIPv6)
+
+	originalFECStackVal := TargetFECStackValue{
+		FECs: []MPLSEchoValue{
+			&LDPPrefixFECValue{
+				Prefix:       targetPrefixIPv6.To16(),
+				PrefixLength: 64,
+			},
+			&LDPPrefixFECValue{
+				Prefix:       targetPrefixIPv4.To4(),
+				PrefixLength: 24,
+			},
+			&LDPPrefixFECValue{
+				Prefix:       invalidPrefixIP, // This should force the FECStackValue encoding to fail.
+				PrefixLength: 1,
+			},
+			&LDPPrefixFECValue{
+				Prefix:       targetPrefixIPv6.To16(),
+				PrefixLength: 64,
+			},
+		},
+	}
+
+	encodedFEC, err := originalFECStackVal.EncodeAsTLV()
+	verifyNil(t, encodedFEC)
+	verifyNotNil(t, err)
+	verifyEqual(t,
+		"LDPPrefixFECValue encoding error - Prefix isn't a valid IPv4 or IPv6 address",
+		err.Error())
+}
+
+func TestTargetFECStackValue_DecodeStackWithWrongTLVType_Fail(t *testing.T) {
+	validFECStackVal := TargetFECStackValue{
+		FECs: []MPLSEchoValue{
+			&LDPPrefixFECValue{
+				Prefix:       net.IP{0x1, 0x2, 0x3, 0x0},
+				PrefixLength: 24,
+			},
+		},
+	}
+
+	encodedFECStackVal, err := validFECStackVal.EncodeAsTLV()
+	verifyNil(t, err)
+
+	// Change TLV type to the wrong one.
+	encodedFECStackVal.Type = 42
+
+	// Try to decode the bad TLV.
+	decodedFECStackVal := &TargetFECStackValue{}
+	err = decodedFECStackVal.DecodeFromTLV(encodedFECStackVal)
+	verifyNotNil(t, err)
+	verifyEqual(t,
+		"TargetFECStackValue decoding error - type mismatch: expected 1, got 42",
+		err.Error())
+}
+
+func TestTargetFECStackValue_DecodeStackWithInvalidSubTLV_Fail(t *testing.T) {
+	validFECStackVal := TargetFECStackValue{
+		FECs: []MPLSEchoValue{
+			&LDPPrefixFECValue{
+				Prefix:       net.IP{0x1, 0x2, 0x3, 0x0},
+				PrefixLength: 24,
+			},
+		},
+	}
+
+	encodedFECStackVal, err := validFECStackVal.EncodeAsTLV()
+	verifyNil(t, err)
+
+	// Change sub-TLV value length to something invalid.
+	encodedFECStackVal.Value[2] = 0xFF
+	encodedFECStackVal.Value[3] = 0xFF
+
+	// Try to decode the bad TLV.
+	decodedFECStackVal := &TargetFECStackValue{}
+	err = decodedFECStackVal.DecodeFromTLV(encodedFECStackVal)
+	verifyNotNil(t, err)
+	verifyEqual(t,
+		"MPLSEchoTLV decoding error - TLV of type 1 goes beyond the valid data: tlvByteCountWithPadding (65540) > totalByteCount (12)",
+		err.Error())
+}
+
+func TestTargetFECStackValue_DecodeStackWithInvalidLDPPrefix_Fail(t *testing.T) {
+	validFECStackVal := TargetFECStackValue{
+		FECs: []MPLSEchoValue{
+			&LDPPrefixFECValue{
+				Prefix:       net.IP{0x1, 0x2, 0x3, 0x0},
+				PrefixLength: 24,
+			},
+		},
+	}
+
+	encodedFECStackVal, err := validFECStackVal.EncodeAsTLV()
+	verifyNil(t, err)
+
+	// Change sub-TLV value length so that it doesn't match the LDP Prefix type.
+	encodedFECStackVal.Value[2] = 0x0
+	encodedFECStackVal.Value[3] = 0x3
+
+	// Try to decode the bad TLV.
+	decodedFECStackVal := &TargetFECStackValue{}
+	err = decodedFECStackVal.DecodeFromTLV(encodedFECStackVal)
+	verifyNotNil(t, err)
+	verifyEqual(t,
+		"LDPPrefixFECValue decoding error - Unknown LDPPrefixFECValue type (1) or unexpected valueByteCount (3)",
+		err.Error())
+}
+
+func TestTargetFECStackValue_DecodeStackWithUnknownFECType_Fail(t *testing.T) {
+	validFECStackVal := TargetFECStackValue{
+		FECs: []MPLSEchoValue{
+			&LDPPrefixFECValue{
+				Prefix:       net.IP{0x1, 0x2, 0x3, 0x0},
+				PrefixLength: 24,
+			},
+		},
+	}
+
+	encodedFECStackVal, err := validFECStackVal.EncodeAsTLV()
+	verifyNil(t, err)
+
+	// Change sub-TLV value type to an unknown type.
+	encodedFECStackVal.Value[0] = 0xFF
+	encodedFECStackVal.Value[1] = 0xFF
+
+	// Try to decode the bad TLV.
+	decodedFECStackVal := &TargetFECStackValue{}
+	err = decodedFECStackVal.DecodeFromTLV(encodedFECStackVal)
+	verifyNotNil(t, err)
+	verifyEqual(t,
+		"TargetFECStackValue decoding error - unknown sub-type: 65535",
+		err.Error())
+}
+
+// Define basic object validation macros.
+func containsKind(kinds []reflect.Kind, kind reflect.Kind) bool {
+	for i := 0; i < len(kinds); i++ {
+		if kind == kinds[i] {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isNil(object interface{}) bool {
+	if object == nil {
+		return true
+	}
+
+	value := reflect.ValueOf(object)
+	kind := value.Kind()
+	isNilableKind := containsKind(
+		[]reflect.Kind{
+			reflect.Chan, reflect.Func,
+			reflect.Interface, reflect.Map,
+			reflect.Ptr, reflect.Slice},
+		kind)
+
+	if isNilableKind && value.IsNil() {
+		return true
+	}
+
+	return false
+}
+
+func verifyNotNil(t *testing.T, object interface{}) {
+	if isNil(object) {
+		// Get caller's file name and line number.
+		_, fn, line, _ := runtime.Caller(1)
+		t.Fatalf("\n[%s:%d] Expected value not to be nil", fn, line)
+	}
+}
+
+func verifyNil(t *testing.T, object interface{}) {
+	if !isNil(object) {
+		// Get caller's file name and line number.
+		_, fn, line, _ := runtime.Caller(1)
+		t.Fatalf("\n[%s:%d] Expected value to be nil: %v", fn, line, object)
+	}
+}
+
+func verifyTrue(t *testing.T, value bool) {
+	if !value {
+		// Get caller's file name and line number.
+		_, fn, line, _ := runtime.Caller(1)
+		t.Fatalf("\n[%s:%d] Expected value to be TRUE", fn, line)
+	}
+}
+
+func verifyFalse(t *testing.T, value bool) {
+	if value {
+		// Get caller's file name and line number.
+		_, fn, line, _ := runtime.Caller(1)
+		t.Fatalf("\n[%s:%d] Expected value to be FALSE", fn, line)
+	}
+}
+
+func objectsAreEqual(expected, actual interface{}) bool {
+	if expected == nil || actual == nil {
+		return expected == actual
+	}
+
+	exp, ok := expected.([]byte)
+	if !ok {
+		return reflect.DeepEqual(expected, actual)
+	}
+
+	act, ok := actual.([]byte)
+	if !ok {
+		return false
+	}
+	if exp == nil || act == nil {
+		return exp == nil && act == nil
+	}
+	return bytes.Equal(exp, act)
+}
+
+func verifyEqual(t *testing.T, expected, actual interface{}) {
+	if !objectsAreEqual(expected, actual) {
+		// Get caller's file name and line number.
+		_, fn, line, _ := runtime.Caller(1)
+		t.Fatalf(
+			"\n[%s:%d] Not equal: \nexpected: %v\nactual: %v",
+			fn,
+			line,
+			expected,
+			actual)
+	}
+}
+
+func verifyLessOrEqual(t *testing.T, val1, val2 int) {
+	if val1 > val2 {
+		// Get caller's file name and line number.
+		_, fn, line, _ := runtime.Caller(1)
+		t.Fatalf(
+			"\n[%s:%d] %v is not less or equal than %v",
+			fn,
+			line,
+			val1,
+			val2)
+	}
+}

--- a/layers/ports.go
+++ b/layers/ports.go
@@ -116,6 +116,7 @@ var udpPortLayerType = [65536]gopacket.LayerType{
 	3784: LayerTypeBFD,
 	2152: LayerTypeGTPv1U,
 	623:  LayerTypeRMCP,
+	3503: LayerTypeMPLSEcho,
 }
 
 // RegisterUDPPortLayerType creates a new mapping between a UDPPort


### PR DESCRIPTION
**SUMMARY**
Implementing MPLS Echo protocol, as specified by [RFC8029](https://tools.ietf.org/html/rfc8029). This enables Label Switched Path (LSP) Ping/Traceroute operations to be conducted inside Multiprotocol Label Switching (MPLS) networks for data plane failure detection and localization.

An MPLS echo request/reply is a (possibly labeled) IPv4 or IPv6 UDP packet. Wireshark already displays MPLS Echo as a separate layer in packet captures.

**VALIDATION**
- Passes `./gc`.
- Adding automated tests for all new code, achieving 93% mpls_echo.go code coverage.
- I've gotten real CISCO routers to reply to my MPLS Echo requests crafted using this code.
- Wireshark packet captures confirm that my crafted packets are identical to those generated by CISCO's "ping mpls" command.