### PR TITLE
Enhance the loopback decoder.

### DIFF
--- a/layers/enums.go
+++ b/layers/enums.go
@@ -51,6 +51,7 @@ const (
 	EthernetTypeQinQ                        EthernetType = 0x88a8
 	EthernetTypeLinkLayerDiscovery          EthernetType = 0x88cc
 	EthernetTypeEthernetCTP                 EthernetType = 0x9000
+	EthernetTypeUnspec                      EthernetType = 0xffff
 )
 
 // IPProtocol is an enumeration of IP protocol values, and acts as a decoder
@@ -192,6 +193,9 @@ const (
 type ProtocolFamily uint8
 
 const (
+	// PF_UNSPEC is 0 in socket.h
+	ProtocolFamilyUnspec ProtocolFamily = 0
+
 	ProtocolFamilyIPv4 ProtocolFamily = 2
 	// BSDs use different values for INET6... glory be.  These values taken from
 	// tcpdump 4.3.0.

--- a/layers/loopback.go
+++ b/layers/loopback.go
@@ -9,7 +9,7 @@ package layers
 import (
 	"encoding/binary"
 	"errors"
-	"fmt"
+	"math/bits"
 
 	"github.com/google/gopacket"
 )
@@ -19,7 +19,8 @@ import (
 // and DLT_LOOP, respectively).
 type Loopback struct {
 	BaseLayer
-	Family ProtocolFamily
+	EthType EthernetType
+	Family  ProtocolFamily
 }
 
 // LayerType returns LayerTypeLoopback.
@@ -31,21 +32,38 @@ func (l *Loopback) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) erro
 		return errors.New("Loopback packet too small")
 	}
 
-	// The protocol could be either big-endian or little-endian, we're
-	// not sure.  But we're PRETTY sure that the value is less than
-	// 256, so we can check the first two bytes.
-	var prot uint32
-	if data[0] == 0 && data[1] == 0 {
-		prot = binary.BigEndian.Uint32(data[:4])
-	} else {
-		prot = binary.LittleEndian.Uint32(data[:4])
-	}
-	if prot > 0xFF {
-		return fmt.Errorf("Invalid loopback protocol %q", data[:4])
+	// Please refer to epan/dissectors/packet-null.c and wiretap/wtap.h of Wireshark
+	// project to get more details.
+
+	if binary.BigEndian.Uint16(data) == 0xFF03 {
+		l.EthType = EthernetTypePPP
+		l.Family = ProtocolFamilyUnspec
+		l.BaseLayer = BaseLayer{data[:4], data[4:]}
+		return nil
 	}
 
-	l.Family = ProtocolFamily(prot)
+	nullHeader := binary.BigEndian.Uint32(data)
+	if nullHeader&0xFFFF0000 != 0 {
+		if nullHeader&0xFF000000 == 0 && nullHeader&0x00FF0000 < 0x00060000 {
+			nullHeader >>= 16
+		} else {
+			nullHeader = bits.ReverseBytes32(nullHeader)
+		}
+	} else {
+		if nullHeader&0x000000FF == 0 && nullHeader&0x0000FF00 < 0x00000600 {
+			nullHeader = uint32(bits.ReverseBytes16(uint16(nullHeader & 0xFFFF)))
+		}
+	}
+
+	if nullHeader > uint32(FrameMaxLenIEEE8023) {
+		l.EthType = EthernetType(nullHeader)
+		l.Family = ProtocolFamilyUnspec
+	} else {
+		l.EthType = EthernetTypeUnspec
+		l.Family = ProtocolFamily(nullHeader)
+	}
 	l.BaseLayer = BaseLayer{data[:4], data[4:]}
+
 	return nil
 }
 
@@ -56,7 +74,10 @@ func (l *Loopback) CanDecode() gopacket.LayerClass {
 
 // NextLayerType returns the layer type contained by this DecodingLayer.
 func (l *Loopback) NextLayerType() gopacket.LayerType {
-	return l.Family.LayerType()
+	if l.Family != ProtocolFamilyUnspec {
+		return l.Family.LayerType()
+	}
+	return l.EthType.LayerType()
 }
 
 // SerializeTo writes the serialized form of this layer into the
@@ -66,7 +87,11 @@ func (l *Loopback) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.Seriali
 	if err != nil {
 		return err
 	}
-	binary.LittleEndian.PutUint32(bytes, uint32(l.Family))
+	if l.Family != ProtocolFamilyUnspec {
+		binary.LittleEndian.PutUint32(bytes, uint32(l.Family))
+	} else {
+		binary.LittleEndian.PutUint32(bytes, uint32(l.EthType))
+	}
 	return nil
 }
 
@@ -76,5 +101,8 @@ func decodeLoopback(data []byte, p gopacket.PacketBuilder) error {
 		return err
 	}
 	p.AddLayer(&l)
-	return p.NextDecoder(l.Family)
+	if l.Family != ProtocolFamilyUnspec {
+		return p.NextDecoder(l.Family)
+	}
+	return p.NextDecoder(l.EthType)
 }


### PR DESCRIPTION
Current LayerTypeLoopback decoder will report an error (Invalid loopback protocol) when decoding below packet, but Wireshark won't.
```
0000   00 00 08 00 45 00 00 3c de 11 40 00 40 06 6f 01
0010   0a 86 e6 7d 40 e9 bb bc b6 b1 14 6c 15 fb 92 c4
0020   00 00 00 00 a0 02 ff ff 99 f0 00 00 02 04 05 64
0030   04 02 08 0a 00 03 4c d5 00 00 00 00 01 03 03 08

// Wireshark's output
Frame 4: 68 bytes on wire (544 bits), 68 bytes captured (544 bits)
Null/Loopback
    Type: IPv4 (0x0800)
Internet Protocol Version 4, Src: 157.7.156.154 (157.7.156.154), Dst: 10.134.230.125 (10.134.230.125)
Transmission Control Protocol, Src Port: 443, Dst Port: 60638, Seq: 4154896977, Ack: 728289851, Len: 0
```
Some older version of libpcap use ethernet type (here is 0x0800) to fill in the header instead of the PF_* protocol family. Please refer to wiretap/wtap.h of Wireshark source for more details.
```
 * WTAP_ENCAP_NULL corresponds to DLT_NULL from "libpcap".  This
 * corresponds to
 *
 *  1) PPP-over-HDLC encapsulation, at least with some versions
 *     of ISDN4BSD (but not the current ones, it appears, unless
 *     I've missed something);
 *
 *  2) a 4-byte header containing the AF_ address family, in
 *     the byte order of the machine that saved the capture,
 *     for the packet, as used on many BSD systems for the
 *     loopback device and some other devices, or a 4-byte header
 *     containing the AF_ address family in network byte order,
 *     as used on recent OpenBSD systems for the loopback device;
 *
 *  3) a 4-byte header containing 2 octets of 0 and an Ethernet
 *     type in the byte order from an Ethernet header, that being
 *     what older versions of "libpcap" on Linux turn the Ethernet
 *     header for loopback interfaces into (0.6.0 and later versions
 *     leave the Ethernet header alone and make it DLT_EN10MB).
```
This PR refers to the Wireshark's "null" decoder (epan/dissectors/packet-null.c) and is translated into golang code.