### PR TITLE
fix dns parse error: rr.data could be nil

### DIFF
--- a/layers/dns.go
+++ b/layers/dns.go
@@ -720,8 +720,10 @@ func (rr *DNSResourceRecord) decode(data []byte, offset int, df gopacket.DecodeF
 	}
 	rr.Data = data[endq+10 : end]
 
-	if err = rr.decodeRData(data[:end], endq+10, buffer); err != nil {
-		return 0, err
+	if rr.DataLength > 0 {
+		if err = rr.decodeRData(data[:end], endq+10, buffer); err != nil {
+			return 0, err
+		}
 	}
 
 	return endq + 10 + int(rr.DataLength), nil


### PR DESCRIPTION
In my case, I found that payload
```
name: a.com
type: CNAME
class: 254(QCLASS None)   # [RFC 2136]
ttl: 0
data-length: 0
data: nil
```
it will report a error `errDNSNameOffsetTooHigh` in v1.1.19, and it will regard the next RR's name as this RR's CNAME value in v1.1.18.