### PR TITLE
fix: LinkType type should be uint32 according to the pcap file specifications

### DIFF
--- a/layers/enums.go
+++ b/layers/enums.go
@@ -85,7 +85,7 @@ const (
 
 // LinkType is an enumeration of link types, and acts as a decoder for any
 // link type it supports.
-type LinkType uint8
+type LinkType uint32
 
 const (
 	// According to pcap-linktype(7) and http://www.tcpdump.org/linktypes.html


### PR DESCRIPTION
Fixing LinkType to follow the pcap file specifications where a LinkType could be bigger than 255 and it's a uint32