### PR TITLE
Fix DHCPv4 header field name hops

### DIFF
--- a/layers/dhcp_test.go
+++ b/layers/dhcp_test.go
@@ -129,8 +129,8 @@ func testDHCPEqual(t *testing.T, d1, d2 *DHCPv4) {
 	if d1.HardwareLen != d2.HardwareLen {
 		t.Errorf("expected HardwareLen=%v, got %v", d1.HardwareLen, d2.HardwareLen)
 	}
-	if d1.HardwareOpts != d2.HardwareOpts {
-		t.Errorf("expected HardwareOpts=%v, got %v", d1.HardwareOpts, d2.HardwareOpts)
+	if d1.RelayHops != d2.RelayHops {
+		t.Errorf("expected RelayHops=%v, got %v", d1.RelayHops, d2.RelayHops)
 	}
 	if d1.Xid != d2.Xid {
 		t.Errorf("expected Xid=%v, got %v", d1.Xid, d2.Xid)

--- a/layers/dhcpv4.go
+++ b/layers/dhcpv4.go
@@ -87,7 +87,7 @@ type DHCPv4 struct {
 	Operation    DHCPOp
 	HardwareType LinkType
 	HardwareLen  uint8
-	HardwareOpts uint8
+	RelayHops    uint8
 	Xid          uint32
 	Secs         uint16
 	Flags        uint16
@@ -132,7 +132,7 @@ func (d *DHCPv4) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error 
 	d.Operation = DHCPOp(data[0])
 	d.HardwareType = LinkType(data[1])
 	d.HardwareLen = data[2]
-	d.HardwareOpts = data[3]
+	d.RelayHops = data[3]
 	d.Xid = binary.BigEndian.Uint32(data[4:8])
 	d.Secs = binary.BigEndian.Uint16(data[8:10])
 	d.Flags = binary.BigEndian.Uint16(data[10:12])
@@ -209,7 +209,7 @@ func (d *DHCPv4) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.Serialize
 		d.HardwareLen = uint8(len(d.ClientHWAddr))
 	}
 	data[2] = d.HardwareLen
-	data[3] = d.HardwareOpts
+	data[3] = d.RelayHops
 	binary.BigEndian.PutUint32(data[4:8], d.Xid)
 	binary.BigEndian.PutUint16(data[8:10], d.Secs)
 	binary.BigEndian.PutUint16(data[10:12], d.Flags)


### PR DESCRIPTION
The DHCPv4 header field "HardwareOpts" is misleading. This fields original name by RFC 2131, which just takes it from RFC 951, is "hops". It has never changed meaning and still reflects number of relay agents it passed, as described in RFC 951 section 8.

This commit changes the name of the field "HardwareOpts" to "RelayHops".