### PR TITLE
Miscellaneous bsdbpf fixes and improvements

### DIFF
--- a/bsdbpf/bsd_bpf_sniffer.go
+++ b/bsdbpf/bsd_bpf_sniffer.go
@@ -4,6 +4,7 @@
 // that can be found in the LICENSE file in the root of the source
 // tree.
 
+//go:build darwin || dragonfly || freebsd || netbsd || openbsd
 // +build darwin dragonfly freebsd netbsd openbsd
 
 package bsdbpf
@@ -11,6 +12,7 @@ package bsdbpf
 import (
 	"errors"
 	"fmt"
+	"github.com/google/gopacket/pcap"
 	"syscall"
 	"time"
 	"unsafe"
@@ -22,7 +24,7 @@ import (
 const wordSize = int(unsafe.Sizeof(uintptr(0)))
 
 func bpfWordAlign(x int) int {
-	return (((x) + (wordSize - 1)) &^ (wordSize - 1))
+	return ((x) + (wordSize - 1)) &^ (wordSize - 1)
 }
 
 // Options is used to configure various properties of the BPF sniffer.
@@ -58,6 +60,9 @@ type Options struct {
 	// as provided, to the wire.
 	// The default is true.
 	PreserveLinkAddr bool
+	// SeeSent is set to false if locally generated packets on the interface should not be returned by BPF.
+	// The default is true.
+	SeeSent bool
 }
 
 var defaultOptions = Options{
@@ -67,6 +72,7 @@ var defaultOptions = Options{
 	Promisc:          true,
 	Immediate:        true,
 	PreserveLinkAddr: true,
+	SeeSent:          true,
 }
 
 // BPFSniffer is a struct used to track state of a BSD BPF ethernet sniffer
@@ -97,34 +103,32 @@ func NewBPFSniffer(iface string, options *Options) (*BPFSniffer, error) {
 		sniffer.options = options
 	}
 
-	if sniffer.options.BPFDeviceName == "" {
-		sniffer.pickBpfDevice()
-	}
+	sniffer.pickBpfDevice()
 
 	// setup our read buffer
 	if sniffer.options.ReadBufLen == 0 {
 		sniffer.options.ReadBufLen, err = syscall.BpfBuflen(sniffer.fd)
 		if err != nil {
-			return nil, err
+			goto err
 		}
 	} else {
 		sniffer.options.ReadBufLen, err = syscall.SetBpfBuflen(sniffer.fd, sniffer.options.ReadBufLen)
 		if err != nil {
-			return nil, err
+			goto err
 		}
 	}
 	sniffer.readBuffer = make([]byte, sniffer.options.ReadBufLen)
 
 	err = syscall.SetBpfInterface(sniffer.fd, sniffer.sniffDeviceName)
 	if err != nil {
-		return nil, err
+		goto err
 	}
 
 	if sniffer.options.Immediate {
 		// turn immediate mode on. This makes the snffer non-blocking.
 		err = syscall.SetBpfImmediate(sniffer.fd, enable)
 		if err != nil {
-			return nil, err
+			goto err
 		}
 	}
 
@@ -134,7 +138,7 @@ func NewBPFSniffer(iface string, options *Options) (*BPFSniffer, error) {
 	if sniffer.options.Timeout != nil {
 		err = syscall.SetBpfTimeout(sniffer.fd, sniffer.options.Timeout)
 		if err != nil {
-			return nil, err
+			goto err
 		}
 	}
 
@@ -143,7 +147,7 @@ func NewBPFSniffer(iface string, options *Options) (*BPFSniffer, error) {
 		// higher level protocol analyzers will not need this
 		err = syscall.SetBpfHeadercmpl(sniffer.fd, enable)
 		if err != nil {
-			return nil, err
+			goto err
 		}
 	}
 
@@ -151,11 +155,22 @@ func NewBPFSniffer(iface string, options *Options) (*BPFSniffer, error) {
 		// forces the interface into promiscuous mode
 		err = syscall.SetBpfPromisc(sniffer.fd, enable)
 		if err != nil {
-			return nil, err
+			goto err
+		}
+	}
+
+	if !sniffer.options.SeeSent {
+		// See sent is set by default, need to turn it off
+		err = unix.IoctlSetInt(sniffer.fd, syscall.BIOCSSEESENT, 0)
+		if err != nil {
+			goto err
 		}
 	}
 
 	return &sniffer, nil
+err:
+	syscall.Close(sniffer.fd)
+	return nil, err
 }
 
 // Close is used to close the file-descriptor of the BPF device file.
@@ -165,12 +180,25 @@ func (b *BPFSniffer) Close() error {
 
 func (b *BPFSniffer) pickBpfDevice() {
 	var err error
-	b.options.BPFDeviceName = ""
-	for i := 0; i < 99; i++ {
-		b.options.BPFDeviceName = fmt.Sprintf("/dev/bpf%d", i)
+	if len(b.options.BPFDeviceName) > 0 {
 		b.fd, err = syscall.Open(b.options.BPFDeviceName, syscall.O_RDWR, 0)
 		if err == nil {
 			return
+		}
+	} else {
+		b.options.BPFDeviceName = ""
+		for i := 0; i < 99; i++ {
+			name := fmt.Sprintf("/dev/bpf%d", i)
+			b.fd, err = syscall.Open(b.options.BPFDeviceName, syscall.O_RDWR, 0)
+			if err == nil {
+				b.options.BPFDeviceName = name
+				return
+			}
+
+			if err == syscall.Errno(syscall.ENOENT) {
+				// No such file, no needs to iterate further
+				break
+			}
 		}
 	}
 	panic("failed to acquire a BPF device for read-write access")
@@ -212,4 +240,24 @@ func (b *BPFSniffer) ReadPacketData() ([]byte, gopacket.CaptureInfo, error) {
 // GetReadBufLen returns the BPF read buffer length
 func (b *BPFSniffer) GetReadBufLen() int {
 	return b.options.ReadBufLen
+}
+
+func (s *BPFSniffer) SetBPFFilter(bpfInstructions []pcap.BPFInstruction) error {
+	bpfIns := make([]syscall.BpfInsn, 0, len(bpfInstructions))
+	for _, ins := range bpfInstructions {
+		sysIns := syscall.BpfInsn{
+			Code: ins.Code,
+			Jt:   ins.Jt,
+			Jf:   ins.Jf,
+			K:    ins.K,
+		}
+		bpfIns = append(bpfIns, sysIns)
+	}
+
+	return syscall.SetBpf(s.fd, bpfIns)
+}
+
+func (h *BPFSniffer) WritePacketData(pkt []byte) error {
+	_, err := unix.Write(h.fd, pkt)
+	return err
 }


### PR DESCRIPTION
In order to more or less unify afpacket and bsdbpf  the following new methods will be added to BPFSniffer:

-  SetBPFFilter(): to set BPF programm,
- WritePacketData(): to write data.

The new  configurable option `SeeSent` will be added, it allows  to turn on/off returning local packets over filter.

There is also several fixes:

- BPFSniffer creation with bpf device name provided over config options;
-  Avoid fd leak in the case of any subsequent error during BPFSniffer instance creation.

This PR also fixes https://github.com/google/gopacket/issues/1053 and makes obsolete https://github.com/google/gopacket/pull/1054