### PR TITLE
fix: Truncate RADIUS attributes before decoding

### DIFF
--- a/layers/radius.go
+++ b/layers/radius.go
@@ -431,6 +431,8 @@ func (radius *RADIUS) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) e
 		return nil
 	}
 
+	radius.Attributes = radius.Attributes[:0]
+
 	pos := radiusMinimumRecordSizeInBytes
 	for {
 		if len(data) == pos {


### PR DESCRIPTION
I noticed that when trying to decode a RADIUS layer multiple times using the same `RADIUS` struct, the attributes from the new packet are appended to the attributes of all previous packets.

As far as I can tell, the current RADIUS implementation is broken for in-place decoding.