### PR TITLE
pcapgo: add read/write support for Decryption Secrets Block (DSB). 

### DIFF
--- a/pcapgo/ngread.go
+++ b/pcapgo/ngread.go
@@ -316,6 +316,10 @@ func (r *NgReader) firstInterface() error {
 			return nil
 		case ngBlockTypePacket, ngBlockTypeEnhancedPacket, ngBlockTypeSimplePacket, ngBlockTypeInterfaceStatistics:
 			return errors.New("A section must have an interface before a packet block")
+		case ngBlockTypeDecryptionSecrets:
+			if err := r.readDecryptionSecretsBlock(); err != nil {
+				return err
+			}
 		}
 		if _, err := r.r.Discard(int(r.currentBlock.length)); err != nil {
 			return err
@@ -485,10 +489,6 @@ FIND_PACKET:
 			}
 		case ngBlockTypeInterfaceStatistics:
 			if err := r.readInterfaceStatistics(); err != nil {
-				return err
-			}
-		case ngBlockTypeDecryptionSecrets:
-			if err := r.readDecryptionSecrets(); err != nil {
 				return err
 			}
 		case ngBlockTypeSectionHeader:

--- a/pcapgo/ngread.go
+++ b/pcapgo/ngread.go
@@ -55,6 +55,7 @@ type NgReader struct {
 	firstSectionFound bool
 	activeSection     bool
 	bigEndian         bool
+	decryptionSecrets []decryptionSecret
 }
 
 // NewNgReader initializes a new writer, reads the first section header, and if necessary according to the options the first interface.
@@ -64,7 +65,8 @@ func NewNgReader(r io.Reader, options NgReaderOptions) (*NgReader, error) {
 		currentOption: ngOption{
 			value: make([]byte, 1024),
 		},
-		options: options,
+		decryptionSecrets: make([]decryptionSecret, 0),
+		options:           options,
 	}
 
 	//pcapng _must_ start with a section header
@@ -483,6 +485,10 @@ FIND_PACKET:
 			}
 		case ngBlockTypeInterfaceStatistics:
 			if err := r.readInterfaceStatistics(); err != nil {
+				return err
+			}
+		case ngBlockTypeDecryptionSecrets:
+			if err := r.readDecryptionSecrets(); err != nil {
 				return err
 			}
 		case ngBlockTypeSectionHeader:

--- a/pcapgo/ngread_dsb.go
+++ b/pcapgo/ngread_dsb.go
@@ -1,4 +1,13 @@
+// Copyright 2018 The GoPacket Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file in the root of the source
+// tree.
+// author: CFC4N <cfc4n@cnxct.com>
+
 package pcapgo
+
+import "fmt"
 
 type decryptionSecret struct {
 	blockInfo pcapngDecryptionSecretsBlock
@@ -6,26 +15,18 @@ type decryptionSecret struct {
 }
 
 // readDecryptionSecrets parses an encryption secrets section from the given
-func (r *NgReader) readDecryptionSecrets() error {
+func (r *NgReader) readDecryptionSecretsBlock() error {
 	if err := r.readBytes(r.buf[:8]); err != nil {
-		return err
+		return fmt.Errorf("could not read DecryptionSecret Header block length: %v", err)
 	}
 	r.currentBlock.length -= 8
-	var blockHeader *pcapngBlockHeader
-	blockHeader.blockType = r.getUint32(r.buf[:4])
-	blockHeader.blockTotalLength = r.getUint32(r.buf[4:8])
 
-	if err := r.readBytes(r.buf[8:16]); err != nil {
-		return err
-	}
-	r.currentBlock.length -= 8
-	var decryptionSecretsBlock *pcapngDecryptionSecretsBlock
-	decryptionSecretsBlock.secretsType = r.getUint32(r.buf[8:12])
-	decryptionSecretsBlock.secretsLength = r.getUint32(r.buf[12:16])
-
+	var decryptionSecretsBlock = &pcapngDecryptionSecretsBlock{}
+	decryptionSecretsBlock.secretsType = r.getUint32(r.buf[0:4])
+	decryptionSecretsBlock.secretsLength = r.getUint32(r.buf[4:8])
 	var payload = make([]byte, decryptionSecretsBlock.secretsLength)
 	if err := r.readBytes(payload); err != nil {
-		return err
+		return fmt.Errorf("could not read %d bytes from DecryptionSecret payload: %v", decryptionSecretsBlock.secretsLength, err)
 	}
 	r.currentBlock.length -= uint32(len(payload))
 

--- a/pcapgo/ngread_dsb.go
+++ b/pcapgo/ngread_dsb.go
@@ -1,0 +1,38 @@
+package pcapgo
+
+type decryptionSecret struct {
+	blockInfo pcapngDecryptionSecretsBlock
+	payload   []byte
+}
+
+// readDecryptionSecrets parses an encryption secrets section from the given
+func (r *NgReader) readDecryptionSecrets() error {
+	if err := r.readBytes(r.buf[:8]); err != nil {
+		return err
+	}
+	r.currentBlock.length -= 8
+	var blockHeader *pcapngBlockHeader
+	blockHeader.blockType = r.getUint32(r.buf[:4])
+	blockHeader.blockTotalLength = r.getUint32(r.buf[4:8])
+
+	if err := r.readBytes(r.buf[8:16]); err != nil {
+		return err
+	}
+	r.currentBlock.length -= 8
+	var decryptionSecretsBlock *pcapngDecryptionSecretsBlock
+	decryptionSecretsBlock.secretsType = r.getUint32(r.buf[8:12])
+	decryptionSecretsBlock.secretsLength = r.getUint32(r.buf[12:16])
+
+	var payload = make([]byte, decryptionSecretsBlock.secretsLength)
+	if err := r.readBytes(payload); err != nil {
+		return err
+	}
+	r.currentBlock.length -= uint32(len(payload))
+
+	// save decryption secrets
+	var decryptSecret decryptionSecret
+	decryptSecret.blockInfo = *decryptionSecretsBlock
+	decryptSecret.payload = payload
+	r.decryptionSecrets = append(r.decryptionSecrets, decryptSecret)
+	return nil
+}

--- a/pcapgo/ngread_dsb_test.go
+++ b/pcapgo/ngread_dsb_test.go
@@ -15,7 +15,7 @@ type BufferPacketSource struct {
 	ci    []gopacket.CaptureInfo
 }
 
-// TestNgReadDSB tests the NgReadDSB function.
+// TestNgReadDSB tests the readDecryptionSecretsBlock function.
 func TestNgReaderDSB(t *testing.T) {
 
 	// Test that we can read a pcapng file with DSB.
@@ -36,6 +36,8 @@ func TestNgReaderDSB(t *testing.T) {
 	}
 
 	b := &BufferPacketSource{}
+	var ii int
+	var found bool
 	for {
 		data, ci, err := r.ReadPacketData()
 		if err == io.EOF {
@@ -44,6 +46,14 @@ func TestNgReaderDSB(t *testing.T) {
 		}
 		b.data = append(b.data, data)
 		b.ci = append(b.ci, ci)
+		if !found && len(r.decryptionSecrets) > 0 {
+			found = true
+			t.Log("Decryption Secrets Block found, index block:", ii)
+		}
+		ii++
+	}
+	if len(b.data) != len(b.ci) || len(b.ci) <= 0 {
+		t.Fatal("unexpected data or data length:", len(b.data), ", ci length", len(b.ci))
 	}
 
 	duration := time.Since(start)

--- a/pcapgo/ngread_dsb_test.go
+++ b/pcapgo/ngread_dsb_test.go
@@ -1,0 +1,62 @@
+package pcapgo
+
+import (
+	"fmt"
+	"github.com/google/gopacket"
+	"io"
+	"os"
+	"testing"
+	"time"
+)
+
+type BufferPacketSource struct {
+	index int
+	data  [][]byte
+	ci    []gopacket.CaptureInfo
+}
+
+// TestNgReadDSB tests the NgReadDSB function.
+func TestNgReaderDSB(t *testing.T) {
+
+	// Test that we can read a pcapng file with DSB.
+	pcapngFile := "tests/le/test301.pcapng"
+	start := time.Now()
+	testf, err := os.Open(pcapngFile)
+	if err != nil {
+		t.Fatal("Couldn't open file:", err)
+	}
+	defer testf.Close()
+	options := DefaultNgReaderOptions
+	options.SkipUnknownVersion = true
+
+	var r *NgReader
+	r, err = NewNgReader(testf, options)
+	if err != nil {
+		t.Fatal("Couldn't read start of file:", err)
+	}
+
+	b := &BufferPacketSource{}
+	for {
+		data, ci, err := r.ReadPacketData()
+		if err == io.EOF {
+			t.Log("ReadPacketData returned EOF")
+			break
+		}
+		b.data = append(b.data, data)
+		b.ci = append(b.ci, ci)
+	}
+
+	duration := time.Since(start)
+	t.Logf("bigEndian %t", r.bigEndian)
+	t.Logf("Reading packet data into memory: %d packets in %v, %v per packet\n", len(b.data), duration, duration/time.Duration(len(b.data)))
+
+	t.Log("decryptionSecrets:", len(r.decryptionSecrets))
+	i := 0
+	for _, secret := range r.decryptionSecrets {
+		t.Log(fmt.Sprintf("SecretType:%X, Length:%d, Data:%s", secret.blockInfo.secretsType, secret.blockInfo.secretsLength, secret.payload))
+		i++
+	}
+	if i <= 0 {
+		t.Fatal("Can't found decryption secrets")
+	}
+}

--- a/pcapgo/ngwrite_dsb.go
+++ b/pcapgo/ngwrite_dsb.go
@@ -83,7 +83,8 @@ func (w *NgWriter) WriteDecryptionSecretsBlock(secretType uint32, secretPayload 
 	secretPayloadLen := len(secretPayload)
 	padding := (4 - secretPayloadLen&3) & 3
 
-	// MIN_DSB_SIZE + secretPayloadLen + padding
+	// via https://github.com/wireshark/wireshark/blob/885d6b7f731760f4a76e0f257af57d03934986ed/wiretap/pcapng.c#L5233
+	// langth = MIN_DSB_SIZE + secretPayloadLen + padding
 	// MIN_DSB_SIZE = MIN_BLOCK_SIZE + PcapngDecryptionSecretsBlockSize
 	// MIN_BLOCK_SIZE = PcapngBlockHeadersize + 4
 	//

--- a/pcapgo/ngwrite_dsb.go
+++ b/pcapgo/ngwrite_dsb.go
@@ -71,13 +71,23 @@ type pcapngDecryptionSecretsBlock struct {
 func (w *NgWriter) WriteDecryptionSecretsBlock(secretType uint32, secretPayload []byte) error {
 
 	switch secretType {
-
+	case DSB_SECRETS_TYPE_SSH, DSB_SECRETS_TYPE_ZIGBEE_NWK_KEY, DSB_SECRETS_TYPE_WIREGUARD, DSB_SECRETS_TYPE_ZIGBEE_APS_KEY:
+		// unsupported secrets type
+		return ErrUnsupportedSecretsType
+	case DSB_SECRETS_TYPE_TLS:
+	default:
+		// unknown secrets type
+		return ErrUnknownSecretsType
 	}
+
 	secretPayloadLen := len(secretPayload)
 	padding := (4 - secretPayloadLen&3) & 3
-	secretPayloadLen += padding
 
-	length := uint32(PcapngBlockHeadersize + PcapngDecryptionSecretsBlockSize + secretPayloadLen + padding)
+	// MIN_DSB_SIZE + secretPayloadLen + padding
+	// MIN_DSB_SIZE = MIN_BLOCK_SIZE + PcapngDecryptionSecretsBlockSize
+	// MIN_BLOCK_SIZE = PcapngBlockHeadersize + 4
+	//
+	length := uint32(PcapngBlockHeadersize + 4 + PcapngDecryptionSecretsBlockSize + secretPayloadLen + padding)
 
 	// write block header
 	binary.LittleEndian.PutUint32(w.buf[:4], uint32(ngBlockTypeDecryptionSecrets))

--- a/pcapgo/ngwrite_dsb_test.go
+++ b/pcapgo/ngwrite_dsb_test.go
@@ -1,0 +1,106 @@
+package pcapgo
+
+import (
+	"fmt"
+	"github.com/google/gopacket/layers"
+	"io"
+	"math"
+	"os"
+	"testing"
+)
+
+// TestNgWriterDSB tests the NgReadDSB function.
+func TestNgWriterDSB(t *testing.T) {
+
+	// Test that we can read a DSB file.
+	pcapngFile := "tests/le/test300.pcapng"
+	tlsKey := "CLIENT_RANDOM 75db01ecd858f0066c5b75884de569b7370101ee0cd6a21f900333d501ffc2a4 05edde5321c8a8fe04517c3b7e0e443075c0d6bdae4bffe44a72f9c11e734c6124be4ab5bd932e7d52573e08026b6a35\n"
+	testf, err := os.Open(pcapngFile)
+	if err != nil {
+		t.Fatal("Couldn't open file:", err)
+	}
+	defer testf.Close()
+	options := DefaultNgReaderOptions
+	options.SkipUnknownVersion = true
+	var r *NgReader
+	r, err = NewNgReader(testf, options)
+	if err != nil {
+		t.Fatal("Couldn't read start of file:", err)
+	}
+
+	b := &BufferPacketSource{}
+	for {
+		data, ci, err := r.ReadPacketData()
+		if err == io.EOF {
+			t.Log("ReadPacketData returned EOF")
+			break
+		}
+		b.data = append(b.data, data)
+		b.ci = append(b.ci, ci)
+	}
+
+	t.Logf("bigEndian %t", r.bigEndian)
+	t.Logf("len(b.data) %d", len(b.data))
+	t.Logf("len(b.ci) %d", len(b.ci))
+
+	tmpPcapng := "tests/dbs_tmp.pcapng"
+	writer, err := createPcapng(tmpPcapng)
+
+	//write Decryption Secrets Block
+	err = writer.WriteDecryptionSecretsBlock(DSB_SECRETS_TYPE_TLS, []byte(tlsKey))
+	if err != nil {
+		t.Fatal("Couldn't write Decryption Secrets Block:", err)
+	}
+	for i, ci := range b.ci {
+		err = writer.WritePacket(ci, b.data[i])
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	err = writer.Flush()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log("Wrote Decryption Secrets Block.")
+
+	// TODO check DSB
+
+	os.Remove(tmpPcapng)
+}
+
+func createPcapng(pcapngFilename string) (*NgWriter, error) {
+	pcapFile, err := os.OpenFile(pcapngFilename, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("error creating pcap file: %v", err)
+	}
+
+	pcapOption := NgWriterOptions{
+		SectionInfo: NgSectionInfo{
+			Hardware:    "eCapture Hardware",
+			OS:          "",
+			Application: "ecapture.lua",
+			Comment:     "see https://ecapture.cc for more information.",
+		},
+	}
+	// write interface description
+	ngIface := NgInterface{
+		Name:       "eth0",
+		Comment:    "gopacket: https://github.com/google/gopacket",
+		Filter:     "",
+		LinkType:   layers.LinkTypeEthernet,
+		SnapLength: uint32(math.MaxUint16),
+	}
+
+	pcapWriter, err := NewNgWriterInterface(pcapFile, ngIface, pcapOption)
+	if err != nil {
+		return nil, err
+	}
+
+	// Flush the header
+	err = pcapWriter.Flush()
+	if err != nil {
+		return nil, err
+	}
+	return pcapWriter, nil
+}

--- a/pcapgo/pcapng.go
+++ b/pcapgo/pcapng.go
@@ -45,11 +45,11 @@ const (
 	/*
 	 * Type describing the format of Decryption Secrets Block (DSB).
 	 */
-	SECRETS_TYPE_TLS            = 0x544c534b /* TLS Key Log */
-	SECRETS_TYPE_SSH            = 0x5353484b /* SSH Key Log */
-	SECRETS_TYPE_WIREGUARD      = 0x57474b4c /* WireGuard Key Log */
-	SECRETS_TYPE_ZIGBEE_NWK_KEY = 0x5a4e574b /* Zigbee NWK Key */
-	SECRETS_TYPE_ZIGBEE_APS_KEY = 0x5a415053 /* Zigbee APS Key */
+	DSB_SECRETS_TYPE_TLS            uint32 = 0x544c534b /* TLS Key Log */
+	DSB_SECRETS_TYPE_SSH            uint32 = 0x5353484b /* SSH Key Log */
+	DSB_SECRETS_TYPE_WIREGUARD      uint32 = 0x57474b4c /* WireGuard Key Log */
+	DSB_SECRETS_TYPE_ZIGBEE_NWK_KEY uint32 = 0x5a4e574b /* Zigbee NWK Key */
+	DSB_SECRETS_TYPE_ZIGBEE_APS_KEY uint32 = 0x5a415053 /* Zigbee APS Key */
 )
 
 type ngOptionCode uint16

--- a/pcapgo/pcapng.go
+++ b/pcapgo/pcapng.go
@@ -37,7 +37,19 @@ const (
 	ngBlockTypeSimplePacket        ngBlockType = 3          // Simple packet block
 	ngBlockTypeInterfaceStatistics ngBlockType = 5          // Interface statistics block
 	ngBlockTypeEnhancedPacket      ngBlockType = 6          // Enhanced packet block
+	ngBlockTypeDecryptionSecrets   ngBlockType = 0x0000000A // Decryption secrets block
 	ngBlockTypeSectionHeader       ngBlockType = 0x0A0D0D0A // Section header block (same in both endians)
+)
+
+const (
+	/*
+	 * Type describing the format of Decryption Secrets Block (DSB).
+	 */
+	SECRETS_TYPE_TLS            = 0x544c534b /* TLS Key Log */
+	SECRETS_TYPE_SSH            = 0x5353484b /* SSH Key Log */
+	SECRETS_TYPE_WIREGUARD      = 0x57474b4c /* WireGuard Key Log */
+	SECRETS_TYPE_ZIGBEE_NWK_KEY = 0x5a4e574b /* Zigbee NWK Key */
+	SECRETS_TYPE_ZIGBEE_APS_KEY = 0x5a415053 /* Zigbee APS Key */
 )
 
 type ngOptionCode uint16

--- a/pcapgo/pcapng.go
+++ b/pcapgo/pcapng.go
@@ -52,6 +52,12 @@ const (
 	DSB_SECRETS_TYPE_ZIGBEE_APS_KEY uint32 = 0x5a415053 /* Zigbee APS Key */
 )
 
+// define error types for DSB
+var (
+	ErrUnsupportedSecretsType = errors.New("Unsupported Decryption Secrets Block (DSB) type")
+	ErrUnknownSecretsType     = errors.New("Unknown Decryption Secrets Block (DSB) type")
+)
+
 type ngOptionCode uint16
 
 const (


### PR DESCRIPTION
Support reading and writing pcapng files with DSBs.
As same as [https//github.com/wireshark/wireshark](https://github.com/wireshark/wireshark/commit/52a667143929ace46929bfb6ad15b6a856cdbe77)

The TLS dissector will be updated in the future to make use of these secrets.
pcapng spec update: https://github.com/pcapng/pcapng/pull/54

DSB block format:
```
                        1                   2                   3
    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 0 |                   Block Type = 0x0000000A                     |
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 4 |                      Block Total Length                       |
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 8 |                          Secrets Type                         |
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
12 |                         Secrets Length                        |
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
16 /                                                               /
   /                          Secrets Data                         /
   /              (variable length, padded to 32 bits)             /
   /                                                               /
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
   /                                                               /
   /                       Options (variable)                      /
   /                                                               /
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
   /                       Block Total Length                      /
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
```