### PR TITLE
Use %w instead of %v in error wrapping to preserve underlying errors

### DIFF
--- a/pcapgo/write.go
+++ b/pcapgo/write.go
@@ -122,7 +122,7 @@ func (w *Writer) WritePacket(ci gopacket.CaptureInfo, data []byte) error {
 		return fmt.Errorf("invalid capture info %+v:  capture length > length", ci)
 	}
 	if err := w.writePacketHeader(ci); err != nil {
-		return fmt.Errorf("error writing packet header: %v", err)
+		return fmt.Errorf("error writing packet header: %w", err)
 	}
 	_, err := w.w.Write(data)
 	return err


### PR DESCRIPTION
Currently, errors returned from WritePacket lose their original type because %v only formats the error string. This breaks Go’s errors.Is and errors.

This PR addresses [#1213](https://github.com/google/gopacket/issues/1213).

