### PR TITLE
reassembly: fix check overlap for case 6

### DIFF
--- a/reassembly/tcpassembly.go
+++ b/reassembly/tcpassembly.go
@@ -833,7 +833,7 @@ func (a *Assembler) checkOverlap(half *halfconnection, queue bool, ac AssemblerC
 		} else
 
 		// end < cur.end && start > cur.start: replace bytes inside cur (6)
-		if diffEnd > 0 && diffStart < 0 {
+		if diffEnd >= 0 && diffStart <= 0 {
 			if *debugLog {
 				log.Printf("case 6\n")
 			}

--- a/reassembly/tcpassembly_test.go
+++ b/reassembly/tcpassembly_test.go
@@ -463,8 +463,8 @@ func TestBufferedOverlapCase6(t *testing.T) {
 			in: layers.TCP{
 				SrcPort:   1,
 				DstPort:   2,
-				Seq:       1010,
-				BaseLayer: layers.BaseLayer{Payload: []byte{10, 11, 12, 13, 14}},
+				Seq:       1007,
+				BaseLayer: layers.BaseLayer{Payload: []byte{7, 8, 9, 10, 11, 12, 13, 14}},
 			},
 			want: []Reassembly{},
 		},


### PR DESCRIPTION
Like in case 3, `start` or `end` of a tcp segment may match with an existing (`cur`) segment's boundaries , but still be contained in that `cur` segment. Therefore, it should match case 6.