### PR TITLE
icmp serialize: adding payload serialization.

### DIFF
--- a/layers/icmp4.go
+++ b/layers/icmp4.go
@@ -235,13 +235,20 @@ func (i *ICMPv4) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error 
 // SerializationBuffer, implementing gopacket.SerializableLayer.
 // See the docs for gopacket.SerializableLayer for more info.
 func (i *ICMPv4) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeOptions) error {
-	bytes, err := b.PrependBytes(8)
+	bytes, err := b.PrependBytes(len(i.Payload) + 8)
 	if err != nil {
 		return err
 	}
 	i.TypeCode.SerializeTo(bytes)
 	binary.BigEndian.PutUint16(bytes[4:], i.Id)
 	binary.BigEndian.PutUint16(bytes[6:], i.Seq)
+
+	startIndex := 8
+	for _, element := range i.Payload {
+		bytes[startIndex] = byte(uint16(element))
+		startIndex += 1
+	}
+
 	if opts.ComputeChecksums {
 		bytes[2] = 0
 		bytes[3] = 0


### PR DESCRIPTION
When serializing an ICMP layer the current function allocates 8 bytes of space which only included the id, seq, and type code.
Rather I think it should reserve what it needs to by adding the required 8 bytes and the length of the payload. Then add the payload to the byte array.

I am fairly new to Go so the submitted solution may not be as clean as it could be.
If the payload is not correctly serialized many types of ICMP messages can be dropped or not properly responded to.
If my proposed solution goes against the structure of the library please let me know and I will edit accordingly. 