### PR TITLE
Fixes EAPOLKey.CanDecode to gopacket.LayerClass

### DIFF
--- a/layers/eapol.go
+++ b/layers/eapol.go
@@ -9,6 +9,7 @@ package layers
 import (
 	"encoding/binary"
 	"fmt"
+
 	"github.com/google/gopacket"
 )
 
@@ -166,7 +167,7 @@ func (ek *EAPOLKey) LayerType() gopacket.LayerType {
 }
 
 // CanDecode returns the set of layer types that this DecodingLayer can decode.
-func (ek *EAPOLKey) CanDecode() gopacket.LayerType {
+func (ek *EAPOLKey) CanDecode() gopacket.LayerClass {
 	return LayerTypeEAPOLKey
 }
 


### PR DESCRIPTION
PR https://github.com/google/gopacket/pull/635 incorrectly assigned EAPOLKey's `CanDecode` return. It should have been `gopacket.LayerClass` and not `gopacket.LayerType`.