### PR TITLE
Add a CanDecode function so the Geneve layer matches the interface

### DIFF
--- a/layers/geneve.go
+++ b/layers/geneve.go
@@ -73,6 +73,10 @@ func decodeGeneveOption(data []byte, gn *Geneve, df gopacket.DecodeFeedback) (*G
 	return opt, opt.Length, nil
 }
 
+func (gn *Geneve) CanDecode() gopacket.LayerClass {
+	return LayerTypeGeneve
+}
+
 func (gn *Geneve) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 	if len(data) < 7 {
 		df.SetTruncated()


### PR DESCRIPTION
## Description

Currently the Geneve layer doesnt have a CanDecode method, this PR fixes that.