### PR TITLE
Remove the fmt.Println call in DecodeFromBytes of GTPv1U

### DIFF
--- a/layers/gtp.go
+++ b/layers/gtp.go
@@ -87,7 +87,6 @@ func (g *GTPv1U) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error 
 				// extensionLength is in 4-octet units
 				lIndex := cIndex + (uint16(extensionLength) * 4)
 				if uint16(dLen) < lIndex {
-					fmt.Println(dLen, lIndex)
 					return fmt.Errorf("GTP packet with small extension header: %d bytes", dLen)
 				}
 				content := data[cIndex+1 : lIndex-1]


### PR DESCRIPTION
The fmt.Println should not be used in the library for debugging purpose. The returned error already contains the information of the failure.