### PR TITLE
enums: Add FC2 link types

### DIFF
--- a/layers/enums.go
+++ b/layers/enums.go
@@ -130,6 +130,8 @@ const (
 	LinkTypeLinuxIRDA      LinkType = 144
 	LinkTypeLinuxLAPD      LinkType = 177
 	LinkTypeLinuxUSB       LinkType = 220
+	LinkTypeFC2            LinkType = 224
+	LinkTypeFC2Framed      LinkType = 225
 	LinkTypeIPv4           LinkType = 228
 	LinkTypeIPv6           LinkType = 229
 )


### PR DESCRIPTION
These link types are defined in libpcap as

```
  Fibre Channel FC-2 frames, beginning with a Frame_Header.
  #define DLT_FC_2		224
```

as well as:

```
  Fibre Channel FC-2 frames, beginning with an encoding of the
  SOF, and ending with an encoding of the EOF.
  #define DLT_FC_2_WITH_FRAME_DELIMS	225
```

See https://github.com/the-tcpdump-group/libpcap/blob/master/pcap/dlt.h#L955 and https://github.com/the-tcpdump-group/libpcap/blob/master/pcap-linux.c#L3626 for more info.