### PR TITLE
feat: add bound check in 'convertToPages'

### DIFF
--- a/reassembly/tcpassembly.go
+++ b/reassembly/tcpassembly.go
@@ -250,6 +250,9 @@ func (p *page) assemblerContext() AssemblerContext {
 }
 func (p *page) convertToPages(pc *pageCache, skip int, ac AssemblerContext) (*page, *page, int) {
 	if skip != 0 {
+		if skip > len(p.bytes) {
+			skip = len(p.bytes) - 1
+		}
 		p.bytes = p.bytes[skip:]
 		p.seq = p.seq.Add(skip)
 	}


### PR DESCRIPTION
I am writing a custom tcp reassembly, and after calling the `KeepFrom(offset)` method of `reassembly.ScatterGather` many times, an array **out-of-bounds** error will occasionally occur here (I checked the context carefully, and the incoming offset is less than Length() available bytes ). 

I bet there should be bounds checking to prevent out-of-bounds errors.