### PR TITLE
Set BaseLayer.Contents correctly in SIP layer.

### DIFF
--- a/layers/sip.go
+++ b/layers/sip.go
@@ -245,14 +245,11 @@ func (s *SIP) NextLayerType() gopacket.LayerType {
 
 // DecodeFromBytes decodes the slice into the SIP struct.
 func (s *SIP) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
-
 	// Init some vars for parsing follow-up
 	var countLines int
 	var line []byte
 	var err error
-
-	// Clean leading new line
-	data = bytes.Trim(data, "\n")
+	var offset int
 
 	// Iterate on all lines of the SIP Headers
 	// and stop when we reach the SDP (aka when the new line
@@ -270,14 +267,13 @@ func (s *SIP) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 				return err
 			}
 		}
+		offset += len(line)
 
 		// Trim the new line delimiters
 		line = bytes.Trim(line, "\r\n")
 
 		// Empty line, we hit Body
-		// Putting packet remain in Paypload
 		if len(line) == 0 {
-			s.BaseLayer.Payload = buffer.Bytes()
 			break
 		}
 
@@ -298,6 +294,7 @@ func (s *SIP) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 
 		countLines++
 	}
+	s.BaseLayer = BaseLayer{Contents: data[:offset], Payload: data[offset:]}
 
 	return nil
 }


### PR DESCRIPTION
Make layers.SIP.LayerContents() work correctly, returning the full SIP
message.