### PR TITLE
Extract extended DNS Rcode from OPT record

### DIFF
--- a/layers/dns.go
+++ b/layers/dns.go
@@ -126,25 +126,26 @@ type DNSResponseCode uint8
 
 // DNSResponseCode known values.
 const (
-	DNSResponseCodeNoErr    DNSResponseCode = 0  // No error
-	DNSResponseCodeFormErr  DNSResponseCode = 1  // Format Error                       [RFC1035]
-	DNSResponseCodeServFail DNSResponseCode = 2  // Server Failure                     [RFC1035]
-	DNSResponseCodeNXDomain DNSResponseCode = 3  // Non-Existent Domain                [RFC1035]
-	DNSResponseCodeNotImp   DNSResponseCode = 4  // Not Implemented                    [RFC1035]
-	DNSResponseCodeRefused  DNSResponseCode = 5  // Query Refused                      [RFC1035]
-	DNSResponseCodeYXDomain DNSResponseCode = 6  // Name Exists when it should not     [RFC2136]
-	DNSResponseCodeYXRRSet  DNSResponseCode = 7  // RR Set Exists when it should not   [RFC2136]
-	DNSResponseCodeNXRRSet  DNSResponseCode = 8  // RR Set that should exist does not  [RFC2136]
-	DNSResponseCodeNotAuth  DNSResponseCode = 9  // Server Not Authoritative for zone  [RFC2136]
-	DNSResponseCodeNotZone  DNSResponseCode = 10 // Name not contained in zone         [RFC2136]
-	DNSResponseCodeBadVers  DNSResponseCode = 16 // Bad OPT Version                    [RFC2671]
-	DNSResponseCodeBadSig   DNSResponseCode = 16 // TSIG Signature Failure             [RFC2845]
-	DNSResponseCodeBadKey   DNSResponseCode = 17 // Key not recognized                 [RFC2845]
-	DNSResponseCodeBadTime  DNSResponseCode = 18 // Signature out of time window       [RFC2845]
-	DNSResponseCodeBadMode  DNSResponseCode = 19 // Bad TKEY Mode                      [RFC2930]
-	DNSResponseCodeBadName  DNSResponseCode = 20 // Duplicate key name                 [RFC2930]
-	DNSResponseCodeBadAlg   DNSResponseCode = 21 // Algorithm not supported            [RFC2930]
-	DNSResponseCodeBadTruc  DNSResponseCode = 22 // Bad Truncation                     [RFC4635]
+	DNSResponseCodeNoErr     DNSResponseCode = 0  // No error
+	DNSResponseCodeFormErr   DNSResponseCode = 1  // Format Error                       [RFC1035]
+	DNSResponseCodeServFail  DNSResponseCode = 2  // Server Failure                     [RFC1035]
+	DNSResponseCodeNXDomain  DNSResponseCode = 3  // Non-Existent Domain                [RFC1035]
+	DNSResponseCodeNotImp    DNSResponseCode = 4  // Not Implemented                    [RFC1035]
+	DNSResponseCodeRefused   DNSResponseCode = 5  // Query Refused                      [RFC1035]
+	DNSResponseCodeYXDomain  DNSResponseCode = 6  // Name Exists when it should not     [RFC2136]
+	DNSResponseCodeYXRRSet   DNSResponseCode = 7  // RR Set Exists when it should not   [RFC2136]
+	DNSResponseCodeNXRRSet   DNSResponseCode = 8  // RR Set that should exist does not  [RFC2136]
+	DNSResponseCodeNotAuth   DNSResponseCode = 9  // Server Not Authoritative for zone  [RFC2136]
+	DNSResponseCodeNotZone   DNSResponseCode = 10 // Name not contained in zone         [RFC2136]
+	DNSResponseCodeBadVers   DNSResponseCode = 16 // Bad OPT Version                    [RFC2671]
+	DNSResponseCodeBadSig    DNSResponseCode = 16 // TSIG Signature Failure             [RFC2845]
+	DNSResponseCodeBadKey    DNSResponseCode = 17 // Key not recognized                 [RFC2845]
+	DNSResponseCodeBadTime   DNSResponseCode = 18 // Signature out of time window       [RFC2845]
+	DNSResponseCodeBadMode   DNSResponseCode = 19 // Bad TKEY Mode                      [RFC2930]
+	DNSResponseCodeBadName   DNSResponseCode = 20 // Duplicate key name                 [RFC2930]
+	DNSResponseCodeBadAlg    DNSResponseCode = 21 // Algorithm not supported            [RFC2930]
+	DNSResponseCodeBadTruc   DNSResponseCode = 22 // Bad Truncation                     [RFC4635]
+	DNSResponseCodeBadCookie DNSResponseCode = 23 // Bad/missing Server Cookie          [RFC7873]
 )
 
 func (drc DNSResponseCode) String() string {
@@ -187,6 +188,8 @@ func (drc DNSResponseCode) String() string {
 		return "Algorithm not supported"
 	case DNSResponseCodeBadTruc:
 		return "Bad Truncation"
+	case DNSResponseCodeBadCookie:
+		return "Bad Cookie"
 	}
 }
 
@@ -369,6 +372,12 @@ func (d *DNS) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 		if offset, err = d.Additionals[i].decode(data, offset, df, &d.buffer); err != nil {
 			d.Additionals = d.Additionals[:i] // strip off erroneous value
 			return err
+		}
+		// extract extended RCODE from OPT RRs, RFC 6891 section 6.1.3
+		if d.Additionals[i].Type == DNSTypeOPT {
+			ttldata := make([]byte, 4)
+			binary.BigEndian.PutUint32(ttldata[:], d.Additionals[i].TTL)
+			d.ResponseCode = DNSResponseCode(uint8(d.ResponseCode) | uint8(ttldata[0])<<4)
 		}
 	}
 

--- a/layers/dns.go
+++ b/layers/dns.go
@@ -375,9 +375,7 @@ func (d *DNS) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 		}
 		// extract extended RCODE from OPT RRs, RFC 6891 section 6.1.3
 		if d.Additionals[i].Type == DNSTypeOPT {
-			ttldata := make([]byte, 4)
-			binary.BigEndian.PutUint32(ttldata[:], d.Additionals[i].TTL)
-			d.ResponseCode = DNSResponseCode(uint8(d.ResponseCode) | uint8(ttldata[0])<<4)
+			d.ResponseCode = DNSResponseCode(uint8(d.ResponseCode) | uint8(d.Additionals[i].TTL>>20&0xF0))
 		}
 	}
 

--- a/layers/dns_test.go
+++ b/layers/dns_test.go
@@ -78,6 +78,84 @@ func TestParseDNSTypeTXT(t *testing.T) {
 	}
 }
 
+var testParseDNSBadVers = []byte{
+	0x02, 0x00, 0x00, 0x00, // PF_INET
+	0x45, 0x00, 0x00, 0x38, 0xa5, 0xa0, 0x40, 0x00, 0x38, 0x11, 0x00, 0xbd, 0xc0, 0x05, 0x05, 0xf1,
+	0xac, 0x1e, 0x2a, 0x43, 0x00, 0x35, 0xfd, 0x78, 0x00, 0x24, 0x40, 0xc1, 0x8f, 0xb3, 0x81, 0x00,
+	0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x10, 0x00, 0x01, 0x00, 0x00, 0x29,
+	0x02, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
+}
+var testParseDNSBadVersResponseCode = DNSResponseCodeBadVers
+
+func TestParseDNSBadVers(t *testing.T) {
+	p := gopacket.NewPacket(testParseDNSBadVers, LinkTypeNull, testDecodeOptions)
+	if p.ErrorLayer() != nil {
+		t.Error("Failed to decode packet:", p.ErrorLayer().Error())
+	}
+	checkLayers(p, []gopacket.LayerType{LayerTypeLoopback, LayerTypeIPv4, LayerTypeUDP, LayerTypeDNS}, t)
+	questions := p.Layer(LayerTypeDNS).(*DNS).Questions
+	if len(questions) != 1 {
+		t.Error("Failed to parse 1 DNS question")
+	}
+	answers := p.Layer(LayerTypeDNS).(*DNS).Answers
+	if len(answers) != 0 {
+		t.Error("Failed to parse 0 DNS answer")
+	}
+	additionals := p.Layer(LayerTypeDNS).(*DNS).Additionals
+	if len(additionals) != 1 {
+		t.Error("Failed to parse 1 DNS additional")
+	}
+
+	optAll := additionals[0].OPT
+	if len(optAll) != 0 {
+		t.Errorf("Parsed %d OPTs, expected 0", len(optAll))
+	}
+	responseCode := p.Layer(LayerTypeDNS).(*DNS).ResponseCode
+	if responseCode != testParseDNSBadVersResponseCode {
+		t.Errorf("Incorrect extended response code, expected %q, got %q", testParseDNSBadVersResponseCode, responseCode)
+	}
+}
+
+var testParseDNSBadCookie = []byte{
+	0x02, 0x00, 0x00, 0x00, // PF_INET
+	0x45, 0x00, 0x00, 0x54, 0xfe, 0xaa, 0x00, 0x00, 0x40, 0x11, 0x00, 0x00, 0x7f, 0x00, 0x00, 0x01,
+	0x7f, 0x00, 0x00, 0x01, 0x00, 0x35, 0xd6, 0xaa, 0x00, 0x40, 0xfe, 0x53, 0xf6, 0xab, 0x81, 0x87,
+	0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x06, 0x00, 0x01, 0x00, 0x00, 0x29,
+	0x10, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x1c, 0x00, 0x0a, 0x00, 0x18, 0x36, 0xbf, 0x11, 0x1f,
+	0xef, 0x2e, 0x01, 0x09, 0x7d, 0x8f, 0xfe, 0x06, 0x5c, 0x63, 0x6f, 0xfb, 0x14, 0x2d, 0x76, 0x74,
+	0x94, 0x40, 0x7a, 0x73,
+}
+var testParseDNSBadCookieResponseCode = DNSResponseCodeBadCookie
+
+func TestParseDNSBadCookie(t *testing.T) {
+	p := gopacket.NewPacket(testParseDNSBadCookie, LinkTypeNull, testDecodeOptions)
+	if p.ErrorLayer() != nil {
+		t.Error("Failed to decode packet:", p.ErrorLayer().Error())
+	}
+	checkLayers(p, []gopacket.LayerType{LayerTypeLoopback, LayerTypeIPv4, LayerTypeUDP, LayerTypeDNS}, t)
+	questions := p.Layer(LayerTypeDNS).(*DNS).Questions
+	if len(questions) != 1 {
+		t.Error("Failed to parse 1 DNS question")
+	}
+	answers := p.Layer(LayerTypeDNS).(*DNS).Answers
+	if len(answers) != 0 {
+		t.Error("Failed to parse 0 DNS answer")
+	}
+	additionals := p.Layer(LayerTypeDNS).(*DNS).Additionals
+	if len(additionals) != 1 {
+		t.Error("Failed to parse 1 DNS additional")
+	}
+
+	optAll := additionals[0].OPT
+	if len(optAll) != 1 {
+		t.Errorf("Parsed %d OPTs, expected 1", len(optAll))
+	}
+	responseCode := p.Layer(LayerTypeDNS).(*DNS).ResponseCode
+	if responseCode != testParseDNSBadCookieResponseCode {
+		t.Errorf("Incorrect extended response code, expected %q, got %q", testParseDNSBadCookieResponseCode, responseCode)
+	}
+}
+
 var testParseDNSTypeURI = []byte{
 	0x02, 0x00, 0x00, 0x00, // PF_INET
 	0x45, 0x00, 0x00, 0x6f, 0x3e, 0x65, 0x00, 0x00, 0x40, 0x11, 0x3e, 0x17, 0x7f, 0x00, 0x00, 0x01,


### PR DESCRIPTION
Add decoding of the extended DNS ResponseCode from OPT records as specified in RFC 6891 section 6.1.3.

Additionally also adds the `BADCOOKIE` DNS ResponseCode (from RFC 7873) to the list of known values.