### PR TITLE
layers: remove unused func errorFunc

### DIFF
--- a/layers/enums.go
+++ b/layers/enums.go
@@ -8,7 +8,6 @@
 package layers
 
 import (
-	"errors"
 	"fmt"
 	"runtime"
 
@@ -24,14 +23,6 @@ type EnumMetadata struct {
 	Name string
 	// LayerType is the layer type implied by the given enum.
 	LayerType gopacket.LayerType
-}
-
-// errorFunc returns a decoder that spits out a specific error message.
-func errorFunc(msg string) gopacket.Decoder {
-	var e = errors.New(msg)
-	return gopacket.DecodeFunc(func([]byte, gopacket.PacketBuilder) error {
-		return e
-	})
 }
 
 // EthernetType is an enumeration of ethernet type values, and acts as a decoder


### PR DESCRIPTION
It is unused since commit 8c5cfc5ae25c ("Attempt to reduce memory usage
caused by enums.go strings.")

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>