### PR TITLE
fix getting route method, and fix constructer implements

### DIFF
--- a/.travis.script.sh
+++ b/.travis.script.sh
@@ -6,5 +6,6 @@ go test github.com/google/gopacket
 go test github.com/google/gopacket/layers
 go test github.com/google/gopacket/tcpassembly
 go test github.com/google/gopacket/reassembly
-go test github.com/google/gopacket/pcapgo 
+go test github.com/google/gopacket/pcapgo
 go test github.com/google/gopacket/pcap
+go test github.com/google/gopacket/routing

--- a/.travis.script.sh
+++ b/.travis.script.sh
@@ -8,4 +8,4 @@ go test github.com/google/gopacket/tcpassembly
 go test github.com/google/gopacket/reassembly
 go test github.com/google/gopacket/pcapgo
 go test github.com/google/gopacket/pcap
-go test github.com/google/gopacket/routing
+sudo go test github.com/google/gopacket/routing

--- a/.travis.script.sh
+++ b/.travis.script.sh
@@ -8,4 +8,4 @@ go test github.com/google/gopacket/tcpassembly
 go test github.com/google/gopacket/reassembly
 go test github.com/google/gopacket/pcapgo
 go test github.com/google/gopacket/pcap
-sudo go test github.com/google/gopacket/routing
+sudo $(which go) test github.com/google/gopacket/routing

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,9 @@ module github.com/google/gopacket
 go 1.12
 
 require (
+	github.com/vishvananda/netlink v1.1.0
+	github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859
-	golang.org/x/sys v0.0.0-20190412213103-97732733099d
+	golang.org/x/sys v0.0.0-20200217220822-9197077df867
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,8 @@
+github.com/vishvananda/netlink v1.1.0 h1:1iyaYNBLmP6L0220aDnYQpo1QEV4t4hJ+xEEhhJH8j0=
+github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
+github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
+github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f h1:p4VB7kIXpOQvVn1ZaTIVp+3vuYAXFe3OJEvjbUYJLaA=
+github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b h1:Wh+f8QHJXR411sJR8/vRBTZ7YapZaRvUcLFFJhusH0k=
@@ -13,6 +18,9 @@ golang.org/x/sys v0.0.0-20190405154228-4b34438f7a67 h1:1Fzlr8kkDLQwqMP8GxrhptBLq
 golang.org/x/sys v0.0.0-20190405154228-4b34438f7a67/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190606203320-7fc4e5ec1444/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200217220822-9197077df867 h1:JoRuNIf+rpHl+VhScRQQvzbHed86tKkqwPMV34T8myw=
+golang.org/x/sys v0.0.0-20200217220822-9197077df867/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7 h1:EBZoQjiKKPaLbPrbpssUfuHtwM6KV/vb4U85g/cigFY=
 golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=

--- a/routing/routing_test.go
+++ b/routing/routing_test.go
@@ -1,0 +1,277 @@
+package routing
+
+import (
+	"fmt"
+	"net"
+	"testing"
+)
+
+func TestPrivateRoute(t *testing.T) {
+	tests := []struct {
+		name                          string
+		router                        router
+		routes                        routeSlice
+		input                         net.HardwareAddr
+		src, dst                      net.IP
+		wantIface                     int
+		wantGateway, wantPreferredSrc net.IP
+		wantErr                       error
+	}{
+		{
+			name: "only static routes",
+			router: router{
+				ifaces: map[int]*net.Interface{
+					1: {
+						Index:        1,
+						MTU:          1500,
+						Name:         "eth0",
+						HardwareAddr: net.HardwareAddr{0x54, 0x52, 0x00, 0x00, 0x00, 0x01},
+						Flags:        net.FlagUp,
+					},
+					2: {
+						Index:        2,
+						MTU:          1500,
+						Name:         "eth1",
+						HardwareAddr: net.HardwareAddr{0x54, 0x52, 0x00, 0x00, 0x00, 0x02},
+						Flags:        net.FlagUp,
+					},
+				},
+				addrs: map[int]ipAddrs{
+					1: {
+						v4: net.ParseIP("192.168.10.1/24"),
+					},
+					2: {
+						v4: net.ParseIP("192.168.20.1/24"),
+					},
+				},
+			},
+			routes: []*rtInfo{
+				{
+					Dst: &net.IPNet{
+						IP:   net.ParseIP("192.168.10.0"),
+						Mask: net.IPv4Mask(255, 255, 255, 0),
+					},
+					PrefSrc:     net.ParseIP("192.168.10.1"),
+					OutputIface: 1,
+				},
+				{
+					Dst: &net.IPNet{
+						IP:   net.ParseIP("192.168.20.0"),
+						Mask: net.IPv4Mask(255, 255, 255, 0),
+					},
+					PrefSrc:     net.ParseIP("192.168.20.1"),
+					OutputIface: 2,
+				},
+			},
+			input:            net.HardwareAddr{0x54, 0x52, 0x00, 0x00, 0x00, 0x01},
+			src:              net.ParseIP("192.168.10.1"),
+			dst:              net.ParseIP("192.168.20.1"),
+			wantIface:        2,
+			wantGateway:      nil,
+			wantPreferredSrc: net.ParseIP("192.168.20.1"),
+			wantErr:          nil,
+		},
+		{
+			name: "not exists route with default gateway",
+			router: router{
+				ifaces: map[int]*net.Interface{
+					1: {
+						Index:        1,
+						MTU:          1500,
+						Name:         "eth0",
+						HardwareAddr: net.HardwareAddr{0x54, 0x52, 0x00, 0x00, 0x00, 0x01},
+						Flags:        net.FlagUp,
+					},
+					2: {
+						Index:        2,
+						MTU:          1500,
+						Name:         "eth1",
+						HardwareAddr: net.HardwareAddr{0x54, 0x52, 0x00, 0x00, 0x00, 0x02},
+						Flags:        net.FlagUp,
+					},
+				},
+				addrs: map[int]ipAddrs{
+					1: {
+						v4: net.ParseIP("192.168.10.1/24"),
+					},
+					2: {
+						v4: net.ParseIP("192.168.20.1/24"),
+					},
+				},
+			},
+			routes: []*rtInfo{
+				{
+					Gateway:     net.ParseIP("192.168.20.254"),
+					PrefSrc:     net.ParseIP("192.168.20.1"),
+					OutputIface: 2,
+				},
+				{
+					Dst: &net.IPNet{
+						IP:   net.ParseIP("192.168.10.0"),
+						Mask: net.IPv4Mask(255, 255, 255, 0),
+					},
+					PrefSrc:     net.ParseIP("192.168.10.1"),
+					OutputIface: 1,
+				},
+				{
+					Dst: &net.IPNet{
+						IP:   net.ParseIP("192.168.20.0"),
+						Mask: net.IPv4Mask(255, 255, 255, 0),
+					},
+					PrefSrc:     net.ParseIP("192.168.20.1"),
+					OutputIface: 2,
+				},
+			},
+			input:            net.HardwareAddr{0x54, 0x52, 0x00, 0x00, 0x00, 0x01},
+			src:              net.ParseIP("192.168.10.1"),
+			dst:              net.ParseIP("192.168.30.2"),
+			wantIface:        2,
+			wantGateway:      net.ParseIP("192.168.20.254"),
+			wantPreferredSrc: net.ParseIP("192.168.20.1"),
+			wantErr:          nil,
+		},
+		{
+			name: "exists route with default gateway",
+			router: router{
+				ifaces: map[int]*net.Interface{
+					1: {
+						Index:        1,
+						MTU:          1500,
+						Name:         "eth0",
+						HardwareAddr: net.HardwareAddr{0x54, 0x52, 0x00, 0x00, 0x00, 0x01},
+						Flags:        net.FlagUp,
+					},
+					2: {
+						Index:        2,
+						MTU:          1500,
+						Name:         "eth1",
+						HardwareAddr: net.HardwareAddr{0x54, 0x52, 0x00, 0x00, 0x00, 0x02},
+						Flags:        net.FlagUp,
+					},
+				},
+				addrs: map[int]ipAddrs{
+					1: {
+						v4: net.ParseIP("192.168.10.1/24"),
+					},
+					2: {
+						v4: net.ParseIP("192.168.20.1/24"),
+					},
+				},
+			},
+			routes: []*rtInfo{
+				{
+					Gateway:     net.ParseIP("192.168.20.254"),
+					PrefSrc:     net.ParseIP("192.168.20.1"),
+					OutputIface: 2,
+				},
+				{
+					Dst: &net.IPNet{
+						IP:   net.ParseIP("192.168.10.0"),
+						Mask: net.IPv4Mask(255, 255, 255, 0),
+					},
+					PrefSrc:     net.ParseIP("192.168.10.1"),
+					OutputIface: 1,
+				},
+				{
+					Dst: &net.IPNet{
+						IP:   net.ParseIP("192.168.20.0"),
+						Mask: net.IPv4Mask(255, 255, 255, 0),
+					},
+					PrefSrc:     net.ParseIP("192.168.20.1"),
+					OutputIface: 2,
+				},
+			},
+			input:            net.HardwareAddr{0x54, 0x52, 0x00, 0x00, 0x00, 0x01},
+			src:              net.ParseIP("192.168.10.1"),
+			dst:              net.ParseIP("192.168.20.2"),
+			wantIface:        2,
+			wantGateway:      nil,
+			wantPreferredSrc: net.ParseIP("192.168.20.1"),
+			wantErr:          nil,
+		},
+		{
+			name: "not exists route without default gateway",
+			router: router{
+				ifaces: map[int]*net.Interface{
+					1: {
+						Index:        1,
+						MTU:          1500,
+						Name:         "eth0",
+						HardwareAddr: net.HardwareAddr{0x54, 0x52, 0x00, 0x00, 0x00, 0x01},
+						Flags:        net.FlagUp,
+					},
+					2: {
+						Index:        2,
+						MTU:          1500,
+						Name:         "eth1",
+						HardwareAddr: net.HardwareAddr{0x54, 0x52, 0x00, 0x00, 0x00, 0x02},
+						Flags:        net.FlagUp,
+					},
+				},
+				addrs: map[int]ipAddrs{
+					1: {
+						v4: net.ParseIP("192.168.10.1/24"),
+					},
+					2: {
+						v4: net.ParseIP("192.168.20.1/24"),
+					},
+				},
+			},
+			routes: []*rtInfo{
+				{
+					Dst: &net.IPNet{
+						IP:   net.ParseIP("192.168.10.0"),
+						Mask: net.IPv4Mask(255, 255, 255, 0),
+					},
+					PrefSrc:     net.ParseIP("192.168.10.1"),
+					OutputIface: 1,
+				},
+				{
+					Dst: &net.IPNet{
+						IP:   net.ParseIP("192.168.20.0"),
+						Mask: net.IPv4Mask(255, 255, 255, 0),
+					},
+					PrefSrc:     net.ParseIP("192.168.20.1"),
+					OutputIface: 2,
+				},
+			},
+			input:            net.HardwareAddr{0x54, 0x52, 0x00, 0x00, 0x00, 0x01},
+			src:              net.ParseIP("192.168.10.1"),
+			dst:              net.ParseIP("192.168.30.2"),
+			wantIface:        2,
+			wantGateway:      nil,
+			wantPreferredSrc: nil,
+			wantErr:          fmt.Errorf("no route found for 192.168.30.2"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			iface, gateway, preferredSrc, err := tt.router.route(tt.routes, tt.input, tt.src, tt.dst)
+			if tt.wantErr != nil {
+				if err != nil && tt.wantErr.Error() == err.Error() {
+					return
+				}
+				t.Errorf("route() illegal return value `err`:\ngot	:%#v\n\nwant:	%#v\n\n", err, tt.wantErr)
+
+			}
+			if err != nil {
+				t.Errorf("route() illegal return value `err`:\ngot	:%#v\n\nwant:	nil\n\n", err)
+			}
+
+			if tt.wantIface != iface {
+				t.Errorf("route() illegal return value `iface`:\ngot	:%d\n\nwant:	%d\n\n", iface, tt.wantIface)
+			}
+
+			if !tt.wantGateway.Equal(gateway) {
+				t.Errorf("route() illegal return value `gateway`:\ngot	:%#v\n\nwant	:%#v\n\n", gateway, tt.wantGateway)
+			}
+
+			if !tt.wantPreferredSrc.Equal(preferredSrc) {
+				t.Errorf("route() illegal return value `preferredSrc`:\ngot	:%#v\n\nwant	:%#v\n\n", preferredSrc, tt.wantPreferredSrc)
+			}
+
+		})
+	}
+
+}


### PR DESCRIPTION
Please excuse my poor English.

### fix route method in `routing/routing.go`
route method always return default gateway when routing table contained default gateway.
I think default gateway if `rt.Src` and `rt.Dst` is nil.
return default gateway at last if static route is not found.
so I fixed it in [L132-L152](https://github.com/ophum/gopacket/blob/a0bf7fd45b3d65fd7c494b87eec6d57ef2cb9ef8/routing/routing.go#L132-L152)

### fix constructor implements
creating `rtr.ifaces` of `map[int]*net.Interface`  in New method. but assigned value is pointer of `for` statement 's variable.
then contents of `rtr.ifaces` is all same pointer.
so I fixed it in [L226-L227](https://github.com/ophum/gopacket/blob/a0bf7fd45b3d65fd7c494b87eec6d57ef2cb9ef8/routing/routing.go#L226-L227)
