### PR TITLE
Adds a constant for the Information Element ID that indicates an extension

### DIFF
--- a/layers/dot11.go
+++ b/layers/dot11.go
@@ -412,6 +412,7 @@ const (
 	Dot11InformationElementIDWhiteSpaceMap             Dot11InformationElementID = 205
 	Dot11InformationElementIDFineTuningMeasureParams   Dot11InformationElementID = 206
 	Dot11InformationElementIDVendor                    Dot11InformationElementID = 221
+	Dot11InformationElementIDExtension                 Dot11InformationElementID = 255
 )
 
 // String provides a human readable string for Dot11InformationElementID.
@@ -762,6 +763,8 @@ func (a Dot11InformationElementID) String() string {
 		return "Fine Tuning Measure Parameters"
 	case Dot11InformationElementIDVendor:
 		return "Vendor"
+	case Dot11InformationElementIDExtension:
+		return "Element ID Extension"
 	default:
 		return "Unknown information element id"
 	}


### PR DESCRIPTION
A IE ID value of 255 means the IE is an extension element, where the second byte of the Content is a Element ID Extension value.

More information about this can be found in table 9-92 of IEEE Std 802.11-2020.