### PR TITLE
Replace nil ReassemblyComplete context with flushed bool

### DIFF
--- a/reassembly/tcpassembly.go
+++ b/reassembly/tcpassembly.go
@@ -377,7 +377,10 @@ type Stream interface {
 	// It should return true if the connection should be removed from the pool
 	// It can return false if it want to see subsequent packets with Accept(), e.g. to
 	// see FIN-ACK, for deeper state-machine analysis.
-	ReassemblyComplete(ac AssemblerContext) bool
+	//
+	// If the Stream was flushed due to a call to FlushCloseOlderThan, FlushCloseWithOptions,
+	// or FlushAll, then flushed is true.
+	ReassemblyComplete(flushed bool) bool
 }
 
 // StreamFactory is used by assembly to create a new stream for each
@@ -1099,7 +1102,7 @@ func (a *Assembler) sendToConnection(conn *connection, half *halfconnection, ac 
 	half.stream.ReassembledSG(&a.cacheSG, ac)
 	a.cleanSG(half, ac)
 	if end {
-		a.closeHalfConnection(conn, half)
+		a.closeHalfConnection(conn, half, false)
 	}
 	if *debugLog {
 		log.Printf("after sendToConnection: nextSeq: %d\n", nextSeq)
@@ -1177,7 +1180,7 @@ func (a *Assembler) skipFlush(conn *connection, half *halfconnection) {
 	// Well, it's embarassing it there is still something in half.saved
 	// FIXME: change API to give back saved + new/no packets
 	if half.first == nil {
-		a.closeHalfConnection(conn, half)
+		a.closeHalfConnection(conn, half, true)
 		return
 	}
 	a.ret = a.ret[:0]
@@ -1188,7 +1191,7 @@ func (a *Assembler) skipFlush(conn *connection, half *halfconnection) {
 	}
 }
 
-func (a *Assembler) closeHalfConnection(conn *connection, half *halfconnection) {
+func (a *Assembler) closeHalfConnection(conn *connection, half *halfconnection, flushed bool) {
 	if *debugLog {
 		log.Printf("%v closing", conn)
 	}
@@ -1199,7 +1202,7 @@ func (a *Assembler) closeHalfConnection(conn *connection, half *halfconnection) 
 		half.pages--
 	}
 	if conn.s2c.closed && conn.c2s.closed {
-		if half.stream.ReassemblyComplete(nil) { //FIXME: which context to pass ?
+		if half.stream.ReassemblyComplete(flushed) {
 			a.connPool.remove(conn)
 		}
 	}
@@ -1297,7 +1300,7 @@ func (a *Assembler) flushClose(conn *connection, half *halfconnection, t time.Ti
 	}
 	// Close the connection only if both halfs of the connection last seen before tc.
 	if !half.closed && half.first == nil && conn.lastSeen().Before(tc) {
-		a.closeHalfConnection(conn, half)
+		a.closeHalfConnection(conn, half, true)
 		closed = true
 	}
 	return flushed, closed
@@ -1316,7 +1319,7 @@ func (a *Assembler) FlushAll() (closed int) {
 				a.skipFlush(conn, half)
 			}
 			if !half.closed {
-				a.closeHalfConnection(conn, half)
+				a.closeHalfConnection(conn, half, true)
 			}
 		}
 		conn.mu.Unlock()

--- a/reassembly/tcpassembly_test.go
+++ b/reassembly/tcpassembly_test.go
@@ -53,7 +53,7 @@ func (t *testFactoryBench) Accept(tcp *layers.TCP, ci gopacket.CaptureInfo, dir 
 }
 func (t *testFactoryBench) ReassembledSG(sg ScatterGather, ac AssemblerContext) {
 }
-func (t *testFactoryBench) ReassemblyComplete(ac AssemblerContext) bool {
+func (t *testFactoryBench) ReassemblyComplete(flushed bool) bool {
 	return true
 }
 
@@ -82,7 +82,7 @@ func (t *testFactory) ReassembledSG(sg ScatterGather, ac AssemblerContext) {
 	})
 }
 
-func (t *testFactory) ReassemblyComplete(ac AssemblerContext) bool {
+func (t *testFactory) ReassemblyComplete(flushed bool) bool {
 	return true
 }
 
@@ -105,7 +105,7 @@ func (tf *testMemoryFactory) ReassembledSG(sg ScatterGather, ac AssemblerContext
 	bytes, _ := sg.Lengths()
 	tf.bytes += bytes
 }
-func (tf *testMemoryFactory) ReassemblyComplete(ac AssemblerContext) bool {
+func (tf *testMemoryFactory) ReassemblyComplete(flushed bool) bool {
 	return true
 }
 
@@ -941,7 +941,7 @@ func (tkf *testKeepFactory) ReassembledSG(sg ScatterGather, ac AssemblerContext)
 	tkf.bytes = sg.Fetch(l)
 	sg.KeepFrom(tkf.keep)
 }
-func (tkf *testKeepFactory) ReassemblyComplete(ac AssemblerContext) bool {
+func (tkf *testKeepFactory) ReassemblyComplete(flushed bool) bool {
 	return true
 }
 
@@ -1206,7 +1206,7 @@ func (t *testFSMFactory) New(a, b gopacket.Flow, tcp *layers.TCP, ac AssemblerCo
 }
 func (t *testFSMFactory) ReassembledSG(sg ScatterGather, ac AssemblerContext) {
 }
-func (t *testFSMFactory) ReassemblyComplete(ac AssemblerContext) bool {
+func (t *testFSMFactory) ReassemblyComplete(flushed bool) bool {
 	return false
 }
 


### PR DESCRIPTION
ReassemblyComplete always returns a nil AssemblerContext. Removing
this parameter will prevent any confusion during implementation
for individuals who expect a valid AssemblerContext when calling
this method.

I have added the flushed parameter instead. This parameter is true
if the call to ReassemblyComplete is due to the connection being
flushed by either FlushCloseOlderThan, FlushCloseWithOptions,
or FlushAll. If flushed is false, then the connection was closed
normally due to a FIN or RST packet.

This parameter is much more useful than a nil AssemblerContext.
it allows implementations to know whether the connection was
actually completed normally, or instead the assembler flushed it
due to a timeout.