### PR TITLE
fix: remove iface slice index check

### DIFF
--- a/routing/routing.go
+++ b/routing/routing.go
@@ -212,9 +212,6 @@ loop:
 		return nil, err
 	}
 	for i, iface := range ifaces {
-		if i != iface.Index-1 {
-			return nil, fmt.Errorf("out of order iface %d = %v", i, iface)
-		}
 		rtr.ifaces = append(rtr.ifaces, iface)
 		var addrs ipAddrs
 		ifaceAddrs, err := iface.Addrs()


### PR DESCRIPTION
There is no guarantee that the iface number will match an index position in a slice.  Removing the check as it causes a failure condition in servers where interfaces may be added/removed dynamically.  This addresses:

https://github.com/google/gopacket/issues/698