### PR TITLE
reassembly: Fix offset calculation in reassemblyObject.CaptureInfo

### DIFF
--- a/reassembly/tcpassembly.go
+++ b/reassembly/tcpassembly.go
@@ -156,16 +156,16 @@ func (rl *reassemblyObject) KeepFrom(offset int) {
 }
 
 func (rl *reassemblyObject) CaptureInfo(offset int) gopacket.CaptureInfo {
+	if offset < 0 {
+		return gopacket.CaptureInfo{}
+	}
+
 	current := 0
-	var r byteContainer
-	for _, r = range rl.all {
-		if current >= offset {
+	for _, r := range rl.all {
+		if current+r.length() > offset {
 			return r.captureInfo()
 		}
 		current += r.length()
-	}
-	if r != nil && current >= offset {
-		return r.captureInfo()
 	}
 	// Invalid offset
 	return gopacket.CaptureInfo{}
@@ -284,7 +284,6 @@ type livePacket struct {
 	bytes []byte
 	start bool
 	end   bool
-	ci    gopacket.CaptureInfo
 	ac    AssemblerContext
 	seq   Sequence
 }
@@ -293,7 +292,7 @@ func (lp *livePacket) getBytes() []byte {
 	return lp.bytes
 }
 func (lp *livePacket) captureInfo() gopacket.CaptureInfo {
-	return lp.ci
+	return lp.ac.GetCaptureInfo()
 }
 func (lp *livePacket) assemblerContext() AssemblerContext {
 	return lp.ac
@@ -317,7 +316,7 @@ func (lp *livePacket) isPacket() bool {
 // Creates a page (or set of pages) from a TCP packet: returns the first and last
 // page in its doubly-linked list of new pages.
 func (lp *livePacket) convertToPages(pc *pageCache, skip int, ac AssemblerContext) (*page, *page, int) {
-	ts := lp.ci.Timestamp
+	ts := lp.captureInfo().Timestamp
 	first := pc.next(ts)
 	current := first
 	current.prev = nil
@@ -722,7 +721,7 @@ func (a *Assembler) AssembleWithContext(netFlow gopacket.Flow, t *layers.TCP, ac
 		}
 	}
 
-	action = a.handleBytes(bytes, seq, half, ci, t.SYN, t.RST || t.FIN, action, ac)
+	action = a.handleBytes(bytes, seq, half, t.SYN, t.RST || t.FIN, action, ac)
 	if len(a.ret) > 0 {
 		action.nextSeq = a.sendToConnection(conn, half, ac)
 	}
@@ -955,12 +954,11 @@ func (a *Assembler) overlapExisting(half *halfconnection, start, end Sequence, b
 }
 
 // Prepare send or queue
-func (a *Assembler) handleBytes(bytes []byte, seq Sequence, half *halfconnection, ci gopacket.CaptureInfo, start bool, end bool, action assemblerAction, ac AssemblerContext) assemblerAction {
+func (a *Assembler) handleBytes(bytes []byte, seq Sequence, half *halfconnection, start bool, end bool, action assemblerAction, ac AssemblerContext) assemblerAction {
 	a.cacheLP.bytes = bytes
 	a.cacheLP.start = start
 	a.cacheLP.end = end
 	a.cacheLP.seq = seq
-	a.cacheLP.ci = ci
 	a.cacheLP.ac = ac
 
 	if action.queue {


### PR DESCRIPTION
CaptureInfo is supposed to return info of packet corresponding to the
given offset. The current implementation does not take the livePacket
or page length into account, so any offset other than the first offset
of a packet will get the CaptureInfo of the next packet.

This PR also removes a redundant `CaptureInfo` field within
`livePacket`.