### PR TITLE
Add SLL2 layer decoding

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -34,6 +34,7 @@ Kane Mathers <kane@kanemathers.name>
 Jose Selvi <jselvi@pentester.es>
 Yerden Zhumabekov <yerden.zhumabekov@gmail.com>
 Jensen Hwa <jensenhwa@gmail.com>
+Dylan Reimerink <97.dylan@gmail.com>
 
 -----------------------------------------------
 FORKED FROM github.com/akrennmair/gopcap

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/vishvananda/netlink v1.1.0
 	github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f
-	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
+	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859
 	golang.org/x/sys v0.0.0-20200217220822-9197077df867
 )

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b h1:Wh+f8QHJXR411sJR8/vRBTZ7YapZaRvUcLFFJhusH0k=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
+golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 h1:VLliZ0d+/avPrXXH+OakdXhpJuEoBZuwh1m2j7U6Iug=
+golang.org/x/lint v0.0.0-20210508222113-6edffad5e616/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 h1:0GoQqolDA55aaLxZyTzK/Y2ePZzZTUrRacwib7cNsYQ=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=

--- a/layers/.lint_blacklist
+++ b/layers/.lint_blacklist
@@ -37,3 +37,5 @@ udp.go
 udplite.go
 usb.go
 vrrp.go
+radius.go
+stp.go

--- a/layers/bitfield_test.go
+++ b/layers/bitfield_test.go
@@ -1,3 +1,8 @@
+// Copyright 2021 The GoPacket Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file in the root of the source tree.
+
 package layers
 
 import "testing"

--- a/layers/enums.go
+++ b/layers/enums.go
@@ -85,11 +85,11 @@ const (
 
 // LinkType is an enumeration of link types, and acts as a decoder for any
 // link type it supports.
-type LinkType uint8
+type LinkType uint16
 
 const (
 	// According to pcap-linktype(7) and http://www.tcpdump.org/linktypes.html
-	LinkTypeNull           LinkType = 0
+	LinkTypeNull           LinkType = iota
 	LinkTypeEthernet       LinkType = 1
 	LinkTypeAX25           LinkType = 3
 	LinkTypeTokenRing      LinkType = 6
@@ -126,6 +126,10 @@ const (
 	LinkTypeFC2Framed      LinkType = 225
 	LinkTypeIPv4           LinkType = 228
 	LinkTypeIPv6           LinkType = 229
+	LinkTypeLinuxSLL2      LinkType = 276
+
+	// Warning: this const should always be 1 larger than the largest valid value
+	LinkTypeMax LinkType = 277
 )
 
 // PPPoECode is the PPPoE code enum, taken from http://tools.ietf.org/html/rfc2516
@@ -385,6 +389,7 @@ func initActualTypeData() {
 	LinkTypeMetadata[LinkTypeLinuxUSB] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeUSB), Name: "USB"}
 	LinkTypeMetadata[LinkTypeLinuxSLL] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeLinuxSLL), Name: "Linux SLL"}
 	LinkTypeMetadata[LinkTypePrismHeader] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodePrismHeader), Name: "Prism"}
+	LinkTypeMetadata[LinkTypeLinuxSLL2] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeLinuxSLL2), Name: "Linux SLL2"}
 
 	FDDIFrameControlMetadata[FDDIFrameControlLLC] = EnumMetadata{DecodeWith: gopacket.DecodeFunc(decodeLLC), Name: "LLC"}
 

--- a/layers/enums_generated.go
+++ b/layers/enums_generated.go
@@ -3,7 +3,7 @@
 package layers
 
 // Created by gen2.go, don't edit manually
-// Generated at 2017-10-23 10:20:24.458771856 -0600 MDT m=+0.001159033
+// Generated at 2022-01-26 17:39:42.397387731 +0100 CET m=+0.000923751
 
 import (
 	"fmt"
@@ -28,16 +28,29 @@ func init() {
 
 // Decoder calls LinkTypeMetadata.DecodeWith's decoder.
 func (a LinkType) Decode(data []byte, p gopacket.PacketBuilder) error {
+	if int(a) >= 277 {
+		errDecoder := errorDecoderForLinkType(a)
+		return &errDecoder
+	}
+
 	return LinkTypeMetadata[a].DecodeWith.Decode(data, p)
 }
 
 // String returns LinkTypeMetadata.Name.
 func (a LinkType) String() string {
+	if int(a) >= 277 {
+		return "UnknownLinkType"
+	}
+
 	return LinkTypeMetadata[a].Name
 }
 
 // LayerType returns LinkTypeMetadata.LayerType.
 func (a LinkType) LayerType() gopacket.LayerType {
+	if int(a) >= 277 {
+		return 0
+	}
+
 	return LinkTypeMetadata[a].LayerType
 }
 
@@ -50,11 +63,11 @@ func (a *errorDecoderForLinkType) Error() string {
 	return fmt.Sprintf("Unable to decode LinkType %d", int(*a))
 }
 
-var errorDecodersForLinkType [256]errorDecoderForLinkType
-var LinkTypeMetadata [256]EnumMetadata
+var errorDecodersForLinkType [277]errorDecoderForLinkType
+var LinkTypeMetadata [277]EnumMetadata
 
 func initUnknownTypesForLinkType() {
-	for i := 0; i < 256; i++ {
+	for i := 0; i < 277; i++ {
 		errorDecodersForLinkType[i] = errorDecoderForLinkType(i)
 		LinkTypeMetadata[i] = EnumMetadata{
 			DecodeWith: &errorDecodersForLinkType[i],
@@ -65,16 +78,29 @@ func initUnknownTypesForLinkType() {
 
 // Decoder calls EthernetTypeMetadata.DecodeWith's decoder.
 func (a EthernetType) Decode(data []byte, p gopacket.PacketBuilder) error {
+	if int(a) >= 65536 {
+		errDecoder := errorDecoderForEthernetType(a)
+		return &errDecoder
+	}
+
 	return EthernetTypeMetadata[a].DecodeWith.Decode(data, p)
 }
 
 // String returns EthernetTypeMetadata.Name.
 func (a EthernetType) String() string {
+	if int(a) >= 65536 {
+		return "UnknownEthernetType"
+	}
+
 	return EthernetTypeMetadata[a].Name
 }
 
 // LayerType returns EthernetTypeMetadata.LayerType.
 func (a EthernetType) LayerType() gopacket.LayerType {
+	if int(a) >= 65536 {
+		return 0
+	}
+
 	return EthernetTypeMetadata[a].LayerType
 }
 
@@ -102,16 +128,29 @@ func initUnknownTypesForEthernetType() {
 
 // Decoder calls PPPTypeMetadata.DecodeWith's decoder.
 func (a PPPType) Decode(data []byte, p gopacket.PacketBuilder) error {
+	if int(a) >= 65536 {
+		errDecoder := errorDecoderForPPPType(a)
+		return &errDecoder
+	}
+
 	return PPPTypeMetadata[a].DecodeWith.Decode(data, p)
 }
 
 // String returns PPPTypeMetadata.Name.
 func (a PPPType) String() string {
+	if int(a) >= 65536 {
+		return "UnknownPPPType"
+	}
+
 	return PPPTypeMetadata[a].Name
 }
 
 // LayerType returns PPPTypeMetadata.LayerType.
 func (a PPPType) LayerType() gopacket.LayerType {
+	if int(a) >= 65536 {
+		return 0
+	}
+
 	return PPPTypeMetadata[a].LayerType
 }
 
@@ -139,16 +178,29 @@ func initUnknownTypesForPPPType() {
 
 // Decoder calls IPProtocolMetadata.DecodeWith's decoder.
 func (a IPProtocol) Decode(data []byte, p gopacket.PacketBuilder) error {
+	if int(a) >= 256 {
+		errDecoder := errorDecoderForIPProtocol(a)
+		return &errDecoder
+	}
+
 	return IPProtocolMetadata[a].DecodeWith.Decode(data, p)
 }
 
 // String returns IPProtocolMetadata.Name.
 func (a IPProtocol) String() string {
+	if int(a) >= 256 {
+		return "UnknownIPProtocol"
+	}
+
 	return IPProtocolMetadata[a].Name
 }
 
 // LayerType returns IPProtocolMetadata.LayerType.
 func (a IPProtocol) LayerType() gopacket.LayerType {
+	if int(a) >= 256 {
+		return 0
+	}
+
 	return IPProtocolMetadata[a].LayerType
 }
 
@@ -176,16 +228,29 @@ func initUnknownTypesForIPProtocol() {
 
 // Decoder calls SCTPChunkTypeMetadata.DecodeWith's decoder.
 func (a SCTPChunkType) Decode(data []byte, p gopacket.PacketBuilder) error {
+	if int(a) >= 256 {
+		errDecoder := errorDecoderForSCTPChunkType(a)
+		return &errDecoder
+	}
+
 	return SCTPChunkTypeMetadata[a].DecodeWith.Decode(data, p)
 }
 
 // String returns SCTPChunkTypeMetadata.Name.
 func (a SCTPChunkType) String() string {
+	if int(a) >= 256 {
+		return "UnknownSCTPChunkType"
+	}
+
 	return SCTPChunkTypeMetadata[a].Name
 }
 
 // LayerType returns SCTPChunkTypeMetadata.LayerType.
 func (a SCTPChunkType) LayerType() gopacket.LayerType {
+	if int(a) >= 256 {
+		return 0
+	}
+
 	return SCTPChunkTypeMetadata[a].LayerType
 }
 
@@ -213,16 +278,29 @@ func initUnknownTypesForSCTPChunkType() {
 
 // Decoder calls PPPoECodeMetadata.DecodeWith's decoder.
 func (a PPPoECode) Decode(data []byte, p gopacket.PacketBuilder) error {
+	if int(a) >= 256 {
+		errDecoder := errorDecoderForPPPoECode(a)
+		return &errDecoder
+	}
+
 	return PPPoECodeMetadata[a].DecodeWith.Decode(data, p)
 }
 
 // String returns PPPoECodeMetadata.Name.
 func (a PPPoECode) String() string {
+	if int(a) >= 256 {
+		return "UnknownPPPoECode"
+	}
+
 	return PPPoECodeMetadata[a].Name
 }
 
 // LayerType returns PPPoECodeMetadata.LayerType.
 func (a PPPoECode) LayerType() gopacket.LayerType {
+	if int(a) >= 256 {
+		return 0
+	}
+
 	return PPPoECodeMetadata[a].LayerType
 }
 
@@ -250,16 +328,29 @@ func initUnknownTypesForPPPoECode() {
 
 // Decoder calls FDDIFrameControlMetadata.DecodeWith's decoder.
 func (a FDDIFrameControl) Decode(data []byte, p gopacket.PacketBuilder) error {
+	if int(a) >= 256 {
+		errDecoder := errorDecoderForFDDIFrameControl(a)
+		return &errDecoder
+	}
+
 	return FDDIFrameControlMetadata[a].DecodeWith.Decode(data, p)
 }
 
 // String returns FDDIFrameControlMetadata.Name.
 func (a FDDIFrameControl) String() string {
+	if int(a) >= 256 {
+		return "UnknownFDDIFrameControl"
+	}
+
 	return FDDIFrameControlMetadata[a].Name
 }
 
 // LayerType returns FDDIFrameControlMetadata.LayerType.
 func (a FDDIFrameControl) LayerType() gopacket.LayerType {
+	if int(a) >= 256 {
+		return 0
+	}
+
 	return FDDIFrameControlMetadata[a].LayerType
 }
 
@@ -287,16 +378,29 @@ func initUnknownTypesForFDDIFrameControl() {
 
 // Decoder calls EAPOLTypeMetadata.DecodeWith's decoder.
 func (a EAPOLType) Decode(data []byte, p gopacket.PacketBuilder) error {
+	if int(a) >= 256 {
+		errDecoder := errorDecoderForEAPOLType(a)
+		return &errDecoder
+	}
+
 	return EAPOLTypeMetadata[a].DecodeWith.Decode(data, p)
 }
 
 // String returns EAPOLTypeMetadata.Name.
 func (a EAPOLType) String() string {
+	if int(a) >= 256 {
+		return "UnknownEAPOLType"
+	}
+
 	return EAPOLTypeMetadata[a].Name
 }
 
 // LayerType returns EAPOLTypeMetadata.LayerType.
 func (a EAPOLType) LayerType() gopacket.LayerType {
+	if int(a) >= 256 {
+		return 0
+	}
+
 	return EAPOLTypeMetadata[a].LayerType
 }
 
@@ -324,16 +428,29 @@ func initUnknownTypesForEAPOLType() {
 
 // Decoder calls ProtocolFamilyMetadata.DecodeWith's decoder.
 func (a ProtocolFamily) Decode(data []byte, p gopacket.PacketBuilder) error {
+	if int(a) >= 256 {
+		errDecoder := errorDecoderForProtocolFamily(a)
+		return &errDecoder
+	}
+
 	return ProtocolFamilyMetadata[a].DecodeWith.Decode(data, p)
 }
 
 // String returns ProtocolFamilyMetadata.Name.
 func (a ProtocolFamily) String() string {
+	if int(a) >= 256 {
+		return "UnknownProtocolFamily"
+	}
+
 	return ProtocolFamilyMetadata[a].Name
 }
 
 // LayerType returns ProtocolFamilyMetadata.LayerType.
 func (a ProtocolFamily) LayerType() gopacket.LayerType {
+	if int(a) >= 256 {
+		return 0
+	}
+
 	return ProtocolFamilyMetadata[a].LayerType
 }
 
@@ -361,16 +478,29 @@ func initUnknownTypesForProtocolFamily() {
 
 // Decoder calls Dot11TypeMetadata.DecodeWith's decoder.
 func (a Dot11Type) Decode(data []byte, p gopacket.PacketBuilder) error {
+	if int(a) >= 256 {
+		errDecoder := errorDecoderForDot11Type(a)
+		return &errDecoder
+	}
+
 	return Dot11TypeMetadata[a].DecodeWith.Decode(data, p)
 }
 
 // String returns Dot11TypeMetadata.Name.
 func (a Dot11Type) String() string {
+	if int(a) >= 256 {
+		return "UnknownDot11Type"
+	}
+
 	return Dot11TypeMetadata[a].Name
 }
 
 // LayerType returns Dot11TypeMetadata.LayerType.
 func (a Dot11Type) LayerType() gopacket.LayerType {
+	if int(a) >= 256 {
+		return 0
+	}
+
 	return Dot11TypeMetadata[a].LayerType
 }
 
@@ -398,16 +528,29 @@ func initUnknownTypesForDot11Type() {
 
 // Decoder calls USBTransportTypeMetadata.DecodeWith's decoder.
 func (a USBTransportType) Decode(data []byte, p gopacket.PacketBuilder) error {
+	if int(a) >= 256 {
+		errDecoder := errorDecoderForUSBTransportType(a)
+		return &errDecoder
+	}
+
 	return USBTransportTypeMetadata[a].DecodeWith.Decode(data, p)
 }
 
 // String returns USBTransportTypeMetadata.Name.
 func (a USBTransportType) String() string {
+	if int(a) >= 256 {
+		return "UnknownUSBTransportType"
+	}
+
 	return USBTransportTypeMetadata[a].Name
 }
 
 // LayerType returns USBTransportTypeMetadata.LayerType.
 func (a USBTransportType) LayerType() gopacket.LayerType {
+	if int(a) >= 256 {
+		return 0
+	}
+
 	return USBTransportTypeMetadata[a].LayerType
 }
 

--- a/layers/erspan2.go
+++ b/layers/erspan2.go
@@ -29,6 +29,7 @@ type ERSPANII struct {
 	Index                               uint32
 }
 
+// LayerType returns gopacket.LayerTypeEtherIP.
 func (erspan2 *ERSPANII) LayerType() gopacket.LayerType { return LayerTypeERSPANII }
 
 // DecodeFromBytes decodes the given bytes into this layer.

--- a/layers/gen2.go
+++ b/layers/gen2.go
@@ -4,6 +4,7 @@
 // that can be found in the LICENSE file in the root of the source
 // tree.
 
+//go:build ignore
 // +build ignore
 
 // This binary handles creating string constants and function templates for enums.
@@ -37,14 +38,27 @@ import (
 var funcsTmpl = template.Must(template.New("foo").Parse(`
 // Decoder calls {{.Name}}Metadata.DecodeWith's decoder.
 func (a {{.Name}}) Decode(data []byte, p gopacket.PacketBuilder) error {
+	if int(a) >= {{.Num}} {
+		errDecoder := errorDecoderFor{{.Name}}(a)
+		return &errDecoder
+	}
+
 	return {{.Name}}Metadata[a].DecodeWith.Decode(data, p)
 }
 // String returns {{.Name}}Metadata.Name.
 func (a {{.Name}}) String() string {
+	if int(a) >= {{.Num}} {
+		return "Unknown{{.Name}}"
+	}
+
 	return {{.Name}}Metadata[a].Name
 }
 // LayerType returns {{.Name}}Metadata.LayerType.
 func (a {{.Name}}) LayerType() gopacket.LayerType {
+	if int(a) >= {{.Num}} {
+		return 0
+	}
+
 	return {{.Name}}Metadata[a].LayerType
 }
 
@@ -77,7 +91,7 @@ func main() {
 		Name string
 		Num  int
 	}{
-		{"LinkType", 256},
+		{"LinkType", 277},
 		{"EthernetType", 65536},
 		{"PPPType", 65536},
 		{"IPProtocol", 256},

--- a/layers/layertypes.go
+++ b/layers/layertypes.go
@@ -148,6 +148,7 @@ var (
 	LayerTypeASFPresencePong              = gopacket.RegisterLayerType(144, gopacket.LayerTypeMetadata{Name: "ASFPresencePong", Decoder: gopacket.DecodeFunc(decodeASFPresencePong)})
 	LayerTypeERSPANII                     = gopacket.RegisterLayerType(145, gopacket.LayerTypeMetadata{Name: "ERSPAN Type II", Decoder: gopacket.DecodeFunc(decodeERSPANII)})
 	LayerTypeRADIUS                       = gopacket.RegisterLayerType(146, gopacket.LayerTypeMetadata{Name: "RADIUS", Decoder: gopacket.DecodeFunc(decodeRADIUS)})
+	LayerTypeLinuxSLL2                    = gopacket.RegisterLayerType(276, gopacket.LayerTypeMetadata{Name: "Linux SLL2", Decoder: gopacket.DecodeFunc(decodeLinuxSLL2)})
 )
 
 var (

--- a/layers/linux_sll2.go
+++ b/layers/linux_sll2.go
@@ -1,0 +1,176 @@
+// Copyright 2022 Google, Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file in the root of the source
+// tree.
+
+package layers
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"net"
+
+	"github.com/google/gopacket"
+)
+
+// The ARPHardwareType contains a Linux ARPHRD_ value for the link-layer device type
+type ARPHardwareType uint16
+
+const (
+	ARPHardwareTypeEthernet      ARPHardwareType = 1
+	ARPHardwareTypeFRAD          ARPHardwareType = 770
+	ARPHardwareTypeLoopback      ARPHardwareType = 772
+	ARPHardwareTypeIPGRE         ARPHardwareType = 778
+	ARPHardwareTypeDot11Radiotap ARPHardwareType = 803
+)
+
+func (l ARPHardwareType) String() string {
+	switch l {
+	case ARPHardwareTypeEthernet:
+		return "Ethernet"
+	case ARPHardwareTypeFRAD:
+		return "Frame Relay Access Device"
+	case ARPHardwareTypeLoopback:
+		return "Loopback device"
+	case ARPHardwareTypeIPGRE:
+		return "GRE over IP"
+	case ARPHardwareTypeDot11Radiotap:
+		return "IEEE 802.11 + radiotap header"
+	}
+
+	return fmt.Sprintf("Unknown(%d)", int(l))
+}
+
+// The LinuxSLL2PacketType can contain the same values as LinuxSLLPacketType accept it is a uint8 instread of a uint16
+type LinuxSLL2PacketType uint8
+
+const (
+	LinuxSLL2PacketTypeHost      LinuxSLL2PacketType = 0 // To us
+	LinuxSLL2PacketTypeBroadcast LinuxSLL2PacketType = 1 // To all
+	LinuxSLL2PacketTypeMulticast LinuxSLL2PacketType = 2 // To group
+	LinuxSLL2PacketTypeOtherhost LinuxSLL2PacketType = 3 // To someone else
+	LinuxSLL2PacketTypeOutgoing  LinuxSLL2PacketType = 4 // Outgoing of any type
+	// These ones are invisible by user level
+	LinuxSLL2PacketTypeLoopback  LinuxSLL2PacketType = 5 // MC/BRD frame looped back
+	LinuxSLL2PacketTypeFastroute LinuxSLL2PacketType = 6 // Fastrouted frame
+)
+
+func (l LinuxSLL2PacketType) String() string {
+	switch l {
+	case LinuxSLL2PacketTypeHost:
+		return "host"
+	case LinuxSLL2PacketTypeBroadcast:
+		return "broadcast"
+	case LinuxSLL2PacketTypeMulticast:
+		return "multicast"
+	case LinuxSLL2PacketTypeOtherhost:
+		return "otherhost"
+	case LinuxSLL2PacketTypeOutgoing:
+		return "outgoing"
+	case LinuxSLL2PacketTypeLoopback:
+		return "loopback"
+	case LinuxSLL2PacketTypeFastroute:
+		return "fastroute"
+	}
+	return fmt.Sprintf("Unknown(%d)", int(l))
+}
+
+const (
+	LinuxSLL2EthernetTypeDot3    EthernetType = 0x0001
+	LinuxSLL2EthernetTypeUnknown EthernetType = 0x0003
+	LinuxSLL2EthernetTypeLLC     EthernetType = 0x0004
+	LinuxSLL2EthernetTypeCAN     EthernetType = 0x000C
+)
+
+// LinuxSLL2 is the second version of the Linux "cooked" capture encapsulation protocol. It is used to encapsulate
+// packets within packet capture files, particularly by libpcap/tcpdump when making a packet capture with -i any
+// https://www.tcpdump.org/linktypes/LINKTYPE_LINUX_SLL2.html
+type LinuxSLL2 struct {
+	BaseLayer
+	ProtocolType    EthernetType
+	InterfaceIndex  uint32
+	ARPHardwareType ARPHardwareType
+	PacketType      LinuxSLL2PacketType
+	AddrLength      uint8
+	Addr            net.HardwareAddr
+}
+
+// LayerType returns LayerTypeLinuxSLL.
+func (sll *LinuxSLL2) LayerType() gopacket.LayerType { return LayerTypeLinuxSLL2 }
+
+func (sll *LinuxSLL2) CanDecode() gopacket.LayerClass {
+	return LayerTypeLinuxSLL2
+}
+
+func (sll *LinuxSLL2) LinkFlow() gopacket.Flow {
+	return gopacket.NewFlow(EndpointMAC, sll.Addr, nil)
+}
+
+func (sll *LinuxSLL2) NextLayerType() gopacket.LayerType {
+	switch sll.ARPHardwareType {
+	case ARPHardwareTypeFRAD:
+		// If the ARPHRD_ type is ARPHRD_FRAD (770), the protocol type field is ignored,
+		// and the payload following the LINKTYPE_LINUX_SLL header is a Frame Relay LAPF frame,
+		// beginning with a ITU-T Recommendation Q.922 LAPF header starting with the address field,
+		// and without an FCS at the end of the frame.
+		return gopacket.LayerTypeZero // LAPF layer not yet implemented
+
+	case ARPHardwareTypeDot11Radiotap:
+		return LayerTypeRadioTap
+
+	case ARPHardwareTypeIPGRE:
+		// Docs: If the ARPHRD_ type is ARPHRD_IPGRE (778), the protocol type field contains a GRE protocol type.
+		//
+		// It doesn't clearly state if if the next header should be GRE or Ethernet in this case. Will assume ethernet
+		// for now
+		return LayerTypeEthernet
+
+	default:
+		switch sll.ProtocolType {
+		case LinuxSLL2EthernetTypeDot3:
+			// Docs: if the frame is a Novell 802.3 frame without an 802.2 LLC header
+			return gopacket.LayerTypeZero // Novell 802.3 frame layer not yet implemented
+
+		case LinuxSLL2EthernetTypeUnknown:
+			// Docs: in some mysterious cases;
+			return gopacket.LayerTypeZero // Mysterious cases not implemented
+
+		case LinuxSLL2EthernetTypeLLC:
+			return LayerTypeLLC
+
+		case LinuxSLL2EthernetTypeCAN:
+			// Docs: if the frame is a CAN bus frame that begins with a header of the form
+			return gopacket.LayerTypeZero
+		}
+
+		return sll.ProtocolType.LayerType()
+	}
+}
+
+func (sll *LinuxSLL2) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
+	if len(data) < 20 {
+		return errors.New("Linux SLL2 packet too small")
+	}
+	sll.ProtocolType = EthernetType(binary.BigEndian.Uint16(data[0:2]))
+	sll.InterfaceIndex = binary.BigEndian.Uint32(data[4:8])
+	sll.ARPHardwareType = ARPHardwareType(binary.BigEndian.Uint16(data[8:10]))
+	sll.PacketType = LinuxSLL2PacketType(data[10])
+	sll.AddrLength = data[11]
+	sll.Addr = data[12:20]
+	sll.Addr = sll.Addr[:sll.AddrLength]
+	sll.BaseLayer = BaseLayer{data[:20], data[20:]}
+
+	return nil
+}
+
+func decodeLinuxSLL2(data []byte, p gopacket.PacketBuilder) error {
+	sll := &LinuxSLL2{}
+	if err := sll.DecodeFromBytes(data, p); err != nil {
+		return err
+	}
+	p.AddLayer(sll)
+	p.SetLinkLayer(sll)
+	return p.NextDecoder(sll.NextLayerType())
+}

--- a/layers/linux_sll2.go
+++ b/layers/linux_sll2.go
@@ -19,10 +19,15 @@ import (
 type ARPHardwareType uint16
 
 const (
-	ARPHardwareTypeEthernet      ARPHardwareType = 1
-	ARPHardwareTypeFRAD          ARPHardwareType = 770
-	ARPHardwareTypeLoopback      ARPHardwareType = 772
-	ARPHardwareTypeIPGRE         ARPHardwareType = 778
+	// ARPHardwareTypeEthernet means that the SLL2 packet was captured on an ethernet link
+	ARPHardwareTypeEthernet ARPHardwareType = 1
+	// ARPHardwareTypeFRAD means that the SLL2 packet was captured on a frame relay link
+	ARPHardwareTypeFRAD ARPHardwareType = 770
+	// ARPHardwareTypeLoopback means that the SLL2 packet was captured on a loopback device
+	ARPHardwareTypeLoopback ARPHardwareType = 772
+	// ARPHardwareTypeIPGRE means that the SLL2 packet was captured on a GRE connection
+	ARPHardwareTypeIPGRE ARPHardwareType = 778
+	// ARPHardwareTypeDot11Radiotap means that the SLL2 packet was captured on a IEEE802.11 radiotap link
 	ARPHardwareTypeDot11Radiotap ARPHardwareType = 803
 )
 
@@ -47,14 +52,23 @@ func (l ARPHardwareType) String() string {
 type LinuxSLL2PacketType uint8
 
 const (
-	LinuxSLL2PacketTypeHost      LinuxSLL2PacketType = 0 // To us
-	LinuxSLL2PacketTypeBroadcast LinuxSLL2PacketType = 1 // To all
-	LinuxSLL2PacketTypeMulticast LinuxSLL2PacketType = 2 // To group
-	LinuxSLL2PacketTypeOtherhost LinuxSLL2PacketType = 3 // To someone else
-	LinuxSLL2PacketTypeOutgoing  LinuxSLL2PacketType = 4 // Outgoing of any type
+	// LinuxSLL2PacketTypeHost means a packet SLL2 was directed to us(the host capturing)
+	LinuxSLL2PacketTypeHost LinuxSLL2PacketType = 0
+	// LinuxSLL2PacketTypeBroadcast means a packet SLL2 was directed to everyone on the local network all
+	LinuxSLL2PacketTypeBroadcast LinuxSLL2PacketType = 1
+	// LinuxSLL2PacketTypeMulticast means a packet SLL2 was directed to multiple hosts
+	LinuxSLL2PacketTypeMulticast LinuxSLL2PacketType = 2
+	// LinuxSLL2PacketTypeOtherhost means a packet SLL2 was sent to another host
+	LinuxSLL2PacketTypeOtherhost LinuxSLL2PacketType = 3
+	// LinuxSLL2PacketTypeOutgoing means a packet SLL2 was sent by us(outgoing traffic)
+	LinuxSLL2PacketTypeOutgoing LinuxSLL2PacketType = 4
+
 	// These ones are invisible by user level
-	LinuxSLL2PacketTypeLoopback  LinuxSLL2PacketType = 5 // MC/BRD frame looped back
-	LinuxSLL2PacketTypeFastroute LinuxSLL2PacketType = 6 // Fastrouted frame
+
+	// LinuxSLL2PacketTypeLoopback MC/BRD frame looped back
+	LinuxSLL2PacketTypeLoopback LinuxSLL2PacketType = 5
+	// LinuxSLL2PacketTypeFastroute Fastrouted frame
+	LinuxSLL2PacketTypeFastroute LinuxSLL2PacketType = 6
 )
 
 func (l LinuxSLL2PacketType) String() string {
@@ -78,10 +92,14 @@ func (l LinuxSLL2PacketType) String() string {
 }
 
 const (
-	LinuxSLL2EthernetTypeDot3    EthernetType = 0x0001
+	// LinuxSLL2EthernetTypeDot3 means the SLL2 layer is followed by a Novell 802.3 frame without an 802.2 LLC header
+	LinuxSLL2EthernetTypeDot3 EthernetType = 0x0001
+	// LinuxSLL2EthernetTypeUnknown is emitted by the linux kernel in some unknown cases
 	LinuxSLL2EthernetTypeUnknown EthernetType = 0x0003
-	LinuxSLL2EthernetTypeLLC     EthernetType = 0x0004
-	LinuxSLL2EthernetTypeCAN     EthernetType = 0x000C
+	// LinuxSLL2EthernetTypeLLC means the SLL2 layer is followed by a LLC layer
+	LinuxSLL2EthernetTypeLLC EthernetType = 0x0004
+	// LinuxSLL2EthernetTypeCAN means the SLL2 layer is followed by a CAN bus layer
+	LinuxSLL2EthernetTypeCAN EthernetType = 0x000C
 )
 
 // LinuxSLL2 is the second version of the Linux "cooked" capture encapsulation protocol. It is used to encapsulate
@@ -100,14 +118,17 @@ type LinuxSLL2 struct {
 // LayerType returns LayerTypeLinuxSLL.
 func (sll *LinuxSLL2) LayerType() gopacket.LayerType { return LayerTypeLinuxSLL2 }
 
+// CanDecode returns the set of layer types that this DecodingLayer can decode.
 func (sll *LinuxSLL2) CanDecode() gopacket.LayerClass {
 	return LayerTypeLinuxSLL2
 }
 
+// LinkFlow returns the Flow of the link layer
 func (sll *LinuxSLL2) LinkFlow() gopacket.Flow {
 	return gopacket.NewFlow(EndpointMAC, sll.Addr, nil)
 }
 
+// NextLayerType returns the layer type of the next layer
 func (sll *LinuxSLL2) NextLayerType() gopacket.LayerType {
 	switch sll.ARPHardwareType {
 	case ARPHardwareTypeFRAD:
@@ -149,6 +170,7 @@ func (sll *LinuxSLL2) NextLayerType() gopacket.LayerType {
 	}
 }
 
+// DecodeFromBytes decodes a SLL2 layer from bytes
 func (sll *LinuxSLL2) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 	if len(data) < 20 {
 		return errors.New("Linux SLL2 packet too small")

--- a/layers/modbustcp.go
+++ b/layers/modbustcp.go
@@ -118,7 +118,7 @@ func (d *ModbusTCP) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) err
 	// ModbusTCP type embeds type BaseLayer which contains two fields:
 	//    Contents is supposed to contain the bytes of the data at this level (MPBA).
 	//    Payload is supposed to contain the payload of this level (PDU).
-	d.BaseLayer = BaseLayer{Contents: data[:mbapRecordSizeInBytes], Payload: data[mbapRecordSizeInBytes:len(data)]}
+	d.BaseLayer = BaseLayer{Contents: data[:mbapRecordSizeInBytes], Payload: data[mbapRecordSizeInBytes:]}
 
 	// Extract the fields from the block of bytes.
 	// The fields can just be copied in big endian order.
@@ -151,6 +151,6 @@ func (d *ModbusTCP) Payload() []byte {
 }
 
 // CanDecode returns the set of layer types that this DecodingLayer can decode
-func (s *ModbusTCP) CanDecode() gopacket.LayerClass {
+func (d *ModbusTCP) CanDecode() gopacket.LayerClass {
 	return LayerTypeModbusTCP
 }


### PR DESCRIPTION
This pull request adds SLL2(Linux "cooked" capture encapsulation v2) layer decoding. SLL2 seems to be the preferred encapsulation method used by `tcpdump` when capturing packets in cooked mode("-i any").

The `LinkType` value for [SLL2](https://www.tcpdump.org/linktypes/LINKTYPE_LINUX_SLL2.html) is 276, according to https://www.tcpdump.org/linktypes.html. This exceeds the max value of `layers.LinkType` which is a `uint8`. 

To accommodate link types above 255 we have to change `layers.LinkType` from a `uint8` to a `uint16`. From what I have read in existing issues(#916 #289), the downside of doing this is the added memory usage of the `layers.LinkTypeMetadata` array. Just changing the type `layers.LinkTypeMetadata` is not a good idea for high performance decoding. Changing `layers.LinkType` from a `uint8` to a `uint16` and increasing the size of `layers.LinkTypeMetadata` to 65535 could cause out of bounds access which is also not acceptable.

This PR modifies `layers/gen2.go` to now generate bounds checks for the `Decode`, `String` and `LayerType` methods on the enum types, which prevents panics when a enum value is out of bounds of a `...Metadata` array, allowing the arrays to be smaller than all possible values of the enum type.

This does make decoding a little bit slower(about 5% judging by the total benchmark times) but we don't have to allocate memory which will not be used. Since `gen2.go` generates code for all enums, this penalty is shared across all of them. However, the benefits can also be shared by all of them. While this PR doesn't modify more than necessary, the `EthernetType` could benefit from shrinking the Metadata array to `0x9001`(36865) saving 28672 unused values from being allocated. Same goes for the `PPPType` which can save 64893 values since only up to 0x0283(643) is used.