### PR TITLE
Fix pointer error in for loop

### DIFF
--- a/routing/routing.go
+++ b/routing/routing.go
@@ -215,7 +215,8 @@ loop:
 		return nil, err
 	}
 	for _, iface := range ifaces {
-		rtr.ifaces[iface.Index] = &iface
+		t := iface
+		rtr.ifaces[iface.Index] = &t
 		var addrs ipAddrs
 		ifaceAddrs, err := iface.Addrs()
 		if err != nil {


### PR DESCRIPTION
All addresses of loop variable are the same. So it's always return the wrong route if the MAC is provided.