### PR TITLE
eap: add fuzz target

### DIFF
--- a/layers/eap_fuzz.go
+++ b/layers/eap_fuzz.go
@@ -1,0 +1,20 @@
+// Copyright 2020 Google, Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file in the root of the source
+// tree.
+
+// +build gofuzz
+
+package layers
+
+import (
+	"github.com/google/gopacket"
+)
+
+func FuzzEAPDecoder(in []byte) int {
+	gopacket.NewPacket(in, LayerTypeEAP, gopacket.DecodeOptions{
+		SkipDecodeRecovery: true,
+	})
+	return 0
+}


### PR DESCRIPTION
https://github.com/dvyukov/go-fuzz can execute this test as follows:

```
$ cd layers/
$ go-fuzz
2020/05/04 20:13:08 workers: 4, corpus: 7 (3s ago), crashers: 0, restarts: 1/0, execs: 0 (0/sec), cover: 0, uptime: 3s
2020/05/04 20:13:11 workers: 4, corpus: 7 (6s ago), crashers: 0, restarts: 1/0, execs: 0 (0/sec), cover: 108, uptime: 6s
2020/05/04 20:13:14 workers: 4, corpus: 7 (9s ago), crashers: 0, restarts: 1/6442, execs: 103077 (11452/sec), cover: 108, uptime: 9s
```

I have raised https://github.com/google/oss-fuzz/pull/3760 to include gopacket in https://google.github.io/oss-fuzz .