### PR TITLE
udp: Encode 0 checksums as 0xFFFF

### DIFF
--- a/layers/udp.go
+++ b/layers/udp.go
@@ -89,6 +89,12 @@ func (u *UDP) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeOpt
 		if err != nil {
 			return err
 		}
+		// RFC768: If the computed checksum is zero, it is transmitted as all ones (the
+		// equivalent in one's complement arithmetic). An all zero transmitted
+		// checksum  value means that the transmitter generated no checksum.
+		if csum == 0 {
+			csum = 0xFFFF
+		}
 		u.Checksum = csum
 	}
 	binary.BigEndian.PutUint16(bytes[6:], u.Checksum)


### PR DESCRIPTION
RFC768 states:

    If the computed checksum is zero, it is transmitted as all ones (the
    equivalent in one's complement arithmetic). An all zero transmitted
    checksum  value means that the transmitter generated no checksum.

Updated the serialization logic to correctly handle this. It isn't a big
problem for IPv4 where checksums are optional, but affects IPv6 which
has mandatory UDP checksums.