### PR TITLE
remove index ref

### DIFF
--- a/afpacket/afpacket.go
+++ b/afpacket/afpacket.go
@@ -27,7 +27,7 @@ import (
 	"golang.org/x/net/bpf"
 	"golang.org/x/sys/unix"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 /*

--- a/bsdbpf/bsd_bpf_sniffer.go
+++ b/bsdbpf/bsd_bpf_sniffer.go
@@ -15,7 +15,7 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"golang.org/x/sys/unix"
 )
 

--- a/defrag/lcmdefrag/lcmdefrag.go
+++ b/defrag/lcmdefrag/lcmdefrag.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"github.com/google/gopacket/layers"
 )
 

--- a/defrag/lcmdefrag/lcmdefrag_test.go
+++ b/defrag/lcmdefrag/lcmdefrag_test.go
@@ -9,7 +9,7 @@ package lcmdefrag
 import (
 	"testing"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"github.com/google/gopacket/layers"
 )
 

--- a/dumpcommand/tcpdump.go
+++ b/dumpcommand/tcpdump.go
@@ -16,7 +16,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"github.com/google/gopacket/ip4defrag"
 	"github.com/google/gopacket/layers" // pulls in all layers decoders
 )

--- a/examples/afpacket/afpacket.go
+++ b/examples/afpacket/afpacket.go
@@ -16,7 +16,7 @@ import (
 	"runtime/pprof"
 	"time"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"github.com/google/gopacket/afpacket"
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcap"

--- a/examples/arpscan/arpscan.go
+++ b/examples/arpscan/arpscan.go
@@ -20,7 +20,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcap"
 )

--- a/examples/bidirectional/main.go
+++ b/examples/bidirectional/main.go
@@ -11,7 +11,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"github.com/google/gopacket/examples/util"
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcap"

--- a/examples/httpassembly/main.go
+++ b/examples/httpassembly/main.go
@@ -17,7 +17,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"github.com/google/gopacket/examples/util"
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcap"

--- a/examples/pcaplay/main.go
+++ b/examples/pcaplay/main.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"github.com/google/gopacket/examples/util"
 	"github.com/google/gopacket/pcap"
 )

--- a/examples/reassemblydump/main.go
+++ b/examples/reassemblydump/main.go
@@ -29,7 +29,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"github.com/google/gopacket/examples/util"
 	"github.com/google/gopacket/ip4defrag"
 	"github.com/google/gopacket/layers" // pulls in all layers decoders

--- a/examples/snoopread/main.go
+++ b/examples/snoopread/main.go
@@ -13,7 +13,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"github.com/google/gopacket/pcapgo"
 )
 

--- a/examples/statsassembly/main.go
+++ b/examples/statsassembly/main.go
@@ -15,7 +15,7 @@ package main
 
 import (
 	"flag"
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"github.com/google/gopacket/examples/util"
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcap"

--- a/examples/synscan/main.go
+++ b/examples/synscan/main.go
@@ -24,7 +24,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"github.com/google/gopacket/examples/util"
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcap"

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/charles-d-burton/gopacket
 go 1.12
 
 require (
+	github.com/google/gopacket v1.1.17
 	golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3
 	golang.org/x/sys v0.0.0-20190405154228-4b34438f7a67
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/google/gopacket
+module github.com/charles-d-burton/gopacket
 
 go 1.12
 

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/google/gopacket v1.1.17 h1:rMrlX2ZY2UbvT+sdz3+6J+pp2z+msCq9MxTU6ymxbBY=
+github.com/google/gopacket v1.1.17/go.mod h1:UdDNZ1OO62aGYVnPhxT1U6aI7ukYtA/kB8vaU0diBUM=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 h1:0GoQqolDA55aaLxZyTzK/Y2ePZzZTUrRacwib7cNsYQ=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=

--- a/ip4defrag/defrag.go
+++ b/ip4defrag/defrag.go
@@ -15,7 +15,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"github.com/google/gopacket/layers"
 )
 

--- a/ip4defrag/defrag_test.go
+++ b/ip4defrag/defrag_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"github.com/google/gopacket/bytediff"
 	"github.com/google/gopacket/layers"
 )

--- a/layers/arp.go
+++ b/layers/arp.go
@@ -12,7 +12,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // Potential values for ARP.Operation.

--- a/layers/arp.go
+++ b/layers/arp.go
@@ -12,8 +12,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/charles-d-burton/gopacket"
-)
+	"github.com/charles-d-burton/gopacket")
 
 // Potential values for ARP.Operation.
 const (

--- a/layers/asf.go
+++ b/layers/asf.go
@@ -12,7 +12,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 const (

--- a/layers/asf_presencepong.go
+++ b/layers/asf_presencepong.go
@@ -16,7 +16,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 type (

--- a/layers/asf_presencepong_test.go
+++ b/layers/asf_presencepong_test.go
@@ -10,7 +10,7 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 func TestASFPresencePongDecodeFromBytes(t *testing.T) {

--- a/layers/asf_test.go
+++ b/layers/asf_test.go
@@ -10,7 +10,7 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 func TestASFDecodeFromBytes(t *testing.T) {

--- a/layers/base.go
+++ b/layers/base.go
@@ -7,7 +7,7 @@
 package layers
 
 import (
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // BaseLayer is a convenience struct which implements the LayerData and

--- a/layers/base.go
+++ b/layers/base.go
@@ -6,9 +6,7 @@
 
 package layers
 
-import (
-	"github.com/charles-d-burton/gopacket"
-)
+import "github.com/charles-d-burton/gopacket"
 
 // BaseLayer is a convenience struct which implements the LayerData and
 // LayerPayload functions of the Layer interface.

--- a/layers/base_test.go
+++ b/layers/base_test.go
@@ -11,7 +11,7 @@ package layers
 import (
 	"testing"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 func min(a, b int) int {

--- a/layers/bfd.go
+++ b/layers/bfd.go
@@ -11,7 +11,7 @@ import (
 	"encoding/binary"
 	"errors"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // BFD Control Packet Format

--- a/layers/bfd_test.go
+++ b/layers/bfd_test.go
@@ -9,7 +9,7 @@
 package layers
 
 import (
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"reflect"
 	"testing"
 )

--- a/layers/cdp.go
+++ b/layers/cdp.go
@@ -16,7 +16,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // CDPTLVType is the type of each TLV value in a CiscoDiscovery packet.

--- a/layers/ctp.go
+++ b/layers/ctp.go
@@ -9,7 +9,7 @@ package layers
 import (
 	"encoding/binary"
 	"fmt"
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // EthernetCTPFunction is the function code used by the EthernetCTP protocol to identify each

--- a/layers/decode_test.go
+++ b/layers/decode_test.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"github.com/google/gopacket/bytediff"
 )
 

--- a/layers/dhcp_test.go
+++ b/layers/dhcp_test.go
@@ -11,7 +11,7 @@ import (
 	"net"
 	"testing"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 func TestDHCPv4EncodeRequest(t *testing.T) {

--- a/layers/dhcpv4.go
+++ b/layers/dhcpv4.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // DHCPOp rerprents a bootp operation

--- a/layers/dhcpv6.go
+++ b/layers/dhcpv6.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // DHCPv6MsgType represents a DHCPv6 operation

--- a/layers/dhcpv6_options.go
+++ b/layers/dhcpv6_options.go
@@ -11,7 +11,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // DHCPv6Opt represents a DHCP option or parameter from RFC-3315

--- a/layers/dhcpv6_test.go
+++ b/layers/dhcpv6_test.go
@@ -10,7 +10,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 func TestDHCPv6EncodeRequest(t *testing.T) {

--- a/layers/dns.go
+++ b/layers/dns.go
@@ -13,7 +13,7 @@ import (
 	"net"
 	"strings"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // DNSClass defines the class associated with a request/response.  Different DNS

--- a/layers/dns_test.go
+++ b/layers/dns_test.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // testPacketDNSRegression is the packet:

--- a/layers/dot11.go
+++ b/layers/dot11.go
@@ -16,7 +16,7 @@ import (
 	"hash/crc32"
 	"net"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // Dot11Flags contains the set of 8 flags in the IEEE 802.11 frame control

--- a/layers/dot11_test.go
+++ b/layers/dot11_test.go
@@ -12,7 +12,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // Generator: python layers/test_creator.py --layerType=LayerTypeRadioTap --linkType=LinkTypeIEEE80211Radio --name=Dot11%s ~/Downloads/mesh.pcap

--- a/layers/dot1q.go
+++ b/layers/dot1q.go
@@ -10,7 +10,7 @@ package layers
 import (
 	"encoding/binary"
 	"fmt"
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // Dot1Q is the packet layer for 802.1Q VLAN headers.

--- a/layers/dot1q_test.go
+++ b/layers/dot1q_test.go
@@ -10,7 +10,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // test harness to ensure the dot1q layer can be encoded/decoded properly

--- a/layers/eap.go
+++ b/layers/eap.go
@@ -9,7 +9,7 @@ package layers
 import (
 	"encoding/binary"
 	"fmt"
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 type EAPCode uint8

--- a/layers/eapol.go
+++ b/layers/eapol.go
@@ -9,7 +9,7 @@ package layers
 import (
 	"encoding/binary"
 	"fmt"
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // EAPOL defines an EAP over LAN (802.1x) layer.

--- a/layers/eapol_test.go
+++ b/layers/eapol_test.go
@@ -9,7 +9,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 const eapolErrFmt = "%s packet processing failed:\ngot  :\n%#v\n\nwant :\n%#v\n\n"

--- a/layers/endpoints.go
+++ b/layers/endpoints.go
@@ -8,7 +8,7 @@ package layers
 
 import (
 	"encoding/binary"
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"net"
 	"strconv"
 )

--- a/layers/endpoints_test.go
+++ b/layers/endpoints_test.go
@@ -10,7 +10,7 @@ import (
 	"net"
 	"testing"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 func TestNewIPEndpoint(t *testing.T) {

--- a/layers/enums.go
+++ b/layers/enums.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 	"runtime"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // EnumMetadata keeps track of a set of metadata for each enumeration value

--- a/layers/enums_generated.go
+++ b/layers/enums_generated.go
@@ -8,7 +8,7 @@ package layers
 import (
 	"fmt"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 func init() {

--- a/layers/etherip.go
+++ b/layers/etherip.go
@@ -8,7 +8,7 @@ package layers
 
 import (
 	"encoding/binary"
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // EtherIP is the struct for storing RFC 3378 EtherIP packet headers.

--- a/layers/ethernet.go
+++ b/layers/ethernet.go
@@ -11,7 +11,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"net"
 )
 

--- a/layers/fddi.go
+++ b/layers/fddi.go
@@ -7,7 +7,7 @@
 package layers
 
 import (
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"net"
 )
 

--- a/layers/gen2.go
+++ b/layers/gen2.go
@@ -29,7 +29,7 @@ package layers
 import (
   "fmt"
 
-  "github.com/google/gopacket"
+  "github.com/charles-d-burton/gopacket"
 )
 
 `

--- a/layers/geneve.go
+++ b/layers/geneve.go
@@ -10,7 +10,7 @@ import (
 	"encoding/binary"
 	"errors"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // Geneve is specifed here https://tools.ietf.org/html/draft-ietf-nvo3-geneve-03

--- a/layers/geneve_test.go
+++ b/layers/geneve_test.go
@@ -10,7 +10,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 var testPacketGeneve1 = []byte{

--- a/layers/gre.go
+++ b/layers/gre.go
@@ -9,7 +9,7 @@ package layers
 import (
 	"encoding/binary"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // GRE is a Generic Routing Encapsulation header.

--- a/layers/gre_test.go
+++ b/layers/gre_test.go
@@ -11,7 +11,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // testPacketGRE is the packet:

--- a/layers/gtp.go
+++ b/layers/gtp.go
@@ -10,7 +10,7 @@ package layers
 import (
 	"encoding/binary"
 	"fmt"
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 const gtpMinimumSizeInBytes int = 8

--- a/layers/gtp_test.go
+++ b/layers/gtp_test.go
@@ -8,7 +8,7 @@
 package layers
 
 import (
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"reflect"
 	"testing"
 )

--- a/layers/icmp4.go
+++ b/layers/icmp4.go
@@ -13,7 +13,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 const (

--- a/layers/icmp6.go
+++ b/layers/icmp6.go
@@ -13,7 +13,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 const (

--- a/layers/icmp6NDflags_test.go
+++ b/layers/icmp6NDflags_test.go
@@ -8,7 +8,7 @@
 package layers
 
 import (
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"testing"
 )
 

--- a/layers/icmp6_test.go
+++ b/layers/icmp6_test.go
@@ -8,7 +8,7 @@
 package layers
 
 import (
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"net"
 	"reflect"
 	"testing"

--- a/layers/icmp6hopbyhop_test.go
+++ b/layers/icmp6hopbyhop_test.go
@@ -8,7 +8,7 @@
 package layers
 
 import (
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"testing"
 )
 

--- a/layers/icmp6msg.go
+++ b/layers/icmp6msg.go
@@ -15,7 +15,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // Based on RFC 4861

--- a/layers/icmp6msg_test.go
+++ b/layers/icmp6msg_test.go
@@ -8,7 +8,7 @@
 package layers
 
 import (
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"testing"
 )
 

--- a/layers/igmp.go
+++ b/layers/igmp.go
@@ -13,7 +13,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 type IGMPType uint8

--- a/layers/igmp_test.go
+++ b/layers/igmp_test.go
@@ -9,7 +9,7 @@ package layers
 import (
 	"testing"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // igmpv1MembershipReportPacket is the packet:

--- a/layers/ip4.go
+++ b/layers/ip4.go
@@ -14,7 +14,7 @@ import (
 	"net"
 	"strings"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 type IPv4Flag uint8

--- a/layers/ip4_test.go
+++ b/layers/ip4_test.go
@@ -16,7 +16,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // Test the function getIPv4OptionSize when the ipv4 has no options

--- a/layers/ip6.go
+++ b/layers/ip6.go
@@ -13,7 +13,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 const (

--- a/layers/ip6_test.go
+++ b/layers/ip6_test.go
@@ -8,7 +8,7 @@ package layers
 
 import (
 	"bytes"
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"net"
 	"reflect"
 	"testing"

--- a/layers/ipsec.go
+++ b/layers/ipsec.go
@@ -8,7 +8,7 @@ package layers
 
 import (
 	"encoding/binary"
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // IPSecAH is the authentication header for IPv4/6 defined in

--- a/layers/ipsec_test.go
+++ b/layers/ipsec_test.go
@@ -7,7 +7,7 @@
 package layers
 
 import (
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"reflect"
 	"testing"
 )

--- a/layers/layertypes.go
+++ b/layers/layertypes.go
@@ -7,7 +7,7 @@
 package layers
 
 import (
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 var (

--- a/layers/lcm.go
+++ b/layers/lcm.go
@@ -10,7 +10,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 const (

--- a/layers/lcm_test.go
+++ b/layers/lcm_test.go
@@ -10,7 +10,7 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 var (

--- a/layers/linux_sll.go
+++ b/layers/linux_sll.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 type LinuxSLLPacketType uint16

--- a/layers/llc.go
+++ b/layers/llc.go
@@ -10,7 +10,7 @@ import (
 	"encoding/binary"
 	"errors"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // LLC is the layer used for 802.2 Logical Link Control headers.

--- a/layers/lldp.go
+++ b/layers/lldp.go
@@ -11,7 +11,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // LLDPTLVType is the type of each TLV value in a LinkLayerDiscovery packet.

--- a/layers/loopback.go
+++ b/layers/loopback.go
@@ -11,7 +11,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // Loopback contains the header for loopback encapsulation.  This header is

--- a/layers/mldv1.go
+++ b/layers/mldv1.go
@@ -14,7 +14,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // MLDv1Message represents the common structure of all MLDv1 messages

--- a/layers/mldv1_test.go
+++ b/layers/mldv1_test.go
@@ -9,7 +9,7 @@ package layers
 import (
 	"testing"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // Adapted from https://github.com/the-tcpdump-group/tcpdump/blob/master/tests/icmpv6.pcap

--- a/layers/mldv2.go
+++ b/layers/mldv2.go
@@ -14,7 +14,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 const (

--- a/layers/mldv2_test.go
+++ b/layers/mldv2_test.go
@@ -9,7 +9,7 @@ package layers
 import (
 	"testing"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // Adapted from https://github.com/the-tcpdump-group/tcpdump/blob/master/tests/icmpv6.pcap

--- a/layers/modbustcp.go
+++ b/layers/modbustcp.go
@@ -11,7 +11,7 @@ package layers
 import (
 	"encoding/binary"
 	"errors"
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 //******************************************************************************

--- a/layers/mpls.go
+++ b/layers/mpls.go
@@ -9,7 +9,7 @@ package layers
 import (
 	"encoding/binary"
 	"errors"
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // MPLS is the MPLS packet header.

--- a/layers/mpls_test.go
+++ b/layers/mpls_test.go
@@ -10,7 +10,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // testPacketMPLS

--- a/layers/ndp.go
+++ b/layers/ndp.go
@@ -11,7 +11,7 @@ package layers
 
 import (
 	"fmt"
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"net"
 )
 

--- a/layers/ntp.go
+++ b/layers/ntp.go
@@ -12,7 +12,7 @@ import (
 	"encoding/binary"
 	"errors"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 //******************************************************************************

--- a/layers/ntp_test.go
+++ b/layers/ntp_test.go
@@ -10,7 +10,7 @@ package layers
 
 import (
 	"crypto/rand"
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"io"
 	"reflect"
 	"testing"

--- a/layers/ospf.go
+++ b/layers/ospf.go
@@ -10,7 +10,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // OSPFType denotes what kind of OSPF type it is

--- a/layers/ospf_test.go
+++ b/layers/ospf_test.go
@@ -10,7 +10,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // testPacketOSPF2Hello is the packet:

--- a/layers/pflog.go
+++ b/layers/pflog.go
@@ -10,7 +10,7 @@ import (
 	"encoding/binary"
 	"errors"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 type PFDirection uint8

--- a/layers/ports.go
+++ b/layers/ports.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // TCPPort is a port in a TCP layer.

--- a/layers/ppp.go
+++ b/layers/ppp.go
@@ -9,7 +9,7 @@ package layers
 import (
 	"encoding/binary"
 	"errors"
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // PPP is the layer for PPP encapsulation headers.

--- a/layers/pppoe.go
+++ b/layers/pppoe.go
@@ -8,7 +8,7 @@ package layers
 
 import (
 	"encoding/binary"
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // PPPoE is the layer for PPPoE encapsulation headers.

--- a/layers/prism.go
+++ b/layers/prism.go
@@ -12,7 +12,7 @@ import (
 	"encoding/binary"
 	"errors"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 func decodePrismValue(data []byte, pv *PrismValue) {

--- a/layers/prism_test.go
+++ b/layers/prism_test.go
@@ -11,7 +11,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // Generator: python layers/test_creator.py --layerType=LayerTypePrismHeader --linkType=LinkTypePrismHeader --name=Prism%s ~/tmp/dump.pcap

--- a/layers/radiotap.go
+++ b/layers/radiotap.go
@@ -13,7 +13,7 @@ import (
 	"hash/crc32"
 	"strings"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // align calculates the number of bytes needed to align with the width

--- a/layers/radiotap_test.go
+++ b/layers/radiotap_test.go
@@ -6,7 +6,7 @@
 package layers
 
 import (
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"testing"
 )
 

--- a/layers/rmcp.go
+++ b/layers/rmcp.go
@@ -11,7 +11,7 @@ package layers
 import (
 	"fmt"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // RMCPClass is the class of a RMCP layer's payload, e.g. ASF or IPMI. This is a

--- a/layers/rmcp_test.go
+++ b/layers/rmcp_test.go
@@ -10,7 +10,7 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 func TestRMCPDecodeFromBytes(t *testing.T) {

--- a/layers/rudp.go
+++ b/layers/rudp.go
@@ -9,7 +9,7 @@ package layers
 import (
 	"encoding/binary"
 	"fmt"
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 type RUDP struct {

--- a/layers/sctp.go
+++ b/layers/sctp.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 	"hash/crc32"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // SCTP contains information on the top level of an SCTP packet.

--- a/layers/sflow.go
+++ b/layers/sflow.go
@@ -77,7 +77,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // SFlowRecord holds both flow sample records and counter sample records.

--- a/layers/sflow_test.go
+++ b/layers/sflow_test.go
@@ -10,7 +10,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // Test packet collected from live network. See the test below for contents

--- a/layers/sip.go
+++ b/layers/sip.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // SIPVersion defines the different versions of the SIP Protocol

--- a/layers/sip_test.go
+++ b/layers/sip_test.go
@@ -9,7 +9,7 @@ package layers
 import (
 	"testing"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // First packet is a REGISTER Request

--- a/layers/stp.go
+++ b/layers/stp.go
@@ -7,7 +7,7 @@
 package layers
 
 import (
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // STP decode spanning tree protocol packets to transport BPDU (bridge protocol data unit) message.

--- a/layers/tcp.go
+++ b/layers/tcp.go
@@ -13,7 +13,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // TCP is the layer for TCP headers.

--- a/layers/tcp_test.go
+++ b/layers/tcp_test.go
@@ -10,7 +10,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 func TestTCPOptionKindString(t *testing.T) {

--- a/layers/tcpip.go
+++ b/layers/tcpip.go
@@ -11,7 +11,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // Checksum computation for TCP/UDP.

--- a/layers/tcpip_test.go
+++ b/layers/tcpip_test.go
@@ -7,7 +7,7 @@
 package layers
 
 import (
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"net"
 	"testing"
 )

--- a/layers/tls.go
+++ b/layers/tls.go
@@ -10,7 +10,7 @@ import (
 	"encoding/binary"
 	"errors"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // TLSType defines the type of data after the TLS Record

--- a/layers/tls_alert.go
+++ b/layers/tls_alert.go
@@ -10,7 +10,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // TLSAlertLevel defines the alert level data type

--- a/layers/tls_appdata.go
+++ b/layers/tls_appdata.go
@@ -9,7 +9,7 @@ package layers
 import (
 	"errors"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // TLSAppDataRecord contains all the information that each AppData Record types should have

--- a/layers/tls_cipherspec.go
+++ b/layers/tls_cipherspec.go
@@ -9,7 +9,7 @@ package layers
 import (
 	"errors"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // TLSchangeCipherSpec defines the message value inside ChangeCipherSpec Record

--- a/layers/tls_handshake.go
+++ b/layers/tls_handshake.go
@@ -7,7 +7,7 @@
 package layers
 
 import (
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // TLSHandshakeRecord defines the structure of a Handshare Record

--- a/layers/tls_test.go
+++ b/layers/tls_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // https://github.com/tintinweb/scapy-ssl_tls/blob/master/tests/files/RSA_WITH_AES_128_CBC_SHA.pcap

--- a/layers/udp.go
+++ b/layers/udp.go
@@ -11,7 +11,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // UDP is the layer for UDP headers.

--- a/layers/udp_test.go
+++ b/layers/udp_test.go
@@ -11,7 +11,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // testUDPPacketDNS is the packet:

--- a/layers/udplite.go
+++ b/layers/udplite.go
@@ -9,7 +9,7 @@ package layers
 
 import (
 	"encoding/binary"
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 // UDPLite is the layer for UDP-Lite headers (rfc 3828).

--- a/layers/usb.go
+++ b/layers/usb.go
@@ -8,7 +8,7 @@ package layers
 
 import (
 	"encoding/binary"
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 type USBEventType uint8

--- a/layers/usb_test.go
+++ b/layers/usb_test.go
@@ -8,7 +8,7 @@ package layers
 
 import (
 	_ "fmt"
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"reflect"
 	"testing"
 )

--- a/layers/vrrp.go
+++ b/layers/vrrp.go
@@ -11,7 +11,7 @@ import (
 	"errors"
 	"net"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 /*

--- a/layers/vrrp_test.go
+++ b/layers/vrrp_test.go
@@ -6,7 +6,7 @@
 package layers
 
 import (
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"testing"
 )
 

--- a/layers/vxlan.go
+++ b/layers/vxlan.go
@@ -9,7 +9,7 @@ package layers
 import (
 	"encoding/binary"
 	"fmt"
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 //  VXLAN is specifed in RFC 7348 https://tools.ietf.org/html/rfc7348

--- a/layers/vxlan_test.go
+++ b/layers/vxlan_test.go
@@ -7,7 +7,7 @@
 package layers
 
 import (
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"reflect"
 	"testing"
 )

--- a/pcap/bpf_test.go
+++ b/pcap/bpf_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"github.com/google/gopacket/layers"
 )
 

--- a/pcap/gopacket_benchmark/benchmark.go
+++ b/pcap/gopacket_benchmark/benchmark.go
@@ -22,7 +22,7 @@ import (
 	"encoding/hex"
 	"flag"
 	"fmt"
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcap"
 	"github.com/google/gopacket/tcpassembly"

--- a/pcap/pcap.go
+++ b/pcap/pcap.go
@@ -22,7 +22,7 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"github.com/google/gopacket/layers"
 )
 

--- a/pcap/pcap_test.go
+++ b/pcap/pcap_test.go
@@ -14,7 +14,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"github.com/google/gopacket/layers"
 )
 

--- a/pcap/pcap_unix.go
+++ b/pcap/pcap_unix.go
@@ -17,7 +17,7 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 
 	"github.com/google/gopacket/layers"
 )

--- a/pcap/pcap_windows.go
+++ b/pcap/pcap_windows.go
@@ -17,7 +17,7 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"github.com/google/gopacket/layers"
 	"golang.org/x/sys/windows"
 )

--- a/pcap/pcapgo_test.go
+++ b/pcap/pcapgo_test.go
@@ -8,7 +8,7 @@ package pcap
 
 import (
 	"bytes"
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcapgo"
 	"io/ioutil"

--- a/pcap/pcapnggo_test.go
+++ b/pcap/pcapnggo_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcapgo"
 )

--- a/pcapgo/capture.go
+++ b/pcapgo/capture.go
@@ -19,7 +19,7 @@ import (
 	"golang.org/x/net/bpf"
 	"golang.org/x/sys/unix"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 var hdrLen = unix.CmsgSpace(0)

--- a/pcapgo/capture_test.go
+++ b/pcapgo/capture_test.go
@@ -11,7 +11,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcapgo"
 )

--- a/pcapgo/ngread.go
+++ b/pcapgo/ngread.go
@@ -14,7 +14,7 @@ import (
 	"io"
 	"time"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"github.com/google/gopacket/layers"
 )
 

--- a/pcapgo/ngread_test.go
+++ b/pcapgo/ngread_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"github.com/google/gopacket/layers"
 )
 

--- a/pcapgo/ngwrite.go
+++ b/pcapgo/ngwrite.go
@@ -14,7 +14,7 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"github.com/google/gopacket/layers"
 )
 

--- a/pcapgo/ngwrite_test.go
+++ b/pcapgo/ngwrite_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"github.com/google/gopacket/layers"
 )
 

--- a/pcapgo/pcapng.go
+++ b/pcapgo/pcapng.go
@@ -11,7 +11,7 @@ import (
 	"math"
 	"time"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"github.com/google/gopacket/layers"
 )
 

--- a/pcapgo/read.go
+++ b/pcapgo/read.go
@@ -16,7 +16,7 @@ import (
 	"bufio"
 	"compress/gzip"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"github.com/google/gopacket/layers"
 )
 

--- a/pcapgo/snoop.go
+++ b/pcapgo/snoop.go
@@ -13,7 +13,7 @@ import (
 	"io"
 	"time"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"github.com/google/gopacket/layers"
 )
 

--- a/pcapgo/write.go
+++ b/pcapgo/write.go
@@ -12,7 +12,7 @@ import (
 	"io"
 	"time"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"github.com/google/gopacket/layers"
 )
 

--- a/pcapgo/write_test.go
+++ b/pcapgo/write_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 func TestWriteHeaderNanos(t *testing.T) {

--- a/pfring/pfring.go
+++ b/pfring/pfring.go
@@ -62,7 +62,7 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 )
 
 const errorBufferSize = 256

--- a/reassembly/cap2test.go
+++ b/reassembly/cap2test.go
@@ -16,7 +16,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcap"
 )

--- a/reassembly/tcpassembly.go
+++ b/reassembly/tcpassembly.go
@@ -28,7 +28,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"github.com/google/gopacket/layers"
 )
 

--- a/reassembly/tcpassembly_test.go
+++ b/reassembly/tcpassembly_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"github.com/google/gopacket/layers"
 )
 

--- a/reassembly/tcpcheck.go
+++ b/reassembly/tcpcheck.go
@@ -10,7 +10,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"github.com/google/gopacket/layers"
 )
 

--- a/reassembly/tcpcheck_test.go
+++ b/reassembly/tcpcheck_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"github.com/google/gopacket/layers"
 )
 

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -211,7 +211,7 @@ loop:
 	if err != nil {
 		return nil, err
 	}
-	for i, iface := range ifaces {
+	for _, iface := range ifaces {
 		rtr.ifaces = append(rtr.ifaces, iface)
 		var addrs ipAddrs
 		ifaceAddrs, err := iface.Addrs()

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -212,9 +212,6 @@ loop:
 		return nil, err
 	}
 	for i, iface := range ifaces {
-		if i != iface.Index-1 {
-			return nil, fmt.Errorf("out of order iface %d = %v", i, iface)
-		}
 		rtr.ifaces = append(rtr.ifaces, iface)
 		var addrs ipAddrs
 		ifaceAddrs, err := iface.Addrs()

--- a/tcpassembly/assembly.go
+++ b/tcpassembly/assembly.go
@@ -21,7 +21,7 @@ package tcpassembly
 import (
 	"flag"
 	"fmt"
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"github.com/google/gopacket/layers"
 	"log"
 	"sync"

--- a/tcpassembly/assembly_test.go
+++ b/tcpassembly/assembly_test.go
@@ -7,7 +7,7 @@
 package tcpassembly
 
 import (
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"github.com/google/gopacket/layers"
 	"net"
 	"reflect"

--- a/tcpassembly/tcpreader/reader_test.go
+++ b/tcpassembly/tcpreader/reader_test.go
@@ -9,7 +9,7 @@ package tcpreader
 import (
 	"bytes"
 	"fmt"
-	"github.com/google/gopacket"
+	"github.com/charles-d-burton/gopacket"
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/tcpassembly"
 	"io"


### PR DESCRIPTION
There is no guarantee that the iface number will match an index position in a slice.  Removing the check as it causes a failure condition in servers where interfaces may be added/removed dynamically.

Fixes issue:
https://github.com/google/gopacket/issues/698