### PR TITLE
Fixes SIP layer to correctly indicate truncated SIP packets

### DIFF
--- a/layers/sip.go
+++ b/layers/sip.go
@@ -262,6 +262,9 @@ func (s *SIP) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 		line, err = buffer.ReadBytes(byte('\n'))
 		if err != nil {
 			if err == io.EOF {
+				if len(bytes.Trim(line, "\r\n")) > 0 {
+					df.SetTruncated()
+				}
 				break
 			} else {
 				return err


### PR DESCRIPTION
Currently, if a SIP packet is truncated, the parser does not indicate this.  The fix calls `SetTruncated()` if this condition is detected.   SIP packets can be considered as truncated if each line does not end in a CR-LF