### PR TITLE
Fix GENEVE test case error message 

### DIFF
--- a/layers/geneve_test.go
+++ b/layers/geneve_test.go
@@ -188,6 +188,6 @@ func TestIsomorphicPacketGeneve(t *testing.T) {
 	gnTranslated.BaseLayer = BaseLayer{}
 
 	if !reflect.DeepEqual(gn, gnTranslated) {
-		t.Errorf("VXLAN isomorph mismatch, \nwant %#v\ngot %#v\n", gn, gnTranslated)
+		t.Errorf("GENEVE isomorph mismatch, \nwant %#v\ngot %#v\n", gn, gnTranslated)
 	}
 }


### PR DESCRIPTION
Error message says "VXLAN". Possibly a cut&paste error.