### PR TITLE
Adds a fuzz target starting from every layer

### DIFF
--- a/layers/fuzz_layer.go
+++ b/layers/fuzz_layer.go
@@ -1,0 +1,35 @@
+// Copyright 2019 Catena cyber All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file in the root of the source
+// tree.
+
+package layers
+
+import (
+	"encoding/binary"
+
+	"github.com/google/gopacket"
+)
+
+var fuzzOpts = gopacket.DecodeOptions{
+	Lazy:                     false,
+	NoCopy:                   true,
+	SkipDecodeRecovery:       true,
+	DecodeStreamsAsDatagrams: true,
+}
+
+func FuzzLayer(data []byte) int {
+	if len(data) < 2 {
+		return 1
+	}
+	startLayer := binary.BigEndian.Uint16(data[:2])
+	p := gopacket.NewPacket(data[2:], gopacket.LayerType(startLayer), fuzzOpts)
+	for _, l := range p.Layers() {
+		gopacket.LayerString(l)
+	}
+	if p.ErrorLayer() != nil {
+		return 0
+	}
+	return 1
+}


### PR DESCRIPTION
This is to allow fuzzing with platforms such as oss-fuzz cf https://github.com/google/oss-fuzz/pull/3110

I can change the copyright if you need to

There is already a fuzz target for go packet here :
https://github.com/dvyukov/go-fuzz-corpus/blob/master/gopacket/main.go

But it is only for the DNS layer, it does not print the contents, and it recovers from panics when accessing slices out of bounds