### PR TITLE
fix issue - 674 (wrong network interface info being returned for a given destination IP) #675

### DIFF
--- a/routing/routing.go
+++ b/routing/routing.go
@@ -133,6 +133,10 @@ func (r *router) route(routes routeSlice, input net.HardwareAddr, src, dst net.I
 		if rt.InputIface != 0 && rt.InputIface != inputIndex {
 			continue
 		}
+		// default route will have both rt.Src and rt.Dst equal to nil
+		if rt.Src == nil && rt.Dst == nil {
+			continue
+		}
 		if rt.Src != nil && !rt.Src.Contains(src) {
 			continue
 		}


### PR DESCRIPTION
**Issue Link:** #674

Route() method returning wrong network interface - even when the destination IP didn't match with any network interface IP, its' returning the default network interface. 