### PR TITLE
Add serialization of non-mandatory LLDP TLVs

### DIFF
--- a/layers/lldp.go
+++ b/layers/lldp.go
@@ -779,6 +779,16 @@ func (c *LinkLayerDiscovery) SerializeTo(b gopacket.SerializeBuffer, opts gopack
 	binary.BigEndian.PutUint16(vb[chassIDLen+portIDLen:], ttlIDLen)
 	binary.BigEndian.PutUint16(vb[chassIDLen+portIDLen+2:], c.TTL)
 
+	for _, v := range c.Values {
+		vb, err := b.AppendBytes(int(v.Length) + 2) // +2 for TLV type and length; 1 byte for subtype is included in v.Value
+		if err != nil {
+			return err
+		}
+		idLen := ((uint16(v.Type) << 9) | v.Length)
+		binary.BigEndian.PutUint16(vb[0:2], idLen)
+		copy(vb[2:], v.Value)
+	}
+
 	vb, err = b.AppendBytes(2) // End Tlv, 2 bytes
 	if err != nil {
 		return err


### PR DESCRIPTION
My use case was to programmatically create an LLDP packet and writing it to a PCAP file. Most of that works, except for TLVs other than the mandatory ones, of which there are many. A small example:

```
	lldpLayer := &layers.LinkLayerDiscovery{
		ChassisID: layers.LLDPChassisID{
			Subtype: layers.LLDPChassisIDSubTypeMACAddr,
			ID:      []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06},
		},
		PortID: layers.LLDPPortID{
			Subtype: layers.LLDPPortIDSubtypeIfaceName,
			ID:      []byte{0x31, 0x2f, 0x31, 0x31, 0x2f, 0x31, 0x31, 0x2f, 0x31, 0x31, 0x2f, 0x31},
		},
		TTL: 300,
	}

	// NOTE: example values taken from the Wireshark lldp.detailed.pcap example
	value := []byte{0x00, 0x12, 0x0f, 0x02}
	value = append(value, []byte{0x07, 0x01, 0x00}...)
	lldpValue := layers.LinkLayerDiscoveryValue{
		Type: layers.LLDPTLVOrgSpecific,
		Length: uint16(len(value)),
		Value:  value,
	}

	lldpLayer.Values = append(lldpLayer.Values, lldpValue)
```

The code is based on what I found [here](https://github.com/google/gopacket/commit/ffe439921b3bd5510313e3dd812a6910aa52b7de#diff-c3dcb92e52d5c5b310a5b7788647d6ccL815). I tested the code with two different vendor specific TLVs and it seems to work OK.

I'm working at Layer 2, `LinkLayerDiscovery`. I'm aware there's also a Layer 3 `LinkLayerDiscoveryInfo`, which contains mostly the same data as the `Values` in the `LinkLayerDiscovery` layer. There's some discussion about how the information is shown redundantly [here](https://github.com/google/gopacket/issues/628), but I thought Layer 2 seemed OK to implement this at, but I'm curious to know what others think about that.