### PR TITLE
Fix Resolution() method return value

### DIFF
--- a/pcap/pcap.go
+++ b/pcap/pcap.go
@@ -722,9 +722,9 @@ func (p *Handle) SnapLen() int {
 // Resolution returns the timestamp resolution of acquired timestamps before scaling to NanosecondTimestampResolution.
 func (p *Handle) Resolution() gopacket.TimestampResolution {
 	if p.nanoSecsFactor == 1 {
-		return gopacket.TimestampResolutionMicrosecond
+		return gopacket.TimestampResolutionNanosecond
 	}
-	return gopacket.TimestampResolutionNanosecond
+	return gopacket.TimestampResolutionMicrosecond
 }
 
 // TimestampSource tells PCAP which type of timestamp to use for packets.

--- a/pcapgo/read.go
+++ b/pcapgo/read.go
@@ -225,7 +225,7 @@ func (r *Reader) String() string {
 // Resolution returns the timestamp resolution of acquired timestamps before scaling to NanosecondTimestampResolution.
 func (r *Reader) Resolution() gopacket.TimestampResolution {
 	if r.nanoSecsFactor == 1 {
-		return gopacket.TimestampResolutionMicrosecond
+		return gopacket.TimestampResolutionNanosecond
 	}
-	return gopacket.TimestampResolutionNanosecond
+	return gopacket.TimestampResolutionMicrosecond
 }


### PR DESCRIPTION
Resolution() methods defined for pcap.Handle and pcapgo.Reader returned
an invalid definition of gopacket.TimestampResolution (µs instead of ns
and vice-versa).  This patch fixes that.