### PR TITLE
add descriptive error message on activate

### DIFF
--- a/pcap/pcap.go
+++ b/pcap/pcap.go
@@ -271,6 +271,7 @@ const (
 	aeDenied       = activateError(pcapErrorDenied)
 	aeNotUp        = activateError(pcapErrorNotUp)
 	aeWarning      = activateError(pcapWarning)
+	aeError        = activateError(pcapError)
 )
 
 func (a activateError) Error() string {
@@ -289,6 +290,8 @@ func (a activateError) Error() string {
 		return "Interface Not Up"
 	case aeWarning:
 		return fmt.Sprintf("Warning: %v", activateErrMsg.Error())
+	case aeError:
+		return fmt.Sprintf("Error: %v", activateErrMsg.Error())
 	default:
 		return fmt.Sprintf("unknown activated error: %d", a)
 	}
@@ -763,7 +766,7 @@ func (p *InactiveHandle) Activate() (*Handle, error) {
 	pcapSetTstampPrecision(p.cptr, pcapTstampPrecisionNano)
 	handle, err := p.pcapActivate()
 	if err != aeNoError {
-		if err == aeWarning {
+		if err == aeWarning || err == aeError {
 			activateErrMsg = p.Error()
 		}
 		return nil, err

--- a/pcap/pcap_unix.go
+++ b/pcap/pcap_unix.go
@@ -179,6 +179,7 @@ const (
 	pcapErrorDenied          = C.PCAP_ERROR_PERM_DENIED
 	pcapErrorNotUp           = C.PCAP_ERROR_IFACE_NOT_UP
 	pcapWarning              = C.PCAP_WARNING
+	pcapError                = C.PCAP_ERROR
 	pcapDIN                  = C.PCAP_D_IN
 	pcapDOUT                 = C.PCAP_D_OUT
 	pcapDINOUT               = C.PCAP_D_INOUT


### PR DESCRIPTION
This PR adds a more detailed error message if activation fails.

From https://www.tcpdump.org/manpages/pcap_activate.3pcap.txt:
```text
PCAP_ERROR
       Another error occurred.  pcap_geterr() or pcap_perror()  may  be
       called  with  p  as  an  argument  to fetch or display a message
       describing the error.
```

This happened when using bettercap with the https://github.com/aircrack-ng/rtl8812au driver (see here https://github.com/bettercap/bettercap/issues/614).

Without the patch:
```text
[err] error while activating handle: unknown activated error: -1
```

After the patch:
```text
[err] error while activating handle: Error: wlan0: SIOCGIWPRIV: Argument list too long
```