### PR TITLE
DNS Type & Class: boundary check is added

### DIFF
--- a/layers/dns.go
+++ b/layers/dns.go
@@ -639,6 +639,10 @@ func (q *DNSQuestion) decode(data []byte, offset int, df gopacket.DecodeFeedback
 		return 0, err
 	}
 
+	if len(data)-endq < 4 {
+		return 0, errDNSTypeClassHasNoData
+	}
+
 	q.Name = name
 	q.Type = DNSType(binary.BigEndian.Uint16(data[endq : endq+2]))
 	q.Class = DNSClass(binary.BigEndian.Uint16(data[endq+2 : endq+4]))
@@ -1088,6 +1092,7 @@ var (
 	errDNSPointerOffsetTooHigh = errors.New("dns offset pointer too high")
 	errDNSIndexOutOfRange      = errors.New("dns index walked out of range")
 	errDNSNameHasNoData        = errors.New("no dns data found for name")
+	errDNSTypeClassHasNoData   = errors.New("dns type nor class data is missed")
 
 	errCharStringMissData = errors.New("Insufficient data for a <character-string>")
 


### PR DESCRIPTION
Signed-off-by: Eugene Bolshakov <pub@relvarsoft.com>

This PR fixes the following panic problem when abnormal DNS packet is received from the Internet:
```   panic: runtime error: slice bounds out of range [:15] with capacity 14
   goroutine 1 [running]:
     github.com/google/gopacket/layers.(*DNSQuestion).decode(0xc00007f7c8, 0xc000306040, 0xe, 0xe, 0xc, 0x1a478d70068, 0xc00030a000, 0xc00030c0a8, 0x1495f00, 0x0, ...)
       go/pkg/mod/github.com/google/gopacket@v1.1.19/layers/dns.go:643 +0x19a
     github.com/google/gopacket/layers.(*DNS).DecodeFromBytes(0xc00030c000, 0xc000306040, 0xe, 0xe, 0x1a478d70068, 0xc00030a000, 0x0, 0xbb5089)
       go/pkg/mod/github.com/google/gopacket@v1.1.19/layers/dns.go:338 +0x225
```