### PR TITLE
Fix DHCPv4 options encoding

### DIFF
--- a/layers/dhcpv4.go
+++ b/layers/dhcpv4.go
@@ -222,8 +222,8 @@ func (d *DHCPv4) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.Serialize
 	copy(data[108:236], d.File)
 	binary.BigEndian.PutUint32(data[236:240], DHCPMagic)
 
+	offset := 240
 	if len(d.Options) > 0 {
-		offset := 240
 		for _, o := range d.Options {
 			if err := o.encode(data[offset:]); err != nil {
 				return err
@@ -235,10 +235,10 @@ func (d *DHCPv4) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.Serialize
 				offset += 2 + len(o.Data)
 			}
 		}
-		optend := NewDHCPOption(DHCPOptEnd, nil)
-		if err := optend.encode(data[offset:]); err != nil {
-			return err
-		}
+	}
+	optend := NewDHCPOption(DHCPOptEnd, nil)
+	if err := optend.encode(data[offset:]); err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
For calculating the DHCPv4 length by the "Len" method there is always a byte added for the end option. But the END option is only set when there are any options at all. This results in a missing END option in case there are no options present.

This commit moves the encoding of the END option so it is always set unconditionally.