### PR TITLE
New fasthash that is collision free for all but IPv6/MAC.

### DIFF
--- a/flows.go
+++ b/flows.go
@@ -159,15 +159,10 @@ func FlowFromEndpoints(src, dst Endpoint) (_ Flow, err error) {
 // code revisions, so should not be used to key values in persistent storage.
 func (f Flow) FastHash() (a uint64) {
 	var b uint64
-	var addrlen int
-	if f.slen > f.dlen {
-		addrlen = f.slen
-	} else {
-		addrlen = f.dlen
-	}
-	for i := 0; i < addrlen; i++ {
-		a ^= uint64(f.src[i]) << (16 * (uint(i) % 4))
-		b ^= uint64(f.dst[i]) << (16 * (uint(i) % 4))
+
+	for i := 0; i < f.slen; i++ {
+		a ^= uint64(f.src[f.slen-1-i]) << (16 * (uint(i) % 4))
+		b ^= uint64(f.dst[f.slen-1-i]) << (16 * (uint(i) % 4))
 	}
 	if a > b {
 		a += (b << 8)

--- a/flows.go
+++ b/flows.go
@@ -64,7 +64,7 @@ func (a Endpoint) LessThan(b Endpoint) bool {
 // code revisions, so should not be used to key values in persistent storage.
 func (a Endpoint) FastHash() (h uint64) {
 	for i := 0; i < a.len; i++ {
-		h ^= uint64(a.raw[i]) << (8 * (uint(i) % 8))
+		h ^= uint64(a.raw[a.len-1-i]) << (8 * (uint(i) % 8))
 	}
 	return
 }

--- a/flows.go
+++ b/flows.go
@@ -159,7 +159,13 @@ func FlowFromEndpoints(src, dst Endpoint) (_ Flow, err error) {
 // code revisions, so should not be used to key values in persistent storage.
 func (f Flow) FastHash() (a uint64) {
 	var b uint64
-	for i := 0; i < f.slen; i++ {
+	var addrlen int
+	if f.slen > f.dlen {
+		addrlen = f.slen
+	} else {
+		addrlen = f.dlen
+	}
+	for i := 0; i < addrlen; i++ {
 		a ^= uint64(f.src[i]) << (8 * (uint(i) % 4))
 		b ^= uint64(f.dst[i]) << (8 * (uint(i) % 4))
 	}

--- a/flows.go
+++ b/flows.go
@@ -166,14 +166,14 @@ func (f Flow) FastHash() (a uint64) {
 		addrlen = f.dlen
 	}
 	for i := 0; i < addrlen; i++ {
-		a ^= uint64(f.src[i]) << (8 * (uint(i) % 4))
-		b ^= uint64(f.dst[i]) << (8 * (uint(i) % 4))
+		a ^= uint64(f.src[i]) << (16 * (uint(i) % 4))
+		b ^= uint64(f.dst[i]) << (16 * (uint(i) % 4))
 	}
 	if a > b {
-		a += (b << 32)
+		a += (b << 8)
 		return
 	}
-	a = b + (a << 32)
+	a = b + (a << 8)
 	return
 }
 


### PR DESCRIPTION
Addresses #860.

The exiting FNV algorithm used by the FastHash methods is a very fast but has poor diffusion. This is especially apparent when dealing with Layer 4 Flows that use 2-byte ports. Writing a crude brute forcer, I was finding approximately 5.5K collisions for each port pair.

Given that FastHash returns a `uint64` and the vast majority endpoints have 32-bits or less addresses, a more direct mapping can produce collision free hashes. One way to do this is breaking the address into `uint`s and xoring them together. For Endpoint's FastHash this is done with `uin64`s. For Flow's FashHash this is done to each address with `uint32`s which as then concatenated together in an order independent way. 

