### PR TITLE
OSPFv2: fix DbDesc LSAheader parse

### DIFF
--- a/layers/ospf.go
+++ b/layers/ospf.go
@@ -237,7 +237,7 @@ type OSPF struct {
 	Content      interface{}
 }
 
-//OSPFv2 extend the OSPF head with version 2 specific fields
+// OSPFv2 extend the OSPF head with version 2 specific fields
 type OSPFv2 struct {
 	BaseLayer
 	OSPF
@@ -518,7 +518,8 @@ func (ospf *OSPFv2) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) err
 		for i := 32; uint16(i+20) <= ospf.PacketLength; i += 20 {
 			lsa := LSAheader{
 				LSAge:       binary.BigEndian.Uint16(data[i : i+2]),
-				LSType:      binary.BigEndian.Uint16(data[i+2 : i+4]),
+				LSOptions:   data[i+2],
+				LSType:      uint16(data[i+3]),
 				LinkStateID: binary.BigEndian.Uint32(data[i+4 : i+8]),
 				AdvRouter:   binary.BigEndian.Uint32(data[i+8 : i+12]),
 				LSSeqNumber: binary.BigEndian.Uint32(data[i+12 : i+16]),


### PR DESCRIPTION
According to [RFC 2328 A.4.1](https://datatracker.ietf.org/doc/html/rfc2328#autoid-28)
The `LSType` field should be located at 4th byte of LSAheader.
and the missing `LSOptions` field should be 3th.