### PR TITLE
Add TLS layer serialization; bugfixes for layer memory reuse

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -33,6 +33,7 @@ Jesse Ward <jesse@jesseward.com>
 Kane Mathers <kane@kanemathers.name>
 Jose Selvi <jselvi@pentester.es>
 Yerden Zhumabekov <yerden.zhumabekov@gmail.com>
+Jensen Hwa <jensenhwa@gmail.com>
 
 -----------------------------------------------
 FORKED FROM github.com/akrennmair/gopcap

--- a/layers/ip6.go
+++ b/layers/ip6.go
@@ -512,6 +512,7 @@ func (i *IPv6HopByHop) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) 
 	if err != nil {
 		return err
 	}
+	i.Options = i.Options[:0]
 	offset := 2
 	for offset < i.ActualLength {
 		opt, err := decodeIPv6HeaderTLVOption(data[offset:], df)

--- a/layers/tcp.go
+++ b/layers/tcp.go
@@ -256,6 +256,7 @@ func (tcp *TCP) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 	} else {
 		tcp.Options = tcp.Options[:0]
 	}
+	tcp.Padding = tcp.Padding[:0]
 	if tcp.DataOffset < 5 {
 		return fmt.Errorf("Invalid TCP data offset %d < 5", tcp.DataOffset)
 	}

--- a/layers/tls.go
+++ b/layers/tls.go
@@ -135,6 +135,7 @@ func (t *TLS) decodeTLSRecords(data []byte, df gopacket.DecodeFeedback) error {
 
 	// since there are no further layers, the baselayer's content is
 	// pointing to this layer
+	// TODO: Consider removing this
 	t.BaseLayer = BaseLayer{Contents: data[:len(data)]}
 
 	var h TLSRecordHeader
@@ -205,4 +206,68 @@ func (t *TLS) NextLayerType() gopacket.LayerType {
 // Payload returns nil, since TLS encrypted payload is inside TLSAppDataRecord
 func (t *TLS) Payload() []byte {
 	return nil
+}
+
+// SerializeTo writes the serialized form of this layer into the
+// SerializationBuffer, implementing gopacket.SerializableLayer.
+func (t *TLS) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeOptions) error {
+	if !opts.FixLengths {
+		return errors.New("serialization of packets without fixing lengths has not been implemented yet")
+	}
+	totalLength := 0
+	for range t.ChangeCipherSpec {
+		totalLength += 5 + 1 // length of header + record
+	}
+	for range t.Handshake {
+		totalLength += 5
+	}
+	for _, record := range t.AppData {
+		totalLength += 5 + len(record.Payload)
+	}
+	for _, record := range t.Alert {
+		if len(record.EncryptedMsg) == 0 {
+			totalLength += 5 + 2
+		} else {
+			totalLength += 5 + len(record.EncryptedMsg)
+		}
+	}
+	data, err := b.PrependBytes(totalLength)
+	if err != nil {
+		return err
+	}
+	off := 0
+	for _, record := range t.ChangeCipherSpec {
+		off = encodeHeader(record.TLSRecordHeader, data, off)
+		data[off] = byte(record.Message)
+		off++
+	}
+	for _, record := range t.Handshake {
+		off = encodeHeader(record.TLSRecordHeader, data, off)
+		// TODO
+	}
+	for _, record := range t.AppData {
+		off = encodeHeader(record.TLSRecordHeader, data, off)
+		copy(data[off:], record.Payload)
+		off += len(record.Payload)
+	}
+	for _, record := range t.Alert {
+		off = encodeHeader(record.TLSRecordHeader, data, off)
+		if len(record.EncryptedMsg) == 0 {
+			data[off] = byte(record.Level)
+			data[off+1] = byte(record.Description)
+			off += 2
+		} else {
+			copy(data[off:], record.EncryptedMsg)
+			off += len(record.EncryptedMsg)
+		}
+	}
+	return nil
+}
+
+func encodeHeader(header TLSRecordHeader, data []byte, offset int) int {
+	data[offset] = byte(header.ContentType)
+	binary.BigEndian.PutUint16(data[offset+1:], uint16(header.Version))
+	binary.BigEndian.PutUint16(data[offset+3:], header.Length)
+
+	return offset + 5
 }


### PR DESCRIPTION
We've been using gopacket in one of the assignments in our computer security course at the University of Michigan, specifically by decoding a real pcap file, randomizing certain bits of information, and then serializing it again to provide to students. Our implementation uses DecodingLayerContainer, as described in the [docs](https://godoc.org/github.com/google/gopacket#hdr-Faster_And_Customized_Decoding_with_DecodingLayerContainer).

As you know, because memory for the layers is reused over and over again, each field of every layer needs to be explicitly assigned or cleared each time, lest it contain stale data. I noticed and fixed two instances where this occurred, in `ip6` and `tcp`.

Separately, I've included some small additions made to the `tls` layer in order to support basic serialization. The layer as a whole still remains unfinished, but as suggested in the [original PR](https://github.com/google/gopacket/pull/534), with everyone adding what they have, eventually we'll get to a complete implementation.

Thanks in advance for your review.