### PR TITLE
Add SEESENT support to bsdbpf

### DIFF
--- a/bsdbpf/bsd_bpf_sniffer.go
+++ b/bsdbpf/bsd_bpf_sniffer.go
@@ -162,10 +162,10 @@ func NewBPFSniffer(iface string, options *Options) (*BPFSniffer, error) {
 
 	// SeeSent defaults to true, so we change it if false
 	if !sniffer.options.SeeSent {
-		enable := 0
-		_, _, err = syscall.Syscall(syscall.SYS_IOCTL, uintptr(sniffer.fd), uintptr(syscall.BIOCSSEESENT), uintptr(unsafe.Pointer(&enable)))
-		if err != nil {
-			return nil, err
+		var enable int = 0
+		_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(sniffer.fd), uintptr(syscall.BIOCSSEESENT), uintptr(unsafe.Pointer(&enable)))
+		if errno != 0 {
+			return nil, errno
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/google/gopacket/issues/1053

Not sure if this is the right approach, considering this is the only raw `syscall.Syscall`.
But the other `syscall.*bpf*` functions are all marked deprecated, so I didn't want to tack even more onto that.