### PR TITLE
Fix reassembly pages allocation/shrinking (second attempt)

### DIFF
--- a/reassembly/tcpassembly.go
+++ b/reassembly/tcpassembly.go
@@ -594,7 +594,7 @@ func NewAssembler(pool *StreamPool) *Assembler {
 // Dump returns a short string describing the page usage of the Assembler
 func (a *Assembler) Dump() string {
 	s := ""
-	s += fmt.Sprintf("pageCache: used: %d, size: %d, free: %d", a.pc.used, a.pc.size, len(a.pc.free))
+	s += fmt.Sprintf("pageCache: used: %d:", a.pc.used)
 	return s
 }
 

--- a/reassembly/tcpassembly_test.go
+++ b/reassembly/tcpassembly_test.go
@@ -125,6 +125,7 @@ func test(t *testing.T, s []testSequence) {
 		if testDebug {
 			fmt.Printf("#### test: #%d: sending:%s\n", i, hex.EncodeToString(test.in.BaseLayer.Payload))
 		}
+		test.in.SetInternalPortsForTesting()
 		a.Assemble(netFlow, &test.in)
 		final := []Reassembly{}
 		if len(test.want) > 0 {
@@ -741,6 +742,7 @@ func testFlush(t *testing.T, s []testSequence, delay time.Duration, flushInterva
 		if port != test.in.SrcPort {
 			flow = flow.Reverse()
 		}
+		test.in.SetInternalPortsForTesting()
 		ctx := assemblerSimpleContext(gopacket.CaptureInfo{Timestamp: simTime})
 		a.AssembleWithContext(flow, &test.in, &ctx)
 		simTime = simTime.Add(delay)
@@ -1713,6 +1715,7 @@ func TestMemoryShrink(t *testing.T) {
 		Seq:       999,
 		BaseLayer: layers.BaseLayer{Payload: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 0}},
 	}
+	tcp.SetInternalPortsForTesting()
 	a := NewAssembler(NewStreamPool(&testFactoryBench{}))
 	var before runtime.MemStats
 	runtime.GC()
@@ -1762,6 +1765,7 @@ func BenchmarkSingleStreamNo(b *testing.B) {
 		Seq:       1000,
 		BaseLayer: layers.BaseLayer{Payload: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 0}},
 	}
+	t.SetInternalPortsForTesting()
 	a := NewAssembler(NewStreamPool(&testFactoryBench{}))
 	for i := 0; i < b.N; i++ {
 		a.Assemble(netFlow, &t)
@@ -1781,6 +1785,7 @@ func BenchmarkSingleStreamSkips(b *testing.B) {
 		Seq:       1000,
 		BaseLayer: layers.BaseLayer{Payload: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 0}},
 	}
+	t.SetInternalPortsForTesting()
 	a := NewAssembler(NewStreamPool(&testFactoryBench{}))
 	skipped := false
 	for i := 0; i < b.N; i++ {
@@ -1811,6 +1816,7 @@ func BenchmarkSingleStreamLoss(b *testing.B) {
 		Seq:       1000,
 		BaseLayer: layers.BaseLayer{Payload: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 0}},
 	}
+	t.SetInternalPortsForTesting()
 	a := NewAssembler(NewStreamPool(&testFactoryBench{}))
 	for i := 0; i < b.N; i++ {
 		a.Assemble(netFlow, &t)
@@ -1829,6 +1835,7 @@ func BenchmarkMultiStreamGrow(b *testing.B) {
 	a := NewAssembler(NewStreamPool(&testFactoryBench{}))
 	for i := 0; i < b.N; i++ {
 		t.SrcPort = layers.TCPPort(i)
+		t.SetInternalPortsForTesting()
 		a.Assemble(netFlow, &t)
 		t.Seq += 10
 	}
@@ -1845,6 +1852,7 @@ func BenchmarkMultiStreamConn(b *testing.B) {
 	a := NewAssembler(NewStreamPool(&testFactoryBench{}))
 	for i := 0; i < b.N; i++ {
 		t.SrcPort = layers.TCPPort(i)
+		t.SetInternalPortsForTesting()
 		a.Assemble(netFlow, &t)
 		if i%65536 == 65535 {
 			if t.SYN {
@@ -1880,6 +1888,8 @@ func TestFullyOrderedAndCompleteStreamDoesNotAlloc(t *testing.T) {
 		ACK:       true,
 		BaseLayer: layers.BaseLayer{Payload: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 0}},
 	}
+	c2s.SetInternalPortsForTesting()
+	s2c.SetInternalPortsForTesting()
 	tf := testMemoryFactory{}
 	a := NewAssembler(NewStreamPool(&tf))
 


### PR DESCRIPTION
### Previous discussions
- PR #665 - first attempt to solve this issue. Allocating pages one by one, not the most efficient but a working solution.
- Discussions in issue #732 - more solutions compared.
- https://github.com/google/gopacket/issues/732#issuecomment-768516343 - other people confirming the issue.

### Fixes
As suggested by @gconnell in https://github.com/google/gopacket/issues/732#issuecomment-584744263, I used `sync.Pool` as the backend for the `pageCache`, and performed some benchmarks comparisons, which will follow.

For measuring performance I mainly used `BenchmarkMultiStreamGrow`, because it triggers a lot of pages allocations, but there are also other similar benchmarks available. However, it is important to note, that all of these benchmarks only trigger pages allocation, and not pages free-ing (returning pages back to `pageCache`/`sync.Pool`).

Before running the benchmarks, I had to fix them and some tests which didn't initialize internal TCP fields.
See commit 07de34057091083e8a2896a75a45121243051ac1

### Benchstats and summary
```
benchstat old.benchs new.benchs
name               old time/op    new time/op    delta
MultiStreamGrow-8    1.42µs ±18%    1.71µs ± 9%  +19.91%  (p=0.000 n=10+10)

name               old alloc/op   new alloc/op   delta
MultiStreamGrow-8    2.68kB ± 3%    2.27kB ± 0%  -15.18%  (p=0.000 n=9+9)

name               old allocs/op  new allocs/op  delta
MultiStreamGrow-8      3.00 ± 0%      4.00 ± 0%  +33.33%  (p=0.000 n=10+10)
```

As it can be seen, `sync.Pool` introduces some performance loss when a lot of pages are allocated.
However, if we also trigger page free-ing we will see that performance difference becomes lower.
One of `Flush*` functions (which should also be used in long running apps) will help us triggering page free-ing, for example:
```
if i%100 == 0 {
	a.FlushAll()
}
```
Benchstat results with Flushing:
```
benchstat old.benchs new.benchs
name               old time/op    new time/op    delta
MultiStreamGrow-8    1.17µs ± 1%    1.25µs ± 1%  +6.25%  (p=0.000 n=10+9)

name               old alloc/op   new alloc/op   delta
MultiStreamGrow-8     95.4B ± 1%     94.0B ± 0%  -1.47%  (p=0.000 n=10+10)

name               old allocs/op  new allocs/op  delta
MultiStreamGrow-8      3.00 ± 0%      3.00 ± 0%    ~     (all equal)
```
So, even though this fix degrades the performance a bit, it will significantly reduce memory usage for long running apps.
Unfortunately, it is hard to showcase the benefits of this solution by a benchmark or test.

### Full benchmarks
Setup:
Intel© Core™ i5-8300H CPU @ 2.30GHz × 4
go version go1.15.7 linux/amd64

google/master (no flushing):
```
goos: linux
goarch: amd64
pkg: github.com/google/gopacket/reassembly
BenchmarkMultiStreamGrow-8   	  658582	      1683 ns/op	    3446 B/op	       3 allocs/op
BenchmarkMultiStreamGrow-8   	  840894	      1521 ns/op	    2717 B/op	       3 allocs/op
BenchmarkMultiStreamGrow-8   	  837558	      1490 ns/op	    2727 B/op	       3 allocs/op
BenchmarkMultiStreamGrow-8   	  850449	      1374 ns/op	    2687 B/op	       3 allocs/op
BenchmarkMultiStreamGrow-8   	  851846	      1359 ns/op	    2683 B/op	       3 allocs/op
BenchmarkMultiStreamGrow-8   	  845178	      1376 ns/op	    2703 B/op	       3 allocs/op
BenchmarkMultiStreamGrow-8   	  871285	      1338 ns/op	    2625 B/op	       3 allocs/op
BenchmarkMultiStreamGrow-8   	  859688	      1370 ns/op	    2659 B/op	       3 allocs/op
BenchmarkMultiStreamGrow-8   	  846808	      1373 ns/op	    2698 B/op	       3 allocs/op
BenchmarkMultiStreamGrow-8   	  877716	      1347 ns/op	    2606 B/op	       3 allocs/op
PASS
ok  	github.com/google/gopacket/reassembly	18.469s
```
google/master (with flushing):
```
goos: linux
goarch: amd64
pkg: github.com/google/gopacket/reassembly
BenchmarkMultiStreamGrow-8   	  911870	      1181 ns/op	      96 B/op	       3 allocs/op
BenchmarkMultiStreamGrow-8   	  928544	      1173 ns/op	      95 B/op	       3 allocs/op
BenchmarkMultiStreamGrow-8   	  928563	      1177 ns/op	      95 B/op	       3 allocs/op
BenchmarkMultiStreamGrow-8   	  932023	      1173 ns/op	      95 B/op	       3 allocs/op
BenchmarkMultiStreamGrow-8   	  888864	      1178 ns/op	      96 B/op	       3 allocs/op
BenchmarkMultiStreamGrow-8   	  893379	      1169 ns/op	      96 B/op	       3 allocs/op
BenchmarkMultiStreamGrow-8   	  924723	      1167 ns/op	      95 B/op	       3 allocs/op
BenchmarkMultiStreamGrow-8   	  949068	      1169 ns/op	      95 B/op	       3 allocs/op
BenchmarkMultiStreamGrow-8   	  906736	      1184 ns/op	      96 B/op	       3 allocs/op
BenchmarkMultiStreamGrow-8   	  939596	      1170 ns/op	      95 B/op	       3 allocs/op
PASS
ok  	github.com/google/gopacket/reassembly	11.009s
```
jandos/fix (no flushing):
```
goos: linux
goarch: amd64
pkg: github.com/google/gopacket/reassembly
BenchmarkMultiStreamGrow-8   	  584973	      1855 ns/op	    2296 B/op	       4 allocs/op
BenchmarkMultiStreamGrow-8   	  723315	      1865 ns/op	    2265 B/op	       4 allocs/op
BenchmarkMultiStreamGrow-8   	  687723	      1610 ns/op	    2271 B/op	       4 allocs/op
BenchmarkMultiStreamGrow-8   	  681864	      1615 ns/op	    2273 B/op	       4 allocs/op
BenchmarkMultiStreamGrow-8   	  689079	      1653 ns/op	    2271 B/op	       4 allocs/op
BenchmarkMultiStreamGrow-8   	  700023	      1674 ns/op	    2269 B/op	       4 allocs/op
BenchmarkMultiStreamGrow-8   	  690376	      1667 ns/op	    2271 B/op	       4 allocs/op
BenchmarkMultiStreamGrow-8   	  660092	      1795 ns/op	    2277 B/op	       4 allocs/op
BenchmarkMultiStreamGrow-8   	  677284	      1664 ns/op	    2274 B/op	       4 allocs/op
BenchmarkMultiStreamGrow-8   	  671883	      1667 ns/op	    2275 B/op	       4 allocs/op
PASS
ok  	github.com/google/gopacket/reassembly	23.748s
```
jandos/fix (with flushing):
```
goos: linux
goarch: amd64
pkg: github.com/google/gopacket/reassembly
BenchmarkMultiStreamGrow-8   	  954180	      1260 ns/op	      94 B/op	       3 allocs/op
BenchmarkMultiStreamGrow-8   	  977046	      1249 ns/op	      94 B/op	       3 allocs/op
BenchmarkMultiStreamGrow-8   	  961699	      1243 ns/op	      94 B/op	       3 allocs/op
BenchmarkMultiStreamGrow-8   	  975854	      1245 ns/op	      94 B/op	       3 allocs/op
BenchmarkMultiStreamGrow-8   	  981787	      1309 ns/op	      94 B/op	       3 allocs/op
BenchmarkMultiStreamGrow-8   	  993898	      1246 ns/op	      94 B/op	       3 allocs/op
BenchmarkMultiStreamGrow-8   	  984214	      1243 ns/op	      94 B/op	       3 allocs/op
BenchmarkMultiStreamGrow-8   	  980049	      1243 ns/op	      94 B/op	       3 allocs/op
BenchmarkMultiStreamGrow-8   	  971522	      1243 ns/op	      94 B/op	       3 allocs/op
BenchmarkMultiStreamGrow-8   	  947020	      1255 ns/op	      94 B/op	       3 allocs/op
PASS
ok  	github.com/google/gopacket/reassembly	13.186s
```