### PR TITLE
reassembly: Update skip count in Assember.cleanSG

### DIFF
--- a/reassembly/tcpassembly.go
+++ b/reassembly/tcpassembly.go
@@ -1070,7 +1070,16 @@ func (a *Assembler) cleanSG(half *halfconnection, ac AssemblerContext) {
 	half.saved = nil
 	var saved *page
 	for _, r := range a.cacheSG.all[ndx:] {
+		preConvertLen := r.length()
 		first, last, nb := r.convertToPages(a.pc, skip, ac)
+
+		// Update skip count as we move from one container to the next.
+		if delta := preConvertLen - r.length(); delta > skip {
+			skip = 0
+		} else {
+			skip -= delta
+		}
+
 		if half.saved == nil {
 			half.saved = first
 		} else {

--- a/reassembly/tcpassembly_test.go
+++ b/reassembly/tcpassembly_test.go
@@ -1212,15 +1212,6 @@ func TestKeepWithManualFlush(t *testing.T) {
 				SrcPort:   1,
 				DstPort:   2,
 				Seq:       1001,
-				BaseLayer: layers.BaseLayer{Payload: makePayload(pageBytes - 1)},
-			},
-			want: []byte{},
-		},
-		{
-			tcp: layers.TCP{
-				SrcPort:   1,
-				DstPort:   2,
-				Seq:       1001,
 				BaseLayer: layers.BaseLayer{Payload: makePayload(pageBytes + 1)},
 			},
 			want: []byte{},


### PR DESCRIPTION
As `cleanSG` iterates through `byteContainers` to convert them to pages, it needs to update the skip count (number of bytes to skip from the start of each container). Failure to do so may result in a panic, as demonstrated with the unit test.