### PR TITLE
all: remove unnecessary string([]byte) conversion in fmt.Sprintf yet %s

### DIFF
--- a/layers/dhcpv4.go
+++ b/layers/dhcpv4.go
@@ -493,7 +493,7 @@ func (o DHCPOption) String() string {
 	case DHCPOptHostname, DHCPOptMeritDumpFile, DHCPOptDomainName, DHCPOptRootPath,
 		DHCPOptExtensionsPath, DHCPOptNISDomain, DHCPOptNetBIOSTCPScope, DHCPOptXFontServer,
 		DHCPOptXDisplayManager, DHCPOptMessage, DHCPOptDomainSearch: // string
-		return fmt.Sprintf("Option(%s:%s)", o.Type, string(o.Data))
+		return fmt.Sprintf("Option(%s:%s)", o.Type, o.Data)
 
 	case DHCPOptMessageType:
 		if len(o.Data) != 1 {

--- a/layers/dns.go
+++ b/layers/dns.go
@@ -833,7 +833,7 @@ func (rr *DNSResourceRecord) String() string {
 		return "OPT " + strings.Join(opts, ",")
 	}
 	if rr.Type == DNSTypeURI {
-		return fmt.Sprintf("URI %d %d %s", rr.URI.Priority, rr.URI.Weight, string(rr.URI.Target))
+		return fmt.Sprintf("URI %d %d %s", rr.URI.Priority, rr.URI.Weight, rr.URI.Target)
 	}
 	if rr.Class == DNSClassIN {
 		switch rr.Type {

--- a/layers/dot11.go
+++ b/layers/dot11.go
@@ -1490,7 +1490,7 @@ func (m *Dot11InformationElement) DecodeFromBytes(data []byte, df gopacket.Decod
 
 func (d *Dot11InformationElement) String() string {
 	if d.ID == 0 {
-		return fmt.Sprintf("802.11 Information Element (ID: %v, Length: %v, SSID: %v)", d.ID, d.Length, string(d.Info))
+		return fmt.Sprintf("802.11 Information Element (ID: %v, Length: %v, SSID: %s)", d.ID, d.Length, d.Info)
 	} else if d.ID == 1 {
 		rates := ""
 		for i := 0; i < len(d.Info); i++ {

--- a/layers/sip.go
+++ b/layers/sip.go
@@ -392,7 +392,7 @@ func (s *SIP) ParseHeader(header []byte) (err error) {
 	if header[0] == '\t' || header[0] == ' ' {
 
 		header = bytes.TrimSpace(header)
-		s.Headers[s.lastHeaderParsed][len(s.Headers[s.lastHeaderParsed])-1] += fmt.Sprintf(" %s", string(header))
+		s.Headers[s.lastHeaderParsed][len(s.Headers[s.lastHeaderParsed])-1] += fmt.Sprintf(" %s", header)
 		return
 	}
 


### PR DESCRIPTION
Noticed from Orijtech's continuous benchmarking product "Bencher" per

https://dashboard.github.orijtech.com/benchmark/3245b8e4bbbd44a597480319aaa4b9fe

that there is a bunch of code in the wild that invokes:

    fmt.Sprintf("%s", string([]byte(...)))

yet the "%s" format specifier in fmt has a purpose:

    %s	the uninterpreted bytes of the string or slice

as well as using the "%c" format specifier

which led to big improvements across every dimension:
* CPU time reduction by 11+% (ns/op)
* throughput improvement by 13+% (MBs/op)
* allocations reduction by 45+% (B/op)
* number of allocations reduction by 18+% (alloc/op)