### PR TITLE
doc: correct documentation for `NewNgReader()`

### DIFF
--- a/pcapgo/ngread.go
+++ b/pcapgo/ngread.go
@@ -57,7 +57,7 @@ type NgReader struct {
 	bigEndian         bool
 }
 
-// NewNgReader initializes a new writer, reads the first section header, and if necessary according to the options the first interface.
+// NewNgReader initializes a new reader, reads the first section header, and if necessary according to the options the first interface.
 func NewNgReader(r io.Reader, options NgReaderOptions) (*NgReader, error) {
 	ret := &NgReader{
 		r: bufio.NewReader(r),


### PR DESCRIPTION
Hi,

Seems like you meant `NewNgReader` initializes a new reader, not a writer.