### PR TITLE
add GetIPV4Routes,GetIPV6Routes function

### DIFF
--- a/routing/common.go
+++ b/routing/common.go
@@ -33,4 +33,10 @@ type Router interface {
 	// information.  Either or both of input/src can be nil.  If both are, this
 	// should behave exactly like Route(dst)
 	RouteWithSrc(input net.HardwareAddr, src, dst net.IP) (iface *net.Interface, gateway, preferredSrc net.IP, err error)
+
+	//GetIPV4Route return kernel's ipv4 routing table
+	GetIPV4Routes() (v4 routeSlice)
+
+	//GetIPV6Route return kernel's ipv6 routing table
+	GetIPV6Routes() (v6 routeSlice)
 }

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -71,13 +71,23 @@ type router struct {
 	v4, v6 routeSlice
 }
 
+//GetIPV4Route return ipv4 kernel's routing table
+func (r *router) GetIPV4Routes() (v4 routeSlice) {
+	return r.v4
+}
+
+//GetIPV6Route return ipv4 kernel's routing table
+func (r *router) GetIPV6Routes() (v6 routeSlice) {
+	return r.v6
+}
+
 func (r *router) String() string {
 	strs := []string{"ROUTER", "--- V4 ---"}
-	for _, route := range r.v4 {
+	for _, route := range r.GetIPV4Routes() {
 		strs = append(strs, fmt.Sprintf("%+v", *route))
 	}
 	strs = append(strs, "--- V6 ---")
-	for _, route := range r.v6 {
+	for _, route := range r.GetIPV6Routes() {
 		strs = append(strs, fmt.Sprintf("%+v", *route))
 	}
 	return strings.Join(strs, "\n")


### PR DESCRIPTION
Currently, after `routing.New()`, the **v4,v6 routing table info** is only used for `String()` or internal use.
It makes sense to increase the interface to obtain ipv4 and ipv6 routing table information separately.

For example, I use it to compare whether the ip segment is in the corresponding routing table.