### PR TITLE
Fix for unhandled error in router.RouteWithSrc

### DIFF
--- a/routing/routing.go
+++ b/routing/routing.go
@@ -100,6 +100,9 @@ func (r *router) RouteWithSrc(input net.HardwareAddr, src, dst net.IP) (iface *n
 		ifaceIndex, gateway, preferredSrc, err = r.route(r.v6, input, src, dst)
 	default:
 		err = errors.New("IP is not valid as IPv4 or IPv6")
+	}
+
+	if err != nil {
 		return
 	}
 

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -133,6 +133,10 @@ func (r *router) route(routes routeSlice, input net.HardwareAddr, src, dst net.I
 		if rt.InputIface != 0 && rt.InputIface != inputIndex {
 			continue
 		}
+		// default route will have both rt.Src and rt.Dst equal to nil
+		if rt.Src == nil && rt.Dst == nil {
+			continue
+		}
 		if rt.Src != nil && !rt.Src.Contains(src) {
 			continue
 		}


### PR DESCRIPTION
## Fix for unhandled error in router.RouteWithSrc

**Issue:**
panic: runtime error: index out of range at line [109](https://github.com/RealImage/gopacket/blob/3ef9fc8f0c56cf922a9b5ce1e5209235809224cd/routing/routing.go#L109) due to unhandled errors 

