### PR TITLE
geneve: fix geneve options SerializeTo

### DIFF
--- a/layers/geneve.go
+++ b/layers/geneve.go
@@ -165,7 +165,7 @@ func (gn *Geneve) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.Serializ
 		bytes[offset] = o.Type
 
 		offset += 1
-		bytes[offset] |= o.Flags << 5
+		bytes[offset] = o.Flags << 5
 		bytes[offset] |= ((o.Length - 4) >> 2) & 0x1f
 
 		offset += 1


### PR DESCRIPTION
During serialization of geneve options, the Flags/Length byte is uninitalized from PrependBytes and should be set prior to bitwise-or operations.