### PR TITLE
Fix SSL 2 version constant to 0x0002

### DIFF
--- a/layers/tls.go
+++ b/layers/tls.go
@@ -49,7 +49,7 @@ func (tv TLSVersion) String() string {
 	switch tv {
 	default:
 		return "Unknown"
-	case 0x0200:
+	case 0x0002:
 		return "SSL 2.0"
 	case 0x0300:
 		return "SSL 3.0"


### PR DESCRIPTION
SSL 2 uses a version field of 0x0002, not 0x0200.  This is confirmed not only in the original Netscape spec [1] and RFC draft of the time [2], but also in major implementations such as OpenSSL [3] and Wireshark [4].

[1] https://www-archive.mozilla.org/projects/security/pki/nss/ssl/draft02.html
[2] https://datatracker.ietf.org/doc/html/draft-hickman-netscape-ssl-00
[3] https://github.com/openssl/openssl/blob/OpenSSL_0_9_6m/ssl/ssl2.h#L66-L71
[4] https://github.com/wireshark/wireshark/blob/release-4.4/epan/dissectors/packet-tls-utils.h#L266-L277