### PR TITLE
Handle edge cases in interface and routing config

### DIFF
--- a/routing/other.go
+++ b/routing/other.go
@@ -4,6 +4,7 @@
 // that can be found in the LICENSE file in the root of the source
 // tree.
 
+//go:build !linux
 // +build !linux
 
 // Package routing is currently only supported in Linux, but the build system requires a valid go file for all architectures.

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -234,6 +234,11 @@ loop:
 		}
 		for _, addr := range ifaceAddrs {
 			if inet, ok := addr.(*net.IPNet); ok {
+				// filter out any non routable addresses
+				if inet.IP.IsLoopback() || inet.IP.IsMulticast() || inet.IP.IsInterfaceLocalMulticast() || inet.IP.IsLinkLocalMulticast() || inet.IP.IsUnspecified() || inet.IP.IsLinkLocalUnicast() {
+					continue
+				}
+
 				// Go has a nasty habit of giving you IPv4s as ::ffff:1.2.3.4 instead of 1.2.3.4.
 				// We want to use mapped v4 addresses as v4 preferred addresses, never as v6
 				// preferred addresses.

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -4,6 +4,7 @@
 // that can be found in the LICENSE file in the root of the source
 // tree.
 
+//go:build linux
 // +build linux
 
 // Package routing provides a very basic but mostly functional implementation of
@@ -134,7 +135,7 @@ func (r *router) route(routes routeSlice, input net.HardwareAddr, src, dst net.I
 		if rt.InputIface != 0 && rt.InputIface != inputIndex {
 			continue
 		}
-		if rt.Src == nil && rt.Dst == nil {
+		if defaultGateway == nil && rt.Src == nil && rt.Dst == nil {
 			defaultGateway = rt
 			continue
 		}

--- a/routing/routing_test.go
+++ b/routing/routing_test.go
@@ -4,6 +4,7 @@
 // that can be found in the LICENSE file in the root of the source
 // tree.
 
+//go:build linux
 // +build linux
 
 package routing
@@ -533,6 +534,8 @@ func init() {
 	testRouter.addrs[2] = ipAddrs{v4: net.IPv4(192, 168, 1, 2)}
 	defaultRoute := &rtInfo{Gateway: net.IPv4(192, 168, 1, 1), InputIface: 0, OutputIface: 2, Priority: 600}
 	testRouter.v4 = append(testRouter.v4, defaultRoute)
+	defaultRouteWithHighPriority := &rtInfo{Gateway: net.IPv4(172, 0, 0, 1), InputIface: 0, OutputIface: 2, Priority: 1000}
+	testRouter.v4 = append(testRouter.v4, defaultRouteWithHighPriority)
 	// Configure local route
 	localHW, _ := net.ParseMAC("01:23:45:67:89:ac")
 	localInterface := net.Interface{Index: 1, MTU: 1500, Name: "Local", HardwareAddr: localHW, Flags: 1}


### PR DESCRIPTION
The pull requests fixes two issues with very special configurations:
- if more than one default route with different metrics is specified, the one with the highest metric is chosen
- if an interface has more than one address and the first routable address is not the first address entry a non routable address is returned.

Here an example of such a fringe configuration:

interface Config (excerpt):
```
10: vlan_1@nic: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    link/ether 01:23:45:cb:2a:b6 brd ff:ff:ff:ff:ff:ff
    inet 169.254.95.54/16 metric 2048 brd 169.254.255.255 scope link vlan_1
       valid_lft forever preferred_lft forever
    inet 10.1.42.7/24 brd 10.1.42.255 scope global vlan_1
       valid_lft forever preferred_lft forever
11: vlan_2@nic: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    link/ether 01:23:45:cb:2a:b6 brd ff:ff:ff:ff:ff:ff
    inet 169.254.26.132/16 metric 2048 brd 169.254.255.255 scope link vlan_2
       valid_lft forever preferred_lft forever
    inet 10.32.1.133/25 brd 10.32.1.255 scope global vlan_2
       valid_lft forever preferred_lft forever
```

routes (excerpt):
```
default via 10.1.42.1 dev vlan_transfer proto static metric 40 
default via 192.168.155.1 dev eno5 proto dhcp src 192.168.155.12 metric 100 
```

With this configuration, the source address for the interfaces `10` and `11` will return the link local address of the interface.
The default route will return `192.168.155.1` which is only the second in the list.

Both issues are addressed in this pull request.

Cheers,
Carsten