### PR TITLE
afpacket: fix unsafe.Pointer misuse

### DIFF
--- a/.travis.govet.sh
+++ b/.travis.govet.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 cd "$(dirname $0)"
-DIRS=". layers pcap pcapgo tcpassembly tcpassembly/tcpreader routing ip4defrag bytediff macs defrag/lcmdefrag"
+DIRS=". afpacket layers pcap pcapgo tcpassembly tcpassembly/tcpreader routing ip4defrag bytediff macs defrag/lcmdefrag"
 set -e
 for subdir in $DIRS; do
   pushd $subdir

--- a/afpacket/afpacket.go
+++ b/afpacket/afpacket.go
@@ -428,21 +428,21 @@ func (h *TPacket) getTPacketHeader() header {
 		if h.offset >= h.opts.framesPerBlock*h.opts.numBlocks {
 			h.offset = 0
 		}
-		position := uintptr(h.rawring) + uintptr(h.opts.frameSize*h.offset)
-		return (*v1header)(unsafe.Pointer(position))
+		position := unsafe.Pointer(uintptr(h.rawring) + uintptr(h.opts.frameSize*h.offset))
+		return (*v1header)(position)
 	case TPacketVersion2:
 		if h.offset >= h.opts.framesPerBlock*h.opts.numBlocks {
 			h.offset = 0
 		}
-		position := uintptr(h.rawring) + uintptr(h.opts.frameSize*h.offset)
-		return (*v2header)(unsafe.Pointer(position))
+		position := unsafe.Pointer(uintptr(h.rawring) + uintptr(h.opts.frameSize*h.offset))
+		return (*v2header)(position)
 	case TPacketVersion3:
 		// TPacket3 uses each block to return values, instead of each frame.  Hence we need to rotate when we hit #blocks, not #frames.
 		if h.offset >= h.opts.numBlocks {
 			h.offset = 0
 		}
-		position := uintptr(h.rawring) + uintptr(h.opts.frameSize*h.offset*h.opts.framesPerBlock)
-		h.v3 = initV3Wrapper(unsafe.Pointer(position))
+		position := unsafe.Pointer(uintptr(h.rawring) + uintptr(h.opts.frameSize*h.offset*h.opts.framesPerBlock))
+		h.v3 = initV3Wrapper(position)
 		return &h.v3
 	}
 	panic("handle tpacket version is invalid")

--- a/afpacket/header.go
+++ b/afpacket/header.go
@@ -184,12 +184,12 @@ func (w *v3wrapper) next() bool {
 		return false
 	}
 
-	next := uintptr(unsafe.Pointer(w.packet))
+	next := unsafe.Pointer(w.packet)
 	if w.packet.tp_next_offset != 0 {
-		next += uintptr(w.packet.tp_next_offset)
+		next = unsafe.Pointer(uintptr(next) + uintptr(w.packet.tp_next_offset))
 	} else {
-		next += uintptr(tpAlign(int(w.packet.tp_snaplen) + int(w.packet.tp_mac)))
+		next = unsafe.Pointer(uintptr(next) +uintptr(tpAlign(int(w.packet.tp_snaplen) + int(w.packet.tp_mac))))
 	}
-	w.packet = (*C.struct_tpacket3_hdr)(unsafe.Pointer(next))
+	w.packet = (*C.struct_tpacket3_hdr)(next)
 	return true
 }


### PR DESCRIPTION
From the unsafe package docs:

```
(2) Conversion of a Pointer to a uintptr (but not back to Pointer).

Converting a Pointer to a uintptr produces the memory address of the
value pointed at, as an integer. The usual use for such a uintptr is
to print it.

Conversion of a uintptr back to Pointer is not valid in general.

A uintptr is an integer, not a reference. Converting a Pointer to a
uintptr creates an integer value with no pointer semantics. Even if a
uintptr holds the address of some object, the garbage collector will
not update that uintptr's value if the object moves, nor will that
uintptr keep the object from being reclaimed.
```