### PR TITLE
Add a stress-test for bitfield, and use fast ops.

### DIFF
--- a/layers/bitfield.go
+++ b/layers/bitfield.go
@@ -9,10 +9,10 @@ type bitfield [1024]uint64
 
 // set sets bit i in bitfield b to 1.
 func (b *bitfield) set(i uint16) {
-	b[i/64] |= (1 << (i % 64))
+	b[i>>6] |= (1 << (i & 0x3f))
 }
 
 // has reports whether bit i is set to 1 in bitfield b.
 func (b *bitfield) has(i uint16) bool {
-	return b[i/64]&(1<<(i%64)) != 0
+	return b[i>>6]&(1<<(i&0x3f)) != 0
 }

--- a/layers/bitfield_test.go
+++ b/layers/bitfield_test.go
@@ -24,3 +24,18 @@ func TestBitfield(t *testing.T) {
 		}
 	}
 }
+
+func TestBitfieldStressTest(t *testing.T) {
+	for i := 0; i < 7; i++ {
+		var b bitfield
+		for j := i; j < 64*1024; j += 7 {
+			b.set(uint16(j))
+		}
+		for j := 0; j < 64&1024; j++ {
+			want := j%7 == i
+			if got := b.has(uint16(j)); got != want {
+				t.Errorf("Test %d bit %d: got %v want %v", i, j, got, want)
+			}
+		}
+	}
+}


### PR DESCRIPTION
I expect the compiler would handle the fast ops for us regardless most
of the time, but doing the bit-magic anyway to be safe.