### PR TITLE
Support RouterV2 details for ospf LSA type1

### DIFF
--- a/layers/ospf.go
+++ b/layers/ospf.go
@@ -295,6 +295,16 @@ func extractLSAInformation(lstype, lsalength uint16, data []byte) (interface{}, 
 	switch lstype {
 	case RouterLSAtypeV2:
 		var routers []RouterV2
+		var j uint32
+		for j = 24; j < uint32(lsalength); j += 12 {
+			router := RouterV2{
+				LinkID:   binary.BigEndian.Uint32(data[j : j+4]),
+				LinkData: binary.BigEndian.Uint32(data[j+4 : j+8]),
+				Type:     uint8(data[j+8]),
+				Metric:   binary.BigEndian.Uint16(data[j+10 : j+12]),
+			}
+			routers = append(routers, router)
+		}
 		links := binary.BigEndian.Uint16(data[22:24])
 		content = RouterLSAV2{
 			Flags:   data[20],

--- a/layers/ospf_test.go
+++ b/layers/ospf_test.go
@@ -468,6 +468,20 @@ func TestPacketOSPF2LSUpdate(t *testing.T) {
 							Content: RouterLSAV2{
 								Flags: 0x2,
 								Links: 0x2,
+								Routers: []RouterV2{
+									RouterV2{
+										LinkID:   0xc0a8aa00,
+										LinkData: 0xffffff00,
+										Type:     0x03,
+										Metric:   0x0a,
+									},
+									RouterV2{
+										LinkID:   0xc0a8aa00,
+										LinkData: 0xffffff00,
+										Type:     0x03,
+										Metric:   0x0a,
+									},
+								},
 							},
 						},
 						LSA{
@@ -656,6 +670,14 @@ func TestPacketOSPF2LSUpdateLSA2(t *testing.T) {
 							Content: RouterLSAV2{
 								Flags: 0x0,
 								Links: 0x1,
+								Routers: []RouterV2{
+									RouterV2{
+										LinkID:   0xac181b56,
+										LinkData: 0xac181b56,
+										Type:     0x02,
+										Metric:   0x01,
+									},
+								},
 							},
 						},
 						LSA{


### PR DESCRIPTION
The ospf LSA type 1 packet was returned with empty Router information.
Implemented to return details of Router information.