### PR TITLE
deliver data on PSH flag

### DIFF
--- a/reassembly/tcpassembly.go
+++ b/reassembly/tcpassembly.go
@@ -703,6 +703,12 @@ func (a *Assembler) AssembleWithContext(netFlow gopacket.Flow, t *layers.TCP, ac
 			}
 			half.nextSeq = seq
 			action.queue = false
+		} else if t.PSH {
+			if *debugLog {
+				log.Printf("%v PSH encountered", key)
+			}
+			half.nextSeq = seq
+			action.queue = false
 		} else {
 			if *debugLog {
 				log.Printf("%v waiting for start, storing into connection", key)


### PR DESCRIPTION
All available data in the stream should be delivered the application when the TCP PSH flag is set.